### PR TITLE
feat: Add aiconfig-online-evals and aiconfig-targeting skills

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -36,6 +36,20 @@
       "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
     },
     {
+      "name": "aiconfig-online-evals",
+      "description": "Attach judges to AI Config variations for automatic LLM-as-a-judge evaluation. Create custom judges, configure sampling rates, and monitor quality scores.",
+      "path": "skills/ai-configs/aiconfig-online-evals",
+      "version": "0.1.0",
+      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
+    },
+    {
+      "name": "aiconfig-targeting",
+      "description": "Configure AI Config targeting rules to control which variations serve to different users. Enable percentage rollouts, attribute-based rules, and segment targeting.",
+      "path": "skills/ai-configs/aiconfig-targeting",
+      "version": "0.1.0",
+      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
+    },
+    {
       "name": "create-skill",
       "description": "Add a new skill to the LaunchDarkly agent-skills repo. Use when creating a new SKILL.md, adding a skill to the catalog, or aligning with repo conventions. Guides exploration of existing skills before creating.",
       "path": "skills/skill-authoring/create-skill",

--- a/skills.json
+++ b/skills.json
@@ -8,11 +8,25 @@
       "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission or LaunchDarkly MCP server."
     },
     {
+      "name": "aiconfig-online-evals",
+      "description": "Attach judges to AI Config variations for automatic LLM-as-a-judge evaluation. Create custom judges, configure sampling rates, and monitor quality scores.",
+      "path": "skills/ai-configs/aiconfig-online-evals",
+      "version": "0.1.0",
+      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission. SDK versions Python v0.14.0+ or Node.js v0.16.1+ for automatic metric recording."
+    },
+    {
       "name": "aiconfig-projects",
       "description": "Guide for setting up LaunchDarkly projects in your codebase. Helps you assess your stack, choose the right approach, and integrate project management that makes sense for your architecture.",
       "path": "skills/ai-configs/aiconfig-projects",
       "version": "0.4.0",
       "compatibility": "Requires LaunchDarkly API access token with projects:write permission or LaunchDarkly MCP server."
+    },
+    {
+      "name": "aiconfig-targeting",
+      "description": "Configure AI Config targeting rules to control which variations serve to different users. Enable percentage rollouts, attribute-based rules, segment targeting, and guarded rollouts.",
+      "path": "skills/ai-configs/aiconfig-targeting",
+      "version": "0.1.0",
+      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
     },
     {
       "name": "aiconfig-tools",
@@ -33,20 +47,6 @@
       "description": "Guide for experimenting with AI configurations. Helps you test different models, prompts, and parameters to find what works best through systematic experimentation.",
       "path": "skills/ai-configs/aiconfig-variations",
       "version": "0.2.0",
-      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
-    },
-    {
-      "name": "aiconfig-online-evals",
-      "description": "Attach judges to AI Config variations for automatic LLM-as-a-judge evaluation. Create custom judges, configure sampling rates, and monitor quality scores.",
-      "path": "skills/ai-configs/aiconfig-online-evals",
-      "version": "0.1.0",
-      "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
-    },
-    {
-      "name": "aiconfig-targeting",
-      "description": "Configure AI Config targeting rules to control which variations serve to different users. Enable percentage rollouts, attribute-based rules, and segment targeting.",
-      "path": "skills/ai-configs/aiconfig-targeting",
-      "version": "0.1.0",
       "compatibility": "Requires LaunchDarkly API access token with ai-configs:write permission."
     },
     {

--- a/skills/ai-configs/aiconfig-online-evals/README.md
+++ b/skills/ai-configs/aiconfig-online-evals/README.md
@@ -1,0 +1,50 @@
+# LaunchDarkly AI Config Online Evaluations Skill
+
+An Agent Skill for attaching judges to AI Config variations for automatic LLM-as-a-judge evaluation.
+
+## Overview
+
+This skill teaches agents how to:
+- Create custom judge AI Configs with evaluation criteria
+- Attach judges to AI Config variations via API
+- Configure sampling rates for cost control
+- Monitor evaluation results in the dashboard
+
+## Installation (Local)
+
+Copy `skills/ai-configs/aiconfig-online-evals/` into your agent client's skills path.
+
+## Prerequisites
+
+- LaunchDarkly API access token with `ai-configs:write` permission
+- Existing AI Config with variations (use `aiconfig-create` skill)
+- For custom judges: understanding of LLM-as-a-judge methodology
+
+## Usage
+
+```
+Attach security and API contract judges to the model-selector config at 100% sampling
+```
+
+```
+Create a custom judge that checks for scope creep in code changes
+```
+
+## Structure
+
+```
+aiconfig-online-evals/
+├── SKILL.md
+└── README.md
+```
+
+## Related
+
+- [AI Config Create](../aiconfig-create/) - Create AI Configs first
+- [AI Config Targeting](../aiconfig-targeting/) - Enable targeting on judges
+- [AI Config Variations](../aiconfig-variations/) - Manage variations
+- [Online Evaluations Docs](https://docs.launchdarkly.com/home/ai-configs/online-evaluations)
+
+## License
+
+Apache-2.0

--- a/skills/ai-configs/aiconfig-online-evals/SKILL.md
+++ b/skills/ai-configs/aiconfig-online-evals/SKILL.md
@@ -1,0 +1,447 @@
+---
+name: aiconfig-online-evals
+description: Attach judges to AI Config variations for automatic LLM-as-a-judge evaluation. Create custom judges, configure sampling rates, and monitor quality scores.
+compatibility: Requires LaunchDarkly API access token with ai-configs:write permission. SDK versions Python v0.14.0+ or Node.js v0.16.1+ for automatic metric recording.
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# AI Config Online Evaluations
+
+Attach judges to AI Config variations for automatic quality scoring using LLM-as-a-judge methodology. Judges evaluate responses and return scores between 0.0 and 1.0.
+
+## Prerequisites
+
+- LaunchDarkly account with AI Configs enabled
+- API access token with write permissions
+- Existing AI Config with variations (use `aiconfig-create` skill)
+- For automatic metric recording: Python AI SDK v0.14.0+ or Node.js AI SDK v0.16.1+
+
+## API Key Detection
+
+1. **Check environment variables** - `LAUNCHDARKLY_API_KEY`, `LAUNCHDARKLY_API_TOKEN`, `LD_API_KEY`
+2. **Check MCP config** - Claude: `~/.claude/config.json` -> `mcpServers.launchdarkly.env.LAUNCHDARKLY_API_KEY`
+3. **Prompt user** - Only if detection fails
+
+## Core Concepts
+
+### What Are Judges?
+
+Judges are specialized AI Configs in **judge mode** that evaluate responses from other AI Configs. They use an LLM to score outputs and return structured results:
+
+```json
+{
+  "score": 0.85,
+  "reasoning": "Answered correctly with one minor omission"
+}
+```
+
+### Built-in Judges
+
+LaunchDarkly provides three pre-configured judges:
+
+| Judge | Metric Key | Measures |
+|-------|-----------|----------|
+| Accuracy | `$ld:ai:judge:accuracy` | How correct and grounded the response is |
+| Relevance | `$ld:ai:judge:relevance` | How well it addresses the user request |
+| Toxicity | `$ld:ai:judge:toxicity` | Harmful or unsafe phrasing (lower = safer) |
+
+### Completion Mode Only
+
+Judges can only be attached to **completion mode** AI Configs in the UI. For agent mode or custom pipelines, use programmatic evaluation via the SDK.
+
+### Restrictions
+
+- Cannot attach judges to judges (no recursion)
+- Cannot attach multiple judges with the same metric key to a single variation
+- Cannot view/edit model parameters or tools on judge variations
+
+## Workflow
+
+### Step 1: Create Custom Judges (Optional)
+
+For domain-specific evaluation, create judge AI Configs:
+
+```bash
+# Create judge config
+curl -X POST "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "key": "security-judge",
+    "name": "Security Judge",
+    "mode": "judge",
+    "evaluationMetricKey": "security",
+    "isInverted": false
+  }'
+```
+
+> **Note:** Set `isInverted: true` for metrics like toxicity where 0.0 is better.
+
+Then add a variation with the evaluation prompt:
+
+```bash
+curl -X POST "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/security-judge/variations" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "key": "default",
+    "name": "Default",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a security auditor. Score from 0.0 to 1.0:\n- 1.0: No security issues\n- 0.7-0.9: Minor issues\n- 0.4-0.6: Moderate issues\n- 0.1-0.3: Serious vulnerabilities\n- 0.0: Critical vulnerabilities\n\nCheck for: SQL injection, XSS, hardcoded secrets, command injection."
+      }
+    ],
+    "modelConfigKey": "OpenAI.gpt-4o-mini",
+    "model": {
+      "parameters": {
+        "temperature": 0.3
+      }
+    }
+  }'
+```
+
+### Step 2: Attach Judges to Variations
+
+Use the variation PATCH endpoint:
+
+```bash
+curl -X PATCH "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/{configKey}/variations/{variationKey}" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "judgeConfiguration": {
+      "judges": [
+        {"judgeConfigKey": "security-judge", "samplingRate": 1.0},
+        {"judgeConfigKey": "api-contract-judge", "samplingRate": 0.5}
+      ]
+    }
+  }'
+```
+
+> **Important:** The `judges` array **replaces all existing** judge attachments. An empty array removes all judges.
+
+### Step 3: Set Fallthrough on Judges
+
+Each judge AI Config needs its fallthrough set to the enabled variation. AI Configs default to the "disabled" variation (index 0).
+
+> **Note:** `turnTargetingOn` does not work for AI Configs. Use `updateFallthroughVariationOrRollout` instead.
+
+```bash
+# First get the variation ID for "Default" from GET targeting response
+curl -X PATCH "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/security-judge/targeting" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json; domain-model=launchdarkly.semanticpatch" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "environmentKey": "production",
+    "instructions": [{
+      "kind": "updateFallthroughVariationOrRollout",
+      "variationId": "your-default-variation-uuid"
+    }]
+  }'
+```
+
+## Python Implementation
+
+```python
+import requests
+import os
+from typing import Optional
+
+class AIConfigJudges:
+    """Manager for AI Config judge attachments"""
+
+    def __init__(self, api_token: str, project_key: str):
+        self.api_token = api_token
+        self.project_key = project_key
+        self.base_url = "https://app.launchdarkly.com/api/v2"
+        self.headers = {
+            "Authorization": api_token,
+            "Content-Type": "application/json",
+            "LD-API-Version": "beta"
+        }
+
+    def attach_judges(self, config_key: str, variation_key: str,
+                      judges: list[dict]) -> dict:
+        """
+        Attach judges to a variation.
+
+        Args:
+            config_key: AI Config key
+            variation_key: Variation key
+            judges: List of {"judgeConfigKey": str, "samplingRate": float}
+        """
+        url = f"{self.base_url}/projects/{self.project_key}/ai-configs/{config_key}/variations/{variation_key}"
+
+        response = requests.patch(url, headers=self.headers, json={
+            "judgeConfiguration": {"judges": judges}
+        })
+
+        if response.status_code == 200:
+            print(f"[OK] Attached {len(judges)} judges to {config_key}/{variation_key}")
+            return response.json()
+        print(f"[ERROR] {response.status_code}: {response.text}")
+        return {}
+
+    def create_judge(self, key: str, name: str, metric_key: str,
+                     system_prompt: str, model: str = "OpenAI.gpt-4o-mini",
+                     is_inverted: bool = False) -> dict:
+        """
+        Create a judge AI Config.
+
+        Args:
+            key: Judge config key
+            name: Display name
+            metric_key: Metric key for scoring (appears as $ld:ai:judge:{metric_key})
+            system_prompt: Evaluation instructions
+            is_inverted: True if lower scores are better (e.g., toxicity)
+        """
+        # Create config
+        config_url = f"{self.base_url}/projects/{self.project_key}/ai-configs"
+        response = requests.post(config_url, headers=self.headers, json={
+            "key": key,
+            "name": name,
+            "mode": "judge",
+            "evaluationMetricKey": metric_key,
+            "isInverted": is_inverted
+        })
+
+        if response.status_code not in [200, 201]:
+            print(f"[ERROR] Creating config: {response.text}")
+            return {}
+
+        # Create variation
+        var_url = f"{self.base_url}/projects/{self.project_key}/ai-configs/{key}/variations"
+        response = requests.post(var_url, headers=self.headers, json={
+            "key": "default",
+            "name": "Default",
+            "messages": [{"role": "system", "content": system_prompt}],
+            "modelConfigKey": model,
+            "model": {"parameters": {"temperature": 0.3}}
+        })
+
+        if response.status_code in [200, 201]:
+            print(f"[OK] Created judge: {key}")
+            return response.json()
+        print(f"[ERROR] Creating variation: {response.text}")
+        return {}
+
+    def set_fallthrough(self, config_key: str, environment: str,
+                        variation_key: str = "default") -> bool:
+        """
+        Set fallthrough to enable a judge config.
+
+        Note: turnTargetingOn doesn't work for AI Configs. Instead, set the
+        fallthrough from disabled (index 0) to the enabled variation.
+        """
+        # Get variation ID
+        url = f"{self.base_url}/projects/{self.project_key}/ai-configs/{config_key}/targeting"
+        response = requests.get(url, headers=self.headers)
+
+        if response.status_code != 200:
+            print(f"[ERROR] {response.status_code}: {response.text}")
+            return False
+
+        targeting = response.json()
+        variation_id = None
+        for var in targeting.get("variations", []):
+            if var.get("key") == variation_key or var.get("name") == variation_key:
+                variation_id = var.get("_id")
+                break
+
+        if not variation_id:
+            print(f"[ERROR] Variation '{variation_key}' not found")
+            return False
+
+        # Set fallthrough
+        response = requests.patch(url, headers={
+            **self.headers,
+            "Content-Type": "application/json; domain-model=launchdarkly.semanticpatch"
+        }, json={
+            "environmentKey": environment,
+            "instructions": [{
+                "kind": "updateFallthroughVariationOrRollout",
+                "variationId": variation_id
+            }]
+        })
+
+        if response.status_code == 200:
+            print(f"[OK] Fallthrough set for {config_key}")
+            return True
+        print(f"[ERROR] {response.status_code}: {response.text}")
+        return False
+```
+
+## SDK: Automatic Evaluation
+
+When using `create_chat()` + `invoke()`, attached judges evaluate automatically:
+
+```python
+import os
+import json
+import asyncio
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldai import LDAIClient, AICompletionConfigDefault
+
+sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
+ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-ai-config')
+
+async def async_main():
+    ldclient.set_config(Config(sdk_key))
+    aiclient = LDAIClient(ldclient.get())
+
+    context = (
+        Context.builder('example-user-key')
+        .kind('user')
+        .name('Sandy')
+        .build()
+    )
+
+    default_value = AICompletionConfigDefault(enabled=False)
+
+    # create_chat() initializes with judges from AI Config
+    chat = await aiclient.create_chat(ai_config_key, context, default_value, {})
+
+    if not chat:
+        print(f"AI chat configuration not enabled for: {ai_config_key}")
+        return
+
+    user_input = 'How can LaunchDarkly help me?'
+
+    # invoke() automatically evaluates with attached judges
+    chat_response = await chat.invoke(user_input)
+    print("Response:", chat_response.message.content)
+
+    # Await evaluation results
+    if chat_response.evaluations and len(chat_response.evaluations) > 0:
+        eval_results = await asyncio.gather(*chat_response.evaluations)
+        results_to_display = [
+            result.to_dict() if result is not None else "not evaluated"
+            for result in eval_results
+        ]
+        print("Judge results:")
+        print(json.dumps(results_to_display, indent=2, default=str))
+
+    ldclient.get().close()
+```
+
+## SDK: Direct Judge Evaluation
+
+For agent mode or custom pipelines, evaluate input/output pairs directly:
+
+```python
+import os
+import json
+import asyncio
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldai import LDAIClient, AICompletionConfigDefault
+
+sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
+judge_key = os.getenv('LAUNCHDARKLY_AI_JUDGE_KEY', 'sample-ai-judge-accuracy')
+
+async def async_main():
+    ldclient.set_config(Config(sdk_key))
+    aiclient = LDAIClient(ldclient.get())
+
+    context = (
+        Context.builder('example-user-key')
+        .kind('user')
+        .name('Sandy')
+        .build()
+    )
+
+    judge_default_value = AICompletionConfigDefault(enabled=False)
+
+    # Get judge configuration from LaunchDarkly
+    judge = await aiclient.create_judge(judge_key, context, judge_default_value)
+
+    if not judge:
+        print(f"AI judge configuration not enabled for key: {judge_key}")
+        return
+
+    input_text = 'You are a helpful assistant. How can you help me?'
+    output_text = 'I can answer any question you have.'
+
+    # Evaluate the input/output pair
+    judge_response = await judge.evaluate(input_text, output_text)
+
+    if judge_response is None:
+        print("Judge evaluation was skipped (sample rate or configuration issue)")
+        return
+
+    # Track scores on the AI Config tracker if needed:
+    # aiConfig.tracker.track_eval_scores(judge_response.evals)
+
+    print("Judge Response:")
+    print(json.dumps(judge_response.to_dict(), indent=2, default=str))
+
+    ldclient.get().close()
+```
+
+> **Note:** Direct evaluation does not automatically record metrics. Use `tracker.track_eval_scores()` to record scores for the AI Config you're evaluating.
+
+## Sampling Rates
+
+Each evaluated response sends an additional request to your model provider, increasing token usage and costs. Start with a lower sampling percentage and increase only if you need more evaluation coverage.
+
+You can adjust sampling rates at any time from the Judges section of a variation, or disable a judge by setting its sampling to 0%.
+
+## Viewing Results
+
+1. Navigate to **AI Configs** > select your config
+2. Click **Monitoring** tab
+3. Select **Evaluator metrics** from dropdown
+4. View scores by variation and time range
+
+Results appear within 1-2 minutes of evaluation.
+
+## Use in Guardrails and Experiments
+
+Evaluation metrics integrate with:
+- **Guarded rollouts**: Pause/revert when scores fall below threshold
+- **Experiments**: Compare variations using evaluation metrics as goals
+
+## Error Handling
+
+| Status | Cause | Solution |
+|--------|-------|----------|
+| 404 | Config/variation not found | Verify keys exist |
+| 400 | Invalid judge config | Check judgeConfigKey exists |
+| 403 | Insufficient permissions | Check API token permissions |
+| 422 | Duplicate metric key | Cannot attach multiple judges with same metric key |
+
+## Next Steps
+
+After attaching judges:
+1. **Set fallthrough** on judge configs to an enabled variation (required)
+2. **Monitor results** in Monitoring tab
+3. **Adjust sampling** based on cost/coverage needs
+4. **Set up guarded rollouts** for automatic regression detection
+
+## Related Skills
+
+- `aiconfig-create` - Create AI Configs and judges
+- `aiconfig-targeting` - Configure targeting rules
+- `aiconfig-variations` - Manage variations
+
+## References
+
+- [Online Evaluations](https://docs.launchdarkly.com/home/ai-configs/online-evaluations)
+- [Custom Judges](https://docs.launchdarkly.com/home/ai-configs/custom-judges)
+
+**Python SDK examples:**
+- [direct_judge_example.py](https://github.com/launchdarkly/hello-python-ai/blob/main/examples/direct_judge_example.py) - Evaluate input/output pairs directly
+- [chat_judge_example.py](https://github.com/launchdarkly/hello-python-ai/blob/main/examples/chat_judge_example.py) - Automatic evaluation with create_chat/invoke
+
+**Node.js SDK examples:**
+- [judge-evaluation](https://github.com/launchdarkly/js-core/blob/main/packages/sdk/server-ai/examples/judge-evaluation/src/index.ts) - Both direct evaluation and automatic chat-based evaluation

--- a/skills/ai-configs/aiconfig-targeting/README.md
+++ b/skills/ai-configs/aiconfig-targeting/README.md
@@ -1,0 +1,51 @@
+# LaunchDarkly AI Config Targeting Skill
+
+An Agent Skill for configuring AI Config targeting rules via the LaunchDarkly API.
+
+## Overview
+
+This skill teaches agents how to:
+- Turn targeting on/off for AI Configs
+- Add attribute-based targeting rules
+- Configure percentage rollouts for A/B testing
+- Set fallthrough (default) variations
+- Target individual contexts or segments
+
+## Installation (Local)
+
+Copy `skills/ai-configs/aiconfig-targeting/` into your agent client's skills path.
+
+## Prerequisites
+
+- LaunchDarkly API access token with `ai-configs:write` permission
+- Existing AI Config with variations (use `aiconfig-create` skill)
+- Understanding of contexts (see `aiconfig-context-basic` skill)
+
+## Usage
+
+```
+Set up targeting rules for model-selector: route sonnet requests to the Sonnet variation, mistral to Mistral, and default to Opus
+```
+
+```
+Add a percentage rollout: 60% to variation A, 40% to variation B for premium users
+```
+
+## Structure
+
+```
+aiconfig-targeting/
+├── SKILL.md
+└── README.md
+```
+
+## Related
+
+- [AI Config Create](../aiconfig-create/) - Create AI Configs first
+- [AI Config Variations](../aiconfig-variations/) - Create variations to target
+- [AI Config Online Evals](../aiconfig-online-evals/) - Attach judges
+- [Targeting Docs](https://docs.launchdarkly.com/home/ai-configs/target)
+
+## License
+
+Apache-2.0

--- a/skills/ai-configs/aiconfig-targeting/SKILL.md
+++ b/skills/ai-configs/aiconfig-targeting/SKILL.md
@@ -64,9 +64,9 @@ curl -X GET "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-config
 
 Response includes `variations` array with `_id` (UUID) for each variation.
 
-### Step 2: Set Fallthrough to Enabled Variation
+### Step 2: Edit the Default Rule
 
-AI Configs have targeting enabled by default, but the fallthrough defaults to variation index 0 (typically "disabled"). You must set the fallthrough to an enabled variation.
+Edit the default rule to serve the variation you created.
 
 > **Important:** The `turnTargetingOn` instruction does not work for AI Configs. Use `updateFallthroughVariationOrRollout` instead.
 

--- a/skills/ai-configs/aiconfig-targeting/SKILL.md
+++ b/skills/ai-configs/aiconfig-targeting/SKILL.md
@@ -1,0 +1,507 @@
+---
+name: aiconfig-targeting
+description: Configure AI Config targeting rules to control which variations serve to different users. Enable percentage rollouts, attribute-based rules, segment targeting, and guarded rollouts.
+compatibility: Requires LaunchDarkly API access token with ai-configs:write permission.
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# AI Config Targeting
+
+Configure targeting rules for AI Configs to control which variations serve to different contexts. Works the same for both completion and agent mode.
+
+## Prerequisites
+
+- LaunchDarkly account with AI Configs enabled
+- API access token with write permissions
+- Project key and environment key
+- Existing AI Config with variations (use `aiconfig-create` skill)
+
+## API Key Detection
+
+1. **Check environment variables** - `LAUNCHDARKLY_API_KEY`, `LAUNCHDARKLY_API_TOKEN`, `LD_API_KEY`
+2. **Check MCP config** - Claude: `~/.claude/config.json` -> `mcpServers.launchdarkly.env.LAUNCHDARKLY_API_KEY`
+3. **Prompt user** - Only if detection fails
+
+## Core Concepts
+
+### Evaluation Order
+
+Targeting rules evaluate in this order (same as feature flags):
+
+1. **Individual targets** - Specific context keys (highest priority)
+2. **Segment rules** - Pre-defined segments
+3. **Custom rules** - Attribute-based conditions (evaluated in order)
+4. **Default rule** - Fallthrough for all others
+5. **Off variation** - When targeting is disabled
+
+### Semantic Patch API
+
+AI Config targeting uses semantic patch instructions:
+
+```
+PATCH /api/v2/projects/{projectKey}/ai-configs/{configKey}/targeting
+Content-Type: application/json; domain-model=launchdarkly.semanticpatch
+```
+
+### Key Concepts
+
+- **variationId**: UUIDs, not keys. Always fetch targeting first to get IDs.
+- **Weights**: Thousandths (50000 = 50%, 100000 = 100%)
+- **Clause logic**: Multiple clauses = AND, multiple values = OR
+- **Null attributes**: Rules with null/missing attributes are skipped
+
+## Workflow
+
+### Step 1: Get Targeting (with Variation IDs)
+
+```bash
+curl -X GET "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/{configKey}/targeting" \
+  -H "Authorization: {api_token}" \
+  -H "LD-API-Version: beta"
+```
+
+Response includes `variations` array with `_id` (UUID) for each variation.
+
+### Step 2: Set Fallthrough to Enabled Variation
+
+AI Configs have targeting enabled by default, but the fallthrough defaults to variation index 0 (typically "disabled"). You must set the fallthrough to an enabled variation.
+
+> **Important:** The `turnTargetingOn` instruction does not work for AI Configs. Use `updateFallthroughVariationOrRollout` instead.
+
+```bash
+# First, get variation IDs from Step 1 response
+# Then set fallthrough to the enabled variation (e.g., "Default" variation)
+curl -X PATCH "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/{configKey}/targeting" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json; domain-model=launchdarkly.semanticpatch" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "environmentKey": "production",
+    "instructions": [{
+      "kind": "updateFallthroughVariationOrRollout",
+      "variationId": "your-enabled-variation-uuid"
+    }]
+  }'
+```
+
+### Step 3: Add Targeting Rules
+
+**Attribute-based rule:**
+
+```bash
+curl -X PATCH "https://app.launchdarkly.com/api/v2/projects/{projectKey}/ai-configs/{configKey}/targeting" \
+  -H "Authorization: {api_token}" \
+  -H "Content-Type: application/json; domain-model=launchdarkly.semanticpatch" \
+  -H "LD-API-Version: beta" \
+  -d '{
+    "environmentKey": "production",
+    "instructions": [{
+      "kind": "addRule",
+      "clauses": [{
+        "contextKind": "user",
+        "attribute": "selectedModel",
+        "op": "contains",
+        "values": ["sonnet"],
+        "negate": false
+      }],
+      "variation": 0
+    }]
+  }'
+```
+
+**Percentage rollout:**
+
+```bash
+curl -X PATCH "..." \
+  -d '{
+    "environmentKey": "production",
+    "instructions": [{
+      "kind": "addRule",
+      "clauses": [{
+        "contextKind": "user",
+        "attribute": "tier",
+        "op": "in",
+        "values": ["premium"],
+        "negate": false
+      }],
+      "percentageRolloutConfig": {
+        "contextKind": "user",
+        "bucketBy": "key",
+        "variations": [
+          {"variation": 0, "weight": 60000},
+          {"variation": 1, "weight": 40000}
+        ]
+      }
+    }]
+  }'
+```
+
+**Set fallthrough (default rule):**
+
+```bash
+curl -X PATCH "..." \
+  -d '{
+    "environmentKey": "production",
+    "instructions": [{
+      "kind": "updateFallthroughVariationOrRollout",
+      "variationId": "fallback-variation-uuid"
+    }]
+  }'
+```
+
+## Python Implementation
+
+```python
+import requests
+import os
+from typing import Dict, List, Optional
+
+class AIConfigTargeting:
+    """Manager for AI Config targeting rules"""
+
+    def __init__(self, api_token: str, project_key: str):
+        self.api_token = api_token
+        self.project_key = project_key
+        self.base_url = "https://app.launchdarkly.com/api/v2"
+
+    def get_targeting(self, config_key: str) -> Optional[Dict]:
+        """Get current targeting with variation IDs."""
+        url = f"{self.base_url}/projects/{self.project_key}/ai-configs/{config_key}/targeting"
+
+        response = requests.get(url, headers={
+            "Authorization": self.api_token,
+            "LD-API-Version": "beta"
+        })
+
+        if response.status_code == 200:
+            return response.json()
+        print(f"[ERROR] {response.status_code}: {response.text}")
+        return None
+
+    def get_variation_id(self, config_key: str, variation_key: str) -> Optional[str]:
+        """Look up variation UUID from key or name."""
+        targeting = self.get_targeting(config_key)
+        if targeting:
+            for var in targeting.get("variations", []):
+                if var.get("key") == variation_key or var.get("name") == variation_key:
+                    return var.get("_id")
+        return None
+
+    def update_targeting(self, config_key: str, environment: str,
+                         instructions: List[Dict], comment: str = "") -> Optional[Dict]:
+        """Send semantic patch instructions."""
+        url = f"{self.base_url}/projects/{self.project_key}/ai-configs/{config_key}/targeting"
+
+        payload = {"environmentKey": environment, "instructions": instructions}
+        if comment:
+            payload["comment"] = comment
+
+        response = requests.patch(url, headers={
+            "Authorization": self.api_token,
+            "Content-Type": "application/json; domain-model=launchdarkly.semanticpatch",
+            "LD-API-Version": "beta"
+        }, json=payload)
+
+        if response.status_code == 200:
+            return response.json()
+        print(f"[ERROR] {response.status_code}: {response.text}")
+        return None
+
+    def enable_config(self, config_key: str, environment: str,
+                      variation_key: str = "default") -> bool:
+        """
+        Enable an AI Config by setting fallthrough to an enabled variation.
+
+        Note: turnTargetingOn doesn't work for AI Configs. Instead, set the
+        fallthrough from the disabled variation (index 0) to an enabled one.
+        """
+        variation_id = self.get_variation_id(config_key, variation_key)
+        if not variation_id:
+            print(f"[ERROR] Variation '{variation_key}' not found")
+            return False
+        return self.set_fallthrough(config_key, environment, variation_id)
+
+    def add_rule(self, config_key: str, environment: str,
+                 clauses: List[Dict], variation: int,
+                 description: str = "") -> bool:
+        """Add targeting rule serving a specific variation index."""
+        instruction = {
+            "kind": "addRule",
+            "clauses": clauses,
+            "variation": variation
+        }
+        if description:
+            instruction["description"] = description
+
+        result = self.update_targeting(config_key, environment,
+            [instruction], f"Add rule: {description}")
+        if result:
+            print(f"[OK] Rule added")
+            return True
+        return False
+
+    def add_rollout_rule(self, config_key: str, environment: str,
+                         clauses: List[Dict],
+                         weights: List[Dict],
+                         bucket_by: str = "key") -> bool:
+        """
+        Add percentage rollout rule.
+
+        weights: [{"variation": 0, "weight": 50000}, {"variation": 1, "weight": 50000}]
+        """
+        result = self.update_targeting(config_key, environment, [{
+            "kind": "addRule",
+            "clauses": clauses,
+            "percentageRolloutConfig": {
+                "contextKind": "user",
+                "bucketBy": bucket_by,
+                "variations": weights
+            }
+        }], "Add percentage rollout")
+        if result:
+            print(f"[OK] Rollout rule added")
+            return True
+        return False
+
+    def set_fallthrough(self, config_key: str, environment: str,
+                        variation_id: str) -> bool:
+        """Set default (fallthrough) variation by UUID."""
+        result = self.update_targeting(config_key, environment, [{
+            "kind": "updateFallthroughVariationOrRollout",
+            "variationId": variation_id
+        }], "Set fallthrough")
+        if result:
+            print(f"[OK] Fallthrough set")
+            return True
+        return False
+
+    def target_individuals(self, config_key: str, environment: str,
+                          context_keys: List[str], variation: int,
+                          context_kind: str = "user") -> bool:
+        """Target specific context keys."""
+        result = self.update_targeting(config_key, environment, [{
+            "kind": "addTargets",
+            "variation": variation,
+            "contextKind": context_kind,
+            "values": context_keys
+        }], f"Target {len(context_keys)} individuals")
+        if result:
+            print(f"[OK] Individual targets added")
+            return True
+        return False
+
+    def target_segment(self, config_key: str, environment: str,
+                      segment_keys: List[str], variation: int) -> bool:
+        """Target a segment."""
+        result = self.update_targeting(config_key, environment, [{
+            "kind": "addRule",
+            "clauses": [{
+                "attribute": "segmentMatch",
+                "contextKind": "",  # Leave blank for segments
+                "op": "segmentMatch",
+                "values": segment_keys,
+                "negate": False
+            }],
+            "variation": variation
+        }], f"Target segments: {segment_keys}")
+        if result:
+            print(f"[OK] Segment targeting added")
+            return True
+        return False
+
+    def clear_rules(self, config_key: str, environment: str) -> bool:
+        """Remove all targeting rules."""
+        result = self.update_targeting(config_key, environment,
+            [{"kind": "replaceRules", "rules": []}], "Clear all rules")
+        if result:
+            print(f"[OK] All rules cleared")
+            return True
+        return False
+```
+
+## Instruction Reference
+
+> **Note:** `turnTargetingOn` and `turnTargetingOff` do not work for AI Configs. AI Configs have targeting enabled by default. To "enable" a config, set the fallthrough to an enabled variation using `updateFallthroughVariationOrRollout`.
+
+### Rules
+| Kind | Description |
+|------|-------------|
+| `addRule` | Add rule with clauses and variation/rollout |
+| `removeRule` | Remove by ruleId |
+| `replaceRules` | Replace all rules |
+| `reorderRules` | Change evaluation order |
+| `updateRuleVariationOrRollout` | Update what a rule serves |
+
+### Fallthrough
+| Kind | Description |
+|------|-------------|
+| `updateFallthroughVariationOrRollout` | Set default variation or rollout |
+
+### Individual Targets
+| Kind | Description |
+|------|-------------|
+| `addTargets` | Target specific context keys |
+| `removeTargets` | Remove specific targets |
+| `replaceTargets` | Replace all targets |
+
+## Operators Reference
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `in` | Value in list | `["premium", "enterprise"]` |
+| `contains` | String contains | `["sonnet"]` |
+| `startsWith` | String prefix | `["user-"]` |
+| `endsWith` | String suffix | `[".edu"]` |
+| `matches` | Regex match | `["^user-\\d+$"]` |
+| `greaterThan` / `lessThan` | Numeric comparison | `[100]` |
+| `before` / `after` | Date comparison | `["2024-12-31T00:00:00Z"]` |
+| `semVerEqual` / `semVerGreaterThan` | Version comparison | `["2.0.0"]` |
+| `segmentMatch` | Segment membership | `["beta-testers"]` |
+
+## Clause Structure
+
+```json
+{
+  "contextKind": "user",
+  "attribute": "email",
+  "op": "endsWith",
+  "values": [".edu"],
+  "negate": false
+}
+```
+
+- Multiple clauses = AND (all must match)
+- Multiple values = OR (any can match)
+- `negate: true` inverts the operator
+
+## Rollout Types
+
+### Manual Percentage Rollout
+```json
+{
+  "percentageRolloutConfig": {
+    "contextKind": "user",
+    "bucketBy": "key",
+    "variations": [
+      {"variation": 0, "weight": 50000},
+      {"variation": 1, "weight": 50000}
+    ]
+  }
+}
+```
+
+### Progressive Rollout
+```json
+{
+  "progressiveRolloutConfig": {
+    "contextKind": "user",
+    "controlVariation": 1,
+    "endVariation": 0,
+    "steps": [
+      {"rolloutWeight": 1000, "duration": {"quantity": 4, "unit": "hour"}},
+      {"rolloutWeight": 5000, "duration": {"quantity": 4, "unit": "hour"}},
+      {"rolloutWeight": 10000, "duration": {"quantity": 4, "unit": "hour"}}
+    ]
+  }
+}
+```
+
+### Guarded Rollout
+```json
+{
+  "guardedRolloutConfig": {
+    "randomizationUnit": "user",
+    "stages": [
+      {"rolloutWeight": 1000, "monitoringWindowMilliseconds": 17280000},
+      {"rolloutWeight": 5000, "monitoringWindowMilliseconds": 17280000}
+    ],
+    "metrics": [{
+      "metricKey": "error-rate",
+      "onRegression": {"rollback": true},
+      "regressionThreshold": 0.01
+    }]
+  }
+}
+```
+
+## Common Patterns
+
+### Model Routing by Attribute
+```python
+# Route based on selectedModel context attribute
+targeting.add_rule(
+    config_key="model-selector",
+    environment="production",
+    clauses=[{
+        "contextKind": "user",
+        "attribute": "selectedModel",
+        "op": "contains",
+        "values": ["sonnet"],
+        "negate": False
+    }],
+    variation=0,  # Sonnet variation index
+    description="Route sonnet requests"
+)
+```
+
+### Tier-Based Variation
+```python
+targeting.add_rule(
+    config_key="chat-assistant",
+    environment="production",
+    clauses=[{
+        "contextKind": "user",
+        "attribute": "tier",
+        "op": "in",
+        "values": ["premium", "enterprise"],
+        "negate": False
+    }],
+    variation=0  # Premium model variation
+)
+```
+
+### Segment Targeting
+```python
+targeting.target_segment(
+    config_key="chat-assistant",
+    environment="production",
+    segment_keys=["beta-testers"],
+    variation=1  # Experimental variation
+)
+```
+
+## Error Handling
+
+| Status | Cause | Solution |
+|--------|-------|----------|
+| 400 | Invalid semantic patch | Check instruction format, ops must be lowercase |
+| 403 | Insufficient permissions | Check API token |
+| 404 | Config not found | Verify projectKey and configKey |
+| 422 | Invalid variation | Use index (0, 1, 2...) or UUID from targeting response |
+
+## Next Steps
+
+After configuring targeting:
+1. **Provide config URL:**
+   ```
+   https://app.launchdarkly.com/projects/{projectKey}/ai-configs/{configKey}
+   ```
+2. **Monitor performance** with `aiconfig-ai-metrics`
+3. **Attach judges** with `aiconfig-online-evals`
+4. **Set up guarded rollouts** for automatic regression detection
+
+## Related Skills
+
+- `aiconfig-create` - Create AI Configs with variations
+- `aiconfig-variations` - Manage variations
+- `aiconfig-online-evals` - Attach judges
+- `aiconfig-segments` - Create segments for targeting
+
+## References
+
+- [Target with AI Configs](https://docs.launchdarkly.com/home/ai-configs/target)
+- [Targeting Rules](https://docs.launchdarkly.com/home/flags/target-rules)
+- [JSON Targeting](https://docs.launchdarkly.com/home/flags/json-targeting)
+- [Guarded Rollouts](https://docs.launchdarkly.com/home/releases/guarded-rollouts)


### PR DESCRIPTION
Add two new skills for AI Config management:

aiconfig-online-evals:
- Attach judges to variations for LLM-as-a-judge evaluation
- Create custom judges with domain-specific criteria
- SDK examples for automatic and programmatic evaluation
- Sampling rate configuration and monitoring guidance

aiconfig-targeting:
- Configure targeting rules via semantic patch API
- Support for individual, segment, and attribute-based targeting
- Percentage rollouts, progressive rollouts, and guarded rollouts
- Complete operator reference and clause logic documentation

Both skills align with current LaunchDarkly API and documentation.

## Summary

- 

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- 
