### PR TITLE
REL-12704: Adds a skill for planning the onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `feature-flags/launchdarkly-flag-targeting` | Control targeting, rollouts, rules, and cross-environment config |
 | `feature-flags/launchdarkly-flag-cleanup` | Safely remove flags from code using LaunchDarkly as the source of truth |
 
+### Setup
+
+| Skill | Description |
+|-------|-------------|
+| `setup/launchdarkly-sdk-onboarding` | Detect stack, install and initialize the LaunchDarkly SDK, validate connectivity, and create a first feature flag |
+
 ### AI Configs
 
 | Skill | Description |

--- a/skills.json
+++ b/skills.json
@@ -123,6 +123,22 @@
         "devops",
         "mcp"
       ]
+    },
+    {
+      "name": "launchdarkly-sdk-onboarding",
+      "description": "Onboard a project to LaunchDarkly by detecting the tech stack, installing the right SDK, initializing it, validating the connection, and creating a first feature flag. Use when the user wants to add LaunchDarkly or feature flags to their project, integrate an SDK, or says 'onboard me'.",
+      "path": "skills/setup/launchdarkly-sdk-onboarding",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires LaunchDarkly API access token or SDK key. MCP server optional; without MCP, use ldcli and direct API calls (see Prerequisites).",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feature-management",
+        "sdk",
+        "devops",
+        "mcp"
+      ]
     }
   ]
 }

--- a/skills.json
+++ b/skills.json
@@ -136,6 +136,7 @@
         "feature-flags",
         "feature-management",
         "sdk",
+        "onboarding",
         "devops",
         "mcp"
       ]

--- a/skills/setup/launchdarkly-sdk-onboarding/SKILL.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: launchdarkly-sdk-onboarding
-description: "Onboard a project to LaunchDarkly by detecting the tech stack, installing the right SDK, initializing it, validating the connection, and creating a first feature flag. Use when the user wants to add LaunchDarkly to their project, integrate an SDK, or says 'onboard me'."
+description: "Onboard a project to LaunchDarkly by detecting the tech stack, installing the right SDK, initializing it, validating the connection, and creating a first feature flag. Use when the user wants to add LaunchDarkly or feature flags to their project, integrate an SDK, or says 'onboard me'."
 license: Apache-2.0
-compatibility: Requires LaunchDarkly API access token. Prefer the LaunchDarkly MCP server when configured for flags and validation.
+compatibility: Requires LaunchDarkly API access token or SDK key. MCP server optional; without MCP, use ldcli and direct API calls (see Prerequisites).
 metadata:
   author: launchdarkly
   version: "0.1.0"
@@ -12,12 +12,25 @@ metadata:
 
 You're using a skill that will guide you through adding LaunchDarkly to a project. Your job is to detect the tech stack, choose the right SDK, install and initialize it, validate the connection, and help the user create their first feature flag.
 
+## Prerequisites
+
+MCP tools are **optional** for this skill—the workflow falls back to **ldcli** (the LaunchDarkly CLI) and **direct LaunchDarkly API** calls (`GET /api/v2/projects/{projectKey}`, environment endpoints, etc.) when MCP is unavailable.
+
+**Optional MCP tools (enhance onboarding when configured):**
+
+- `get-environments` — list environments for a project; use the response (and related project/environment APIs as needed) to obtain SDK keys, client-side IDs, or mobile keys without manual copy-paste when the tool exposes them.
+- `create-feature-flag` — create the boolean flag for [Step 5: Create Your First Feature Flag](#step-5-create-your-first-feature-flag). (Some setups or docs may label this capability `create-flag`; use the tool name your MCP server lists.)
+
+**Other MCP tools you may use if present** (not required): `list-feature-flags`, `get-feature-flag`, `get-flag-status-across-environments`—for confirmation and validation alongside the API or dashboard.
+
+Before starting, confirm the user can authenticate to LaunchDarkly (access token for API/MCP, or SDK keys they paste manually).
+
 ## Account and Credentials
 
 Before starting the SDK integration, ensure the user has access to LaunchDarkly:
 
 1. **Check for existing credentials**: Ask the user if they have a LaunchDarkly access token or SDK key.
-2. **If the user has an account**: Use the LaunchDarkly API (`GET /api/v2/projects/PROJECT_KEY`) or `ldcli` to retrieve the project, environment, and SDK key automatically. Ask the user for permission before reading the SDK key.
+2. **If the user has an account**: Use the LaunchDarkly API (`GET /api/v2/projects/PROJECT_KEY`) or **ldcli** (the LaunchDarkly CLI) to retrieve the project, environment, and SDK key automatically. Ask the user for permission before reading the SDK key.
 3. **If the user does NOT have an account**: Prompt them to sign up at https://launchdarkly.com or log in via `ldcli login`. Guide them through creating their first project and environment if needed.
 4. **SDK key types**: The project response will contain the keys you need. Use the correct key type for the SDK:
    - **SDK Key** for server-side SDKs
@@ -33,7 +46,7 @@ Before starting the SDK integration, ensure the user has access to LaunchDarkly:
 
 ## Workflow
 
-Follow and enumerate **Steps 1-6** in order for the SDK integration and first flag. If any step fails, go to [Step 7: Recover](#step-7-recover).
+Follow and enumerate **Steps 1-5** in order for the SDK integration and first flag. If any step fails, go to [Step 6: Recover](#step-6-recover).
 
 MCP setup, `LAUNCHDARKLY.md`, and editor rules are **not** listed below as steps—they are covered in [Default follow-through](#default-follow-through-not-numbered-steps).
 
@@ -57,27 +70,18 @@ Based on what you found, choose the correct SDK and plan the integration.
 
 See [Generate Integration Plan](references/1.1-plan.md) for detailed instructions.
 
-### Step 3: Install Dependencies and Apply Code
+### Step 3: Install, Apply Code, and Run
 
-Install the SDK and add initialization code to the project.
+Install the SDK, add initialization code, and confirm the app still starts.
 
 1. Install the SDK package using the project's package manager
 2. Add SDK initialization code to the application entrypoint
 3. Configure the SDK key via environment variables
+4. Start the application using its standard run command; confirm there are no import or initialization errors and look for SDK initialization success in logs
 
-See [Apply Code Changes](references/1.2-apply.md) for detailed instructions.
+See [Apply Code Changes](references/1.2-apply.md) and [Start the Application](references/1.3-run.md) for detailed instructions.
 
-### Step 4: Start the Application
-
-Verify the application runs with the SDK integrated.
-
-1. Start the application using its standard run command
-2. Confirm there are no import or initialization errors
-3. Look for SDK initialization success in logs
-
-See [Start the Application](references/1.3-run.md) for detailed instructions.
-
-### Step 5: Validate SDK Connection
+### Step 4: Validate SDK Connection
 
 Confirm that LaunchDarkly sees the SDK connection.
 
@@ -86,7 +90,7 @@ Confirm that LaunchDarkly sees the SDK connection.
 
 See [Validate SDK Connection](references/1.4-validate.md) for detailed instructions.
 
-### Step 6: Create Your First Feature Flag
+### Step 5: Create Your First Feature Flag
 
 Help the user create and evaluate a feature flag.
 
@@ -96,7 +100,7 @@ Help the user create and evaluate a feature flag.
 
 See [Create First Feature Flag](references/1.5-first-flag.md) for detailed instructions.
 
-### Step 7: Recover
+### Step 6: Recover
 
 If any step fails, diagnose the issue and resume.
 
@@ -112,8 +116,8 @@ Do these as part of finishing onboarding—same session when possible. They are 
 
 **LaunchDarkly MCP**
 
-- Use MCP tools whenever they are available (flags, environments, validation).
-- If the MCP server is not configured, briefly offer optional setup; do **not** block completion of Steps 1–6 on it. See [MCP Server Setup](references/1.7-mcp-setup.md).
+- Use MCP tools whenever they are available (see [Prerequisites](#prerequisites)); prefer them for environments and flag creation when configured.
+- If the MCP server is not configured, briefly offer optional setup; do **not** block completion of Steps 1–5 on it. See [MCP Server Setup](references/1.7-mcp-setup.md).
 
 **Setup summary (`LAUNCHDARKLY.md`)**
 
@@ -127,7 +131,7 @@ Do these as part of finishing onboarding—same session when possible. They are 
 
 | Situation | Action |
 |-----------|--------|
-| SDK already installed | Skip to Step 4 (Run) or Step 5 (Validate) |
+| SDK already installed | Skip to Step 3 (run sub-step) or Step 4 (Validate) |
 | Multiple languages in repo | Ask the user which target to integrate first (frontend vs backend vs mobile) |
 | Monorepo | Identify the specific package/service to integrate and work within that subtree |
 | No package manager detected | Ask the user which SDK they want to install and provide manual install instructions |
@@ -143,7 +147,7 @@ Do these as part of finishing onboarding—same session when possible. They are 
 
 ## References
 
-**Core workflow (Steps 1-6, 7 recover)**
+**Core workflow (Steps 1-5, Step 6 recover)**
 
 - [Detect Repository Stack](references/1.0-detect.md) — How to identify language, framework, and existing SDK usage
 - [Generate Integration Plan](references/1.1-plan.md) — How to choose the right SDK and plan changes

--- a/skills/setup/launchdarkly-sdk-onboarding/SKILL.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/SKILL.md
@@ -19,7 +19,8 @@ MCP tools are **optional** for this skill—the workflow falls back to **ldcli**
 **Optional MCP tools (enhance onboarding when configured):**
 
 - `get-environments` — list environments for a project; use the response (and related project/environment APIs as needed) to obtain SDK keys, client-side IDs, or mobile keys without manual copy-paste when the tool exposes them.
-- `create-feature-flag` — create the boolean flag for [Step 5: Create Your First Feature Flag](#step-5-create-your-first-feature-flag). (Some setups or docs may label this capability `create-flag`; use the tool name your MCP server lists.)
+- `create-feature-flag` — create the boolean flag for [Step 5: Create Your First Feature Flag](#step-5-create-your-first-feature-flag).
+- `update-feature-flag` — toggle or patch flag configuration (e.g. turn the first flag **on** during Step 5); tool shape and patch format are defined by your MCP server’s schema—see [Create First Feature Flag](references/1.5-first-flag.md) for ldcli/API fallbacks.
 
 **Other MCP tools you may use if present** (not required): `list-feature-flags`, `get-feature-flag`, `get-flag-status-across-environments`—for confirmation and validation alongside the API or dashboard.
 
@@ -77,7 +78,7 @@ Install the SDK, add initialization code, and confirm the app still starts.
 1. Install the SDK package using the project's package manager
 2. Add SDK initialization code to the application entrypoint
 3. Configure the SDK key via environment variables
-4. Start the application using its standard run command; confirm there are no import or initialization errors and look for SDK initialization success in logs
+4. Start the application (you run it when possible, otherwise give the user the exact command) and **do not** continue to validation until startup is confirmed—explicit user confirmation when they run it locally; see [Start the Application](references/1.3-run.md) Step 4
 
 See [Apply Code Changes](references/1.2-apply.md) and [Start the Application](references/1.3-run.md) for detailed instructions.
 
@@ -85,8 +86,8 @@ See [Apply Code Changes](references/1.2-apply.md) and [Start the Application](re
 
 Confirm that LaunchDarkly sees the SDK connection.
 
-1. Check the SDK is active using the LaunchDarkly API or MCP
-2. Verify the connection in the LaunchDarkly dashboard
+1. **Prefer `ldcli sdk-active` or the REST equivalent** (see the reference). That check does **not** require a feature flag to exist yet—Step 5 comes next on purpose.
+2. **Dashboard-only** validation is weak until a flag exists and is evaluated; the reference describes when to use a short **exception path** (create/evaluate a flag early) if API/CLI access is impossible.
 
 See [Validate SDK Connection](references/1.4-validate.md) for detailed instructions.
 
@@ -94,11 +95,10 @@ See [Validate SDK Connection](references/1.4-validate.md) for detailed instructi
 
 Help the user create and evaluate a feature flag.
 
-1. Create a boolean feature flag
-2. Add flag evaluation code to the project
-3. Toggle the flag and observe the change
+1. Create a boolean feature flag and add evaluation code (see [Create First Feature Flag](references/1.5-first-flag.md))
+2. Toggle the flag and observe the change end-to-end
 
-See [Create First Feature Flag](references/1.5-first-flag.md) for detailed instructions.
+If [LaunchDarkly Flag Create & Configure](../../feature-flags/launchdarkly-flag-create/SKILL.md) is **already** installed, the agent may use it for the create + evaluation parts above—**only** while still finishing the verify/toggle checklist in that reference. Onboarding must remain completable without that skill.
 
 ### Step 6: Recover
 
@@ -127,11 +127,17 @@ Do these as part of finishing onboarding—same session when possible. They are 
 
 - Add editor-specific rules or skill hooks per [Editor Rules and Skills](references/1.9-editor-rules.md) so later agent sessions follow LaunchDarkly practices. Ask permission before writing or committing.
 
+**Companion skill (strongly recommended)**
+
+- If it is **not** already installed, **encourage the user to install** [LaunchDarkly Flag Create & Configure](../../feature-flags/launchdarkly-flag-create/SKILL.md) after Step 5 (Cursor or this repo’s skill marketplace). It is the supported path for ongoing flag work that matches the codebase. If it **is** installed, Step 5 may delegate create/eval to that skill per [Create First Feature Flag](references/1.5-first-flag.md). Note that skill expects the LaunchDarkly MCP server for its default workflow.
+
 ## Edge Cases
 
 | Situation | Action |
 |-----------|--------|
-| SDK already installed | Skip to Step 3 (run sub-step) or Step 4 (Validate) |
+| SDK already installed **and** initialized (see [Detect Repository Stack](references/1.0-detect.md) decision tree) | Skip to **Step 4** (Validate) |
+| SDK in dependencies **but** not initialized | Continue **Step 3** from apply/init (add init, env, then run)—do not skip validation |
+| SDK already installed; state unclear | Re-run detection checks in Step 1 reference, then follow the decision tree there |
 | Multiple languages in repo | Ask the user which target to integrate first (frontend vs backend vs mobile) |
 | Monorepo | Identify the specific package/service to integrate and work within that subtree |
 | No package manager detected | Ask the user which SDK they want to install and provide manual install instructions |
@@ -152,7 +158,7 @@ Do these as part of finishing onboarding—same session when possible. They are 
 - [Detect Repository Stack](references/1.0-detect.md) — How to identify language, framework, and existing SDK usage
 - [Generate Integration Plan](references/1.1-plan.md) — How to choose the right SDK and plan changes
 - [Apply Code Changes](references/1.2-apply.md) — How to install dependencies and add initialization code
-- [Start the Application](references/1.3-run.md) — How to run the app and confirm SDK initialization
+- [Start the Application](references/1.3-run.md) — How to run the app, when the user runs it instead, and **confirm** it is up before validation (no duplicate `sdk-active` here)
 - [Validate SDK Connection](references/1.4-validate.md) — How to verify LaunchDarkly sees the SDK
 - [Create First Feature Flag](references/1.5-first-flag.md) — How to create, evaluate, and toggle a flag
 - [Recovery Procedures](references/1.6-recover.md) — How to diagnose failures and resume
@@ -167,3 +173,7 @@ Do these as part of finishing onboarding—same session when possible. They are 
 
 - [SDK Recipes](references/sdk-recipes.md) — Detection patterns, install commands, and doc links for all SDKs
 - [SDK detail files](references/sdk-snippets/) — Per-SDK pointers (docs, samples, registries); ten files also include copy-paste onboarding samples (linked from each recipe in SDK Recipes)
+
+**Recommended after onboarding**
+
+- [LaunchDarkly Flag Create & Configure](../../feature-flags/launchdarkly-flag-create/SKILL.md) — Install or enable for ongoing flag creation that fits existing patterns (MCP required for that skill’s default workflow)

--- a/skills/setup/launchdarkly-sdk-onboarding/marketplace.json
+++ b/skills/setup/launchdarkly-sdk-onboarding/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "launchdarkly-sdk-onboarding",
+  "description": "Onboard a codebase to LaunchDarkly: detect stack, install and initialize the SDK, validate connectivity, and create a first feature flag",
+  "version": "0.1.0",
+  "author": "LaunchDarkly",
+  "repository": "https://github.com/launchdarkly/agent-skills",
+  "skills": ["./"],
+  "tags": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management",
+    "sdk",
+    "onboarding",
+    "devops",
+    "mcp"
+  ]
+}

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.0-detect.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.0-detect.md
@@ -1,0 +1,130 @@
+---
+title: Detect Repository Stack
+description: Inspect the repository to identify languages, frameworks, package managers, entrypoints, and existing SDK usage
+---
+
+# Detect Repository Stack
+
+Before installing anything, you must understand the project. This step identifies what the project is built with and whether LaunchDarkly is already present.
+
+## What to Detect
+
+Emit each `[STATUS]` line only when you start the matching phase below—not as a single upfront block.
+
+### 1. Language and Framework
+
+Emit `[STATUS] Inspecting repository structure`, then look for the indicator files below (and related root layout). After you have located the relevant manifests, emit `[STATUS] Detecting language and framework` and read them to infer language and framework.
+
+Look for these files to identify the stack:
+
+| File | Language/Framework |
+|------|--------------------|
+| `package.json` | JavaScript/TypeScript (check for React, Next.js, Vue, Angular, Express, React Native, Electron, etc.) |
+| `requirements.txt`, `pyproject.toml`, `Pipfile`, `setup.py` | Python (check for Django, Flask, FastAPI) |
+| `go.mod` | Go (check for Gin, Echo, Fiber, Chi) |
+| `pom.xml`, `build.gradle`, `build.gradle.kts` | Java/Kotlin (check for Spring, Quarkus, Android) |
+| `Gemfile` | Ruby (check for Rails, Sinatra) |
+| `*.csproj`, `*.sln`, `*.fsproj` | .NET/C# (check for ASP.NET, MAUI, Xamarin, WPF, UWP) |
+| `composer.json` | PHP (check for Laravel, Symfony) |
+| `Cargo.toml` | Rust (check for Actix, Axum, Rocket) |
+| `pubspec.yaml` | Flutter/Dart |
+| `Package.swift`, `Podfile`, `*.xcodeproj` | Swift/iOS |
+| `AndroidManifest.xml` | Android (also check `build.gradle` for `com.android`) |
+| `rebar.config`, `mix.exs` | Erlang/Elixir |
+| `CMakeLists.txt`, `Makefile` (with C/C++ patterns) | C/C++ (check for `#include` patterns) |
+| `*.cabal`, `stack.yaml` | Haskell |
+| `*.lua`, `rockspec` | Lua |
+| `manifest`, `*.brs` | Roku (BrightScript) |
+| `wrangler.toml` | Cloudflare Workers (edge SDK) |
+| `vercel.json` with edge functions | Vercel Edge (edge SDK) |
+
+Read the dependency file to identify the specific framework. For `package.json`, check both `dependencies` and `devDependencies`.
+
+**If you cannot identify the language or framework**, ask the user which SDK they want to use. Present the list of available SDKs from the [SDK Recipes](sdk-recipes.md) and let them choose.
+
+### 2. Package Manager
+
+Identify how the project installs dependencies:
+
+| Indicator | Package Manager |
+|-----------|----------------|
+| `package-lock.json` | npm |
+| `yarn.lock` | yarn |
+| `pnpm-lock.yaml` | pnpm |
+| `bun.lockb` | bun |
+| `Pipfile.lock` | pipenv |
+| `poetry.lock` | poetry |
+| `go.sum` | go modules |
+| `Gemfile.lock` | bundler |
+
+Use the detected package manager for all install commands. If multiple lock files exist, prefer the one that was most recently modified.
+
+### 3. Monorepo layout
+
+Some repositories host multiple packages or services. Look for these indicators:
+
+| File / pattern | Tool or layout |
+|----------------|----------------|
+| `pnpm-workspace.yaml` | pnpm workspaces |
+| `lerna.json` | Lerna |
+| `nx.json` | Nx |
+| `turbo.json` | Turborepo |
+| `rush.json` | Rush |
+| `packages/` directory with multiple `package.json` files | Generic monorepo |
+
+When any of these apply, **do not assume the repo root is the integration target**. Identify which package, app, or service the user wants to wire up (or ask if unclear), then run the rest of this detect step—language, package manager, entrypoint, and SDK search—**in that target directory** (and its subtree), not only at the root.
+
+### 4. Application Entrypoint
+
+Find the main file where the application starts. In a monorepo, apply the patterns below within the chosen package after [§3 Monorepo layout](#3-monorepo-layout). Common patterns:
+
+- **Node.js (server)**: Check `package.json` `"main"` field, or look for `index.js`, `server.js`, `app.js`, `src/index.ts`
+- **NestJS**: Look for `src/main.ts` or `src/main.js`
+- **Python**: Look for `app.py`, `main.py`, `manage.py`, `wsgi.py`, or the `[tool.poetry.scripts]` section
+- **Go**: Look for `main.go` or `cmd/*/main.go`
+- **Java**: Search for `public static void main` or `@SpringBootApplication`
+- **Ruby**: Look for `config.ru`, `config/application.rb`
+- **React/Vue/Angular**: Look for `src/index.tsx`, `src/main.tsx`, `src/App.tsx`, `src/main.ts`
+- **Next.js**: App Router — `app/layout.tsx` or `app/layout.js` (root layout). Pages Router — `pages/_app.tsx` or `pages/_app.js`
+- **React Native**: Look for `App.tsx`, `App.js`, `index.js` (with `AppRegistry.registerComponent`)
+- **Electron**: Check `package.json` `"main"`; common paths include `main.js` or `src/main.ts`
+- **JavaScript (browser)**: Look for `index.html`, `src/index.js`, or bundler entry in `webpack.config.js` / `vite.config.ts`
+- **Flutter**: Look for `lib/main.dart`
+- **Swift/iOS**: Look for `AppDelegate.swift`, `SceneDelegate.swift`, or `@main` struct
+- **Android**: Look for `MainActivity.java` or `MainActivity.kt`
+
+### 5. Existing LaunchDarkly SDK
+
+Emit `[STATUS] Checking for existing LaunchDarkly SDK`, then search the codebase for existing LaunchDarkly usage:
+
+```
+Search for: launchdarkly, ldclient, ld-client, LDClient, @launchdarkly, launchdarkly-
+```
+
+Check:
+- Is the SDK already in the dependency file?
+- Is there initialization code?
+- Is it properly configured or partially set up?
+- Are there already feature flag evaluations?
+
+## SDK Confirmation
+
+After detecting the stack, confirm the SDK choice with the user:
+
+- **If one SDK is clearly the right fit**: Tell the user which SDK you recommend and ask for confirmation before proceeding.
+- **If multiple SDKs could apply** (e.g., a Next.js project with both server and client components): Ask the user whether they want to integrate one or multiple SDKs, and which to start with.
+- **If you cannot determine the right SDK**: Present the available options from the [SDK Recipes](sdk-recipes.md) and ask the user to choose.
+
+## Decision Tree
+
+After detection and confirmation:
+
+- **SDK already installed and initialized** -> Skip to [Validate SDK Connection](1.4-validate.md)
+- **SDK installed but not initialized** -> Skip to [Apply Code Changes](1.2-apply.md) (just add init code)
+- **SDK not present** -> Continue to [Generate Integration Plan](1.1-plan.md)
+- **Multiple targets detected (e.g., frontend + backend)** -> Ask the user which to integrate first, then continue to [Generate Integration Plan](1.1-plan.md)
+- **Language not detected** -> Ask the user which SDK they want to use
+
+---
+
+**Upon completion, continue with:** [Generate Integration Plan](1.1-plan.md)

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.1-plan.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.1-plan.md
@@ -1,0 +1,102 @@
+---
+title: Generate Integration Plan
+description: Choose the correct SDK based on detected stack and generate a minimal integration plan
+---
+
+# Generate Integration Plan
+
+Based on what you detected in the previous step, choose the right SDK and plan the minimal set of changes needed.
+
+## Choose the Right SDK
+
+Use the [SDK Recipes](sdk-recipes.md) reference to match the detected stack to an SDK. Start with **Top 10 SDKs (start here)** in that file for common stacks; use the **(other)** sections for less common SDKs.
+
+The key decision:
+
+| Project Type | SDK Type | Key Type |
+|-------------|----------|----------|
+| Backend API, server-rendered app, CLI tool | Server-side SDK | SDK Key |
+| Browser SPA (React, Vue, Angular, vanilla JS) | Client-side SDK | Client-side ID |
+| iOS or Android native app | Mobile SDK | Mobile Key |
+| React Native, Flutter | Mobile SDK | Mobile Key |
+| Electron desktop app | Client-side SDK (Node.js) | Client-side ID |
+| Cloudflare Workers, Vercel Edge, AWS Lambda@Edge | Edge SDK | SDK Key |
+| .NET client (MAUI, Xamarin, WPF, UWP) | Client-side SDK (.NET) | Mobile Key |
+| C/C++ client application | Client-side SDK (C/C++) | Mobile Key |
+| C/C++ server application | Server-side SDK (C/C++) | SDK Key |
+| Haskell server | Server-side SDK (Haskell) | SDK Key |
+| Lua server | Server-side SDK (Lua) | SDK Key |
+| Roku (BrightScript) | Client-side SDK (Roku) | Mobile Key |
+
+For a complete list of SDKs, see:
+- Server-side: https://launchdarkly.com/docs/sdk/server-side
+- Client-side: https://launchdarkly.com/docs/sdk/client-side
+- Edge: https://launchdarkly.com/docs/sdk/edge
+
+**Important distinctions:**
+- **Next.js**: Use server-side SDK for API routes/server components, React client SDK for client components. Start with whichever matches the user's primary use case.
+- **Node.js**: If it's a backend service (Express, Fastify, etc.), use the server-side SDK. There is also a [Node.js client SDK](https://launchdarkly.com/docs/sdk/client-side/node-js) for desktop/Electron apps.
+- **React**: If it's a standalone SPA, use `launchdarkly-react-client-sdk`. If it's part of Next.js, see above.
+- **.NET**: Use the server SDK for ASP.NET/backend services. Use the client SDK for MAUI, Xamarin, WPF, or UWP apps.
+
+## Plan the Changes
+
+Your integration plan should identify exactly:
+
+### 1. Files to Modify
+
+Use the information gathered during the [Detect step](1.0-detect.md) — specifically the detected package manager, dependency file, and application entrypoint:
+
+- **Dependency file**: The file identified during detection (e.g., `package.json`, `requirements.txt`, `go.mod`) — use the detected package manager to add the SDK
+- **Entrypoint file**: The application entrypoint identified during detection — where SDK initialization code will go
+- **Environment/config file**: `.env`, `.env.example`, or equivalent (for the SDK key) — follow the project's existing configuration pattern
+
+### 2. Code Changes
+
+For each file, describe the specific change:
+
+1. **Add SDK dependency** — the install command from the SDK recipe
+2. **Add SDK import** — the import statement at the top of the entrypoint
+3. **Add SDK initialization** — the init code, placed early in the application startup
+4. **Configure the SDK key** — via environment variable, never hardcoded
+
+### 3. Environment Variable Convention
+
+Check how the project handles configuration:
+- Does it use `.env` files? Add `LAUNCHDARKLY_SDK_KEY` (or `LAUNCHDARKLY_CLIENT_SIDE_ID` for client SDKs)
+- Does it use a config module? Add the key there
+- Does it read from process.env directly? Follow that pattern
+
+If a `.env.example` or `.env.sample` exists, plan to add the variable there too (with a placeholder value).
+
+## Present the Plan
+
+Before making any changes, summarize the plan to the user:
+
+```
+Integration Plan:
+- SDK: [SDK name] ([server/client/mobile]-side)
+- Package: [package name]
+- Install: [install command]
+- Files to change:
+  1. [dependency file] — add SDK dependency
+  2. [entrypoint file] — add import and initialization
+  3. [env file] — add SDK key variable
+```
+
+Wait for user confirmation before proceeding, especially if:
+- Multiple SDKs could apply (ask which one)
+- The entrypoint is ambiguous (ask which file)
+- The project structure is unusual
+
+## Status
+
+```
+[STATUS] Selecting SDK for detected stack
+[STATUS] Identifying files to modify
+[STATUS] Generating integration plan
+```
+
+---
+
+**Upon completion, continue with:** [Apply Code Changes](1.2-apply.md)

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.2-apply.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.2-apply.md
@@ -1,0 +1,95 @@
+---
+title: Apply Code Changes
+description: Install the SDK dependency and add initialization code to the application entrypoint
+---
+
+# Apply Code Changes
+
+Now execute the integration plan. Install the SDK and add the minimal code needed to initialize it.
+
+## Step 1: Install the SDK Dependency
+
+Use the **exact** package or module name and install command from the SDK row you already matched in [SDK Recipes](sdk-recipes.md), with the project’s package manager. Do not copy a generic install line from elsewhere—each recipe names the right artifact.
+
+After installation, verify the dependency appears in the lock file or dependency manifest.
+
+## Step 2: Add the SDK Key to Environment Configuration
+
+**Never hardcode SDK keys in source code.**
+
+Add the appropriate environment variable:
+
+| SDK Type | Variable Name | Where to Get It |
+|----------|--------------|-----------------|
+| Server-side | `LAUNCHDARKLY_SDK_KEY` | LaunchDarkly > Project settings > Environments > SDK key |
+| Client-side | `LAUNCHDARKLY_CLIENT_SIDE_ID` (logical name; see below) | LaunchDarkly > Project settings > Environments > Client-side ID |
+| Mobile | `LAUNCHDARKLY_MOBILE_KEY` | LaunchDarkly > Project settings > Environments > Mobile key |
+
+**Client-side (browser) projects:** The value in LaunchDarkly is still the Client-side ID. In `.env`, use a name your bundler exposes to client code—typically the logical name with a **framework prefix**:
+
+| Stack | `.env` key | Read in code |
+|-------|------------|--------------|
+| Create React App | `REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` | `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+| Vite | `VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` | `import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+| Next.js | `NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` | `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+
+Other setups may use different prefixes or inject `LAUNCHDARKLY_CLIENT_SIDE_ID` unchanged—match whatever the project already uses for public env vars.
+
+Add to the project's environment configuration:
+
+1. If `.env` exists, add the variable there
+2. If `.env.example` or `.env.sample` exists, add a placeholder entry
+3. If the project uses a config module, add it there following existing patterns
+
+```bash
+# .env
+LAUNCHDARKLY_SDK_KEY=your-sdk-key-here
+```
+
+Tell the user they need to replace the placeholder with their actual key.
+
+## Step 3: Add SDK Initialization Code
+
+Initialization shape **depends on which SDK was chosen** during detection and planning. This file does not include copy-paste samples per SDK—using the wrong snippet (e.g. React Web when the recipe is Node server) will mislead you.
+
+**Source of truth (use in order):**
+
+1. **[SDK Recipes](sdk-recipes.md)** — the row for your SDK: install is Step 1 above; for init, follow the **SDK detail** / doc links listed there.
+2. **SDK detail files** under [`sdk-snippets/`](sdk-snippets/) (when linked from the recipe)—curated links and, for many SDKs, a full onboarding sample aligned with that SDK.
+3. **LaunchDarkly’s official docs** for that SDK (URLs from the recipe or detail file)—use their entrypoint and async patterns (e.g. React Web: [React Web SDK](https://launchdarkly.com/docs/sdk/client-side/react/react-web)).
+
+Wire credentials using Step 2: server SDKs use `LAUNCHDARKLY_SDK_KEY`; client/browser SDKs use the client-side ID with the **bundler-prefixed** env names from Step 2 where applicable.
+
+Add imports and init to the **application entrypoint** (or the target package’s entrypoint in a monorepo—see [Detect Repository Stack](1.0-detect.md)). Place initialization **early**, before code that evaluates flags.
+
+### Key Principles
+
+1. **Import at the top** of the file with other imports
+2. **Initialize early** in the application lifecycle
+3. **Wait for initialization** before evaluating flags when the SDK supports it
+4. **Handle errors** — log failures but don't crash the application
+5. **Match existing code style** — same patterns (async/await, callbacks, modules CommonJS vs ESM) as the rest of the codebase
+6. **Do not mix SDKs** — only use init patterns for the SDK you matched in `sdk-recipes.md`
+
+## Step 4: Verify the Code Compiles
+
+After making changes:
+
+1. Run the project's build or compile step
+2. Run the linter if one is configured
+3. Fix any import errors or type issues
+
+Do not proceed to the next step if the code doesn't compile.
+
+## Status
+
+```
+[STATUS] Installing SDK dependency
+[STATUS] Configuring SDK key
+[STATUS] Adding initialization code
+[STATUS] Verifying code compiles
+```
+
+---
+
+**Upon completion, continue with:** [Start the Application](1.3-run.md)

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.3-run.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.3-run.md
@@ -1,0 +1,81 @@
+---
+title: Start the Application
+description: Run the application (agent or user), confirm it is running before validation, and require explicit user confirmation when the user starts it locally; SDK connectivity is validated in the next reference
+---
+
+# Start the Application
+
+After installing the SDK and adding initialization code, verify the **application starts** (no crashes, no missing modules). **Do not** call `sdk-active` here—that belongs only in [Validate SDK Connection](1.4-validate.md) so you do not repeat the same check twice.
+
+## Step 1: Identify the Run Command
+
+Find how the project is normally started:
+
+| Indicator | Run Command |
+|-----------|-------------|
+| `package.json` `"scripts"."start"` | `npm start`, `yarn start`, `pnpm start`, or `bun run start` |
+| `package.json` `"scripts"."dev"` | `npm run dev`, `yarn dev`, `pnpm run dev` (or `pnpm dev`), or `bun run dev` |
+| `docker-compose.yml` or `compose.yaml` | `docker compose up` or `docker-compose up` (often from repo root; add `-d` if the README does) |
+| `Makefile` with `run` target | `make run` |
+| `manage.py` (Django) | `python manage.py runserver` |
+| `app.py` or `main.py` (Flask/FastAPI) | `python app.py` or `uvicorn main:app` |
+| `go.mod` | `go run .` or `go run cmd/server/main.go` |
+| `Gemfile` with Rails | `bin/rails server` |
+| `Cargo.toml` | `cargo run` |
+
+Use the same package manager the project uses for installs (npm, yarn, pnpm, or bun—see [Detect Repository Stack](1.0-detect.md)).
+
+If the project has a README with run instructions, follow those.
+
+## Step 2: Start the Application
+
+Decide **who** runs it:
+
+- **Agent runs (preferred when possible):** You execute the run command in the terminal (foreground long enough to see startup, or in the background if the project expects a long-lived process). You only need evidence the process **stayed up past initialization**—not an indefinite run.
+- **User runs:** Use this when the app needs credentials or infra you lack, a GUI, a device/simulator, VPN, corporate network, Docker Desktop only on their machine, or anything else you cannot drive reliably. Tell the user the **exact command** (and working directory if it matters).
+
+Do **not** rely on specific log messages to determine success—different SDKs log differently and some don't log at all.
+
+### What to Look For
+- The application starts without crashing
+- No import errors or module-not-found errors
+- The app is responsive (e.g., serves HTTP requests, renders UI), when you can check
+
+### Common Startup Errors
+- `Module not found` or `ImportError` — the SDK wasn't installed correctly. Re-run the install command.
+- `TypeError` or `undefined` — initialization code may have a syntax issue. Check the code against the SDK recipe.
+- Network timeout — the SDK can't reach LaunchDarkly (check firewall/proxy settings).
+- App crashes on startup — check if the SDK key environment variable is set.
+
+**Important:** The SDK may initialize silently. Do not assume failure just because you don't see a success log message. Confirm LaunchDarkly sees the SDK in [Validate SDK Connection](1.4-validate.md) using `sdk-active` (or the dashboard)—not in this step.
+
+## Step 3: Handle Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| SDK key not set | Remind the user to set the `LAUNCHDARKLY_SDK_KEY` environment variable |
+| Module not found | Re-run the install command; check the dependency file |
+| Initialization timeout | Check network connectivity; verify the SDK key is valid |
+| Type errors | Check the import statement matches the SDK version |
+| App starts but no SDK log | Verify the initialization code is actually being executed (not behind a conditional) |
+
+## Step 4: Confirm Before Validation (required)
+
+Do **not** continue to [Validate SDK Connection](1.4-validate.md) until the app is **known** to be running.
+
+- **If you started the app:** You must have observed clean startup (or a successful health check, e.g. HTTP 200 to the dev server URL). If the process exited or errored, fix that first—do not advance.
+- **If the user started the app:** **Stop and ask for explicit confirmation.** For example: *"Please run `<command>` from `<directory>` (or your usual workflow). Reply when the app is up and not crashing on startup."* Do **not** infer success from silence or from the user moving on verbally—wait until they **confirm** the app is running (or they report a specific error to fix).
+
+If the user cannot run it yet, pause the workflow here; resume after they confirm.
+
+## Status
+
+```
+[STATUS] Identifying run command
+[STATUS] Starting application
+[STATUS] Confirming application is running before validation
+```
+
+---
+
+**Upon completion, continue with:** [Validate SDK Connection](1.4-validate.md)

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.4-validate.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.4-validate.md
@@ -1,0 +1,96 @@
+---
+title: Validate SDK Connection
+description: Confirm that LaunchDarkly sees the SDK connection using ldcli, the REST API, or the dashboard
+---
+
+# Validate SDK Connection
+
+The application is running — now confirm LaunchDarkly actually sees the SDK connection. This is the critical step that proves the integration works end-to-end.
+
+**Flags are not required here.** Options A and B (`sdk-active`) answer whether the SDK has contacted LaunchDarkly, independent of [Create First Feature Flag](1.5-first-flag.md). Keep that order by default: validate connectivity, then create the first flag.
+
+## Option A: Validate via ldcli (Preferred)
+
+The `ldcli sdk-active` command is the fastest way to check if the SDK is connected:
+
+```bash
+ldcli sdk-active \
+  --access-token YOUR_ACCESS_TOKEN \
+  --project PROJECT_KEY \
+  --environment ENVIRONMENT_KEY
+```
+
+This checks the LaunchDarkly backend for recent SDK activity in the target environment.
+
+## Option B: Validate via LaunchDarkly API
+
+If `ldcli` is not available, use the REST API directly:
+
+```bash
+curl -s -X GET \
+  "https://app.launchdarkly.com/api/v2/projects/PROJECT_KEY/environments/ENVIRONMENT_KEY/sdk-active" \
+  -H "Authorization: LAUNCHDARKLY_ACCESS_TOKEN"
+```
+
+Replace:
+- `PROJECT_KEY` with the LaunchDarkly project key
+- `ENVIRONMENT_KEY` with the environment key (e.g., `test`, `production`)
+- `LAUNCHDARKLY_ACCESS_TOKEN` with your API access token as the **full** `Authorization` header value (raw token string; LaunchDarkly REST examples do not use a `Bearer` prefix)
+
+A successful response means the SDK has connected to LaunchDarkly.
+
+## Option C: Validate via Dashboard (last resort)
+
+**Prefer Options A or B.** They are definitive for “is the SDK active?” **before** any flags exist.
+
+The **Flags** page is a **poor** connectivity check during onboarding: with **no flags yet** (normal before Step 5), or before the app has **evaluated** a flag, there is often **nothing** that proves the SDK connected. An empty or quiet Flags view does **not** mean the integration failed.
+
+If the user can only use the UI:
+
+1. They can still open **Flags** to confirm they are in the right project (substitute `PROJECT_KEY`): **https://app.launchdarkly.com/projects/PROJECT_KEY/flags**
+2. For **actual** confirmation without API/CLI access, **exception path**: do the smallest slice of [Create First Feature Flag](1.5-first-flag.md) early (or use MCP flag-creation tools such as `create-feature-flag` if configured)—create a boolean flag, add one evaluation in the running app, adjust targeting if the flag is off for the current context—then look for evaluation-related signals on **that** flag in the UI (wording and placement vary by product version). Afterward, continue the rest of Step 5 as written. Use this only when `sdk-active` is unavailable; it is **not** the default workflow order.
+
+## Interpreting Results
+
+| Result | Meaning | Next Step |
+|--------|---------|-----------|
+| SDK active / connected | Integration is working | Continue to [Create First Feature Flag](1.5-first-flag.md) |
+| SDK not active | SDK hasn't connected yet | Wait 30 seconds and retry; check the SDK key is correct |
+| 401 Unauthorized | Invalid access token | Verify the API access token |
+| 404 Not Found | Invalid project or environment key | Verify the project and environment keys |
+| Network error | Can't reach LaunchDarkly API | Check internet connectivity |
+
+## Retry Logic
+
+The SDK needs to send at least one event to LaunchDarkly before it registers as active. This can take up to 60 seconds after the application starts. All `sdk-active` checks happen in **this** reference—[Start the Application](1.3-run.md) does not call the endpoint, so you will not duplicate the same request when following the workflow in order.
+
+**Retry strategy:**
+1. Wait ~15 seconds after the application is running, then run your first `sdk-active` check
+2. If not active, wait 30 seconds and check again
+3. If not active, wait 30 seconds and check once more
+4. **After 3 failed checks, stop retrying.** Do not loop indefinitely.
+
+Keep track of what you've already tried. If you've already verified the SDK key, checked the environment, and confirmed the app is running, don't repeat those checks — move to the troubleshooting section.
+
+## Troubleshooting
+
+If validation fails after 3 attempts:
+
+1. **Verify the SDK key**: Make sure you're using the right key type (SDK key for server-side, Client-side ID for client-side, Mobile key for mobile)
+2. **Verify the environment**: Make sure the SDK key matches the environment you're validating against
+3. **Check the application logs**: Look for any SDK error messages
+4. **Check network**: The SDK needs outbound HTTPS access to `events.launchdarkly.com` and `stream.launchdarkly.com`
+5. **Check if the app is actually running**: The sdk-active endpoint requires the app to be running and to have sent at least one event. If the app hasn't started or crashed, fix that first.
+
+If none of the above works, proceed to [Recovery Procedures](1.6-recover.md).
+
+## Status
+
+```
+[STATUS] Validating SDK connection
+[STATUS] Checking LaunchDarkly API for SDK activity
+```
+
+---
+
+**Upon completion, continue with:** [Create First Feature Flag](1.5-first-flag.md)

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.5-first-flag.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.5-first-flag.md
@@ -1,0 +1,229 @@
+---
+title: Create Your First Feature Flag
+description: Create a boolean feature flag, add evaluation code, and toggle it to demonstrate end-to-end functionality
+---
+
+# Create Your First Feature Flag
+
+The SDK is connected. Now help the user create their first feature flag and see it work end-to-end.
+
+**Optional — Flag Create skill already installed:** If [LaunchDarkly Flag Create & Configure](../../../feature-flags/launchdarkly-flag-create/SKILL.md) is available in the session, you may use it for **creating the flag** and **choosing evaluation code** that matches the repo. You must still complete **default off → verify OFF → toggle on → verify ON** (Steps 3–5 below). **Do not** require that skill: this page stays the full fallback when it is missing or MCP-only flows conflict with the user’s setup.
+
+## Step 1: Create the Flag
+
+**REST / curl auth:** Replace `LAUNCHDARKLY_ACCESS_TOKEN` with your LaunchDarkly API access token. Use that string as the **entire** `Authorization` header value (LaunchDarkly’s REST examples use the raw token; do not substitute the placeholder literally).
+
+### Via MCP (Preferred)
+
+If the LaunchDarkly MCP server is available, use `create-feature-flag` (or the equivalent flag-creation tool your server exposes):
+
+- **Key**: `my-first-flag` (or a name relevant to the user's project)
+- **Name**: "My First Flag"
+- **Kind**: `boolean`
+- **Variations**: `true` / `false`
+- **Temporary**: `true`
+
+### Via LaunchDarkly API
+
+```bash
+curl -s -X POST \
+  "https://app.launchdarkly.com/api/v2/flags/PROJECT_KEY" \
+  -H "Authorization: LAUNCHDARKLY_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My First Flag",
+    "key": "my-first-flag",
+    "kind": "boolean",
+    "variations": [
+      {"value": true},
+      {"value": false}
+    ],
+    "temporary": true
+  }'
+```
+
+### Via ldcli
+
+```bash
+ldcli flags create \
+  --access-token YOUR_ACCESS_TOKEN \
+  --project PROJECT_KEY \
+  --data '{"name": "My First Flag", "key": "my-first-flag", "kind": "boolean", "temporary": true}'
+```
+
+After creation, the flag starts with **targeting OFF**, serving the off variation (`false`) to everyone.
+
+## Step 2: Add Flag Evaluation Code
+
+Add code to evaluate the flag in the application. Place this where it makes sense for the user's feature.
+
+### Server-Side Examples
+
+```javascript
+// Node.js (@launchdarkly/node-server-sdk) — ldClient is your initialized server client after waitForInitialization
+const context = { kind: 'user', key: 'example-user-key', name: 'Example User' };
+const showFeature = await ldClient.boolVariation('my-first-flag', context, false);
+
+if (showFeature) {
+  console.log('Feature is ON');
+} else {
+  console.log('Feature is OFF');
+}
+```
+
+```python
+# Python (launchdarkly-server-sdk) — client is ldclient.get() after set_config
+from ldclient import Context
+
+context = Context.builder("example-user-key").name("Example User").build()
+show_feature = client.variation("my-first-flag", context, False)
+
+if show_feature:
+    print("Feature is ON")
+else:
+    print("Feature is OFF")
+```
+
+```go
+// Go
+context := ldcontext.NewBuilder("example-user-key").Name("Example User").Build()
+showFeature, _ := ldClient.BoolVariation("my-first-flag", context, false)
+
+if showFeature {
+    fmt.Println("Feature is ON")
+} else {
+    fmt.Println("Feature is OFF")
+}
+```
+
+### Client-Side Examples
+
+```tsx
+// React
+import { useFlags } from 'launchdarkly-react-client-sdk';
+
+function MyComponent() {
+  const { myFirstFlag } = useFlags();
+
+  return (
+    <div>
+      {myFirstFlag ? <p>Feature is ON</p> : <p>Feature is OFF</p>}
+    </div>
+  );
+}
+```
+
+**Note**: Client-side React SDK camelCases flag keys, so `my-first-flag` becomes `myFirstFlag`.
+
+## Step 3: Verify the Default Value
+
+With targeting OFF, the flag should evaluate to `false`. Run the application and confirm:
+
+```
+Feature is OFF
+```
+
+## Step 4: Toggle the Flag On
+
+### Via MCP
+
+The LaunchDarkly MCP server exposes **`update-feature-flag`** (JSON Patch), not a tool named `toggle-flag`—use the tool names your MCP server lists.
+
+**Simplest path:** Prefer **ldcli** or the **LaunchDarkly API** block below when you only need to turn the flag on once.
+
+**If using `update-feature-flag`:** Call it with `projectKey`, `featureFlagKey`, and `PatchWithComment.patch` as a JSON Patch array. Turning the flag **on** for an environment typically uses a `replace` operation on that environment’s `on` field (confirm the exact path from `get-feature-flag` for your account if needed):
+
+```json
+{
+  "projectKey": "PROJECT_KEY",
+  "featureFlagKey": "my-first-flag",
+  "PatchWithComment": {
+    "patch": [
+      {
+        "op": "replace",
+        "path": "/environments/ENVIRONMENT_KEY/on",
+        "value": true
+      }
+    ],
+    "comment": "Onboarding: turn on my-first-flag"
+  }
+}
+```
+
+Replace `ENVIRONMENT_KEY` with the same environment key you used for `sdk-active` (e.g. `test`, `production`).
+
+### Via LaunchDarkly API
+
+```bash
+curl -s -X PATCH \
+  "https://app.launchdarkly.com/api/v2/flags/PROJECT_KEY/my-first-flag" \
+  -H "Authorization: LAUNCHDARKLY_ACCESS_TOKEN" \
+  -H "Content-Type: application/json; domain-model=launchdarkly.semanticpatch" \
+  -d '{
+    "environmentKey": "ENVIRONMENT_KEY",
+    "instructions": [
+      {"kind": "turnFlagOn"}
+    ]
+  }'
+```
+
+### Via ldcli
+
+```bash
+ldcli flags toggle-on \
+  --access-token YOUR_ACCESS_TOKEN \
+  --project PROJECT_KEY \
+  --environment ENVIRONMENT_KEY \
+  --flag my-first-flag
+```
+
+## Step 5: Verify the Toggle
+
+After toggling the flag on, the application should now show:
+
+```
+Feature is ON
+```
+
+For server-side SDKs using streaming (the default), the change should be reflected within seconds. For client-side SDKs, the change appears on the next page load or when the SDK polls for updates.
+
+## Congratulations
+
+The user has successfully:
+1. Installed the LaunchDarkly SDK
+2. Connected it to LaunchDarkly
+3. Created a feature flag
+4. Evaluated it in code
+5. Toggled it and seen the result
+
+**Encourage the next skill:** Suggest they **install or enable** the companion [LaunchDarkly Flag Create & Configure](../../../feature-flags/launchdarkly-flag-create/SKILL.md) skill in Cursor (or their agent’s skill marketplace) so future work—creating flags that match repo conventions, wrapping features, and verifying wiring—has a dedicated playbook. Offer to help them add it if they are unsure how.
+
+## Error Handling
+
+If any step returns an authorization error (401 or 403):
+
+1. **Check if the user is logged in**: The access token may be expired or invalid.
+2. **Prompt the user to log in**: Direct them to `ldcli login` or https://app.launchdarkly.com to sign in.
+3. **If the user doesn't have an account**: Prompt them to sign up at https://launchdarkly.com.
+4. **If the project or environment doesn't exist**: Guide the user to create one via the dashboard or `ldcli`.
+
+Do not retry authorization errors automatically — they require user action.
+
+**Next steps to suggest:**
+- **Install** [LaunchDarkly Flag Create & Configure](../../../feature-flags/launchdarkly-flag-create/SKILL.md) if it is not already available—this onboarding flow only covers a first boolean flag; that skill guides real-world flag creation aligned with existing code patterns (requires LaunchDarkly MCP per that skill’s prerequisites).
+- Use the [flag targeting skill](../../../feature-flags/launchdarkly-flag-targeting/SKILL.md) to set up percentage rollouts and targeting rules
+- Read the [LaunchDarkly docs](https://docs.launchdarkly.com) for advanced topics like contexts, experimentation, and metrics
+
+## Status
+
+```
+[STATUS] Creating feature flag
+[STATUS] Adding flag evaluation code
+[STATUS] Verifying flag evaluates to default
+[STATUS] Toggling flag on
+[STATUS] Verifying flag toggle works
+```
+
+---
+
+**Upon completion, continue with:** [MCP Server Setup](1.7-mcp-setup.md), then [Onboarding Summary](1.8-summary.md) and [Editor Rules and Skills](1.9-editor-rules.md) (default follow-through in the SDK Onboarding skill). Use [Recovery Procedures](1.6-recover.md) if you need to diagnose a failure.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.6-recover.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.6-recover.md
@@ -1,0 +1,137 @@
+---
+title: Recovery Procedures
+description: Diagnose failures and resume the onboarding workflow with ranked recovery options
+---
+
+# Recovery Procedures
+
+When any step in the onboarding workflow fails, use this guide to diagnose the issue and get back on track.
+
+## Step 1: Identify the Failure
+
+Note which step failed and the specific error:
+
+| Failed Step | Common Errors |
+|-------------|---------------|
+| Detect | Unable to identify language or framework |
+| Plan | Multiple SDKs could apply; ambiguous stack |
+| Apply | Install command failed; import errors; code doesn't compile |
+| Run | Application won't start; SDK initialization error |
+| Validate | SDK not showing as active; API errors |
+| First Flag | Flag creation failed; evaluation returns unexpected value |
+
+## Step 2: Choose a Recovery Action
+
+Recovery options are listed in priority order. Start with option 1 and work down.
+
+### Option 1: Retry Current Step
+
+Re-attempt the failed step after reviewing the error output. Many issues are transient (network timeouts, temporary API errors) or are fixed by correcting a small mistake.
+
+### Option 2: Verify Credentials
+
+Confirm the LaunchDarkly access token and SDK key are valid:
+
+```bash
+# Test API access
+curl -s -X GET \
+  "https://app.launchdarkly.com/api/v2/projects" \
+  -H "Authorization: YOUR_ACCESS_TOKEN"
+```
+
+Or via ldcli:
+```bash
+ldcli environments list --project PROJECT_KEY --access-token YOUR_ACCESS_TOKEN
+```
+
+If this fails with 401, the token is invalid or expired. Ask the user to provide a valid token.
+
+### Option 3: Check Network Connectivity
+
+The SDK needs outbound HTTPS access to:
+- `app.launchdarkly.com` (API)
+- `stream.launchdarkly.com` (streaming)
+- `events.launchdarkly.com` (events)
+
+Test connectivity:
+```bash
+curl -s -o /dev/null -w "%{http_code}" https://app.launchdarkly.com/api/v2
+```
+
+If the network is blocked, advise the user to check firewall rules and proxy settings.
+
+### Option 4: Manual SDK Install
+
+If automatic dependency installation fails, provide the user with copy/paste instructions:
+
+1. Show the exact package name and version from the [SDK Recipes](sdk-recipes.md)
+2. Provide the manual install command
+3. Ask the user to run it themselves and confirm completion
+
+### Option 5: Try Alternative SDK
+
+If the detected SDK was wrong:
+
+1. Ask the user what language/framework they're targeting
+2. Let them manually select from the [SDK Recipes](sdk-recipes.md)
+3. Restart from the Plan step with the correct SDK
+
+### Option 6: Skip to Next Step
+
+If the failure is non-critical, skip ahead:
+
+- **Can't auto-run the app?** Ask the user to start it manually, then continue to [Validate SDK Connection](1.4-validate.md)
+- **Can't validate via API / ldcli?** Do **not** treat an empty or quiet **Flags** page as proof the SDK connected—see the **exception path** in [Validate SDK Connection](1.4-validate.md) (minimal flag + evaluation in the running app, or dashboard signals on that flag). You may still open `https://app.launchdarkly.com/projects/PROJECT_KEY/flags` (substitute the real project key) to confirm project context.
+- **Can't create a flag programmatically?** Walk the user through creating it in the dashboard at the same URL pattern (replace `PROJECT_KEY`)
+
+### Option 7: Abort Onboarding
+
+If the issue can't be resolved:
+
+1. Summarize what was accomplished (which steps succeeded)
+2. Provide links for manual setup:
+   - [LaunchDarkly SDK documentation](https://docs.launchdarkly.com/sdk)
+   - [LaunchDarkly getting started guide](https://docs.launchdarkly.com/home/getting-started)
+3. Suggest the user reach out to LaunchDarkly support
+
+## Step 3: Resume After Recovery
+
+Once the issue is resolved, **resume from the onboarding step that failed**—do not restart the whole workflow unless the fix invalidated earlier work (for example, you chose a different SDK and must re-plan).
+
+Map the failure to the reference you should re-enter:
+
+| Failed step (from Step 1) | Resume here |
+|---------------------------|---------------|
+| Detect | [Detect Repository Stack](1.0-detect.md) |
+| Plan | [Generate Integration Plan](1.1-plan.md) |
+| Apply | [Apply Code Changes](1.2-apply.md) |
+| Run | [Start the Application](1.3-run.md) |
+| Validate | [Validate SDK Connection](1.4-validate.md) |
+| First Flag | [Create First Feature Flag](1.5-first-flag.md) |
+
+If you skipped ahead under Option 6, resume at the **next** step you had not successfully completed yet (for example, after manual app start, pick up at [Validate SDK Connection](1.4-validate.md)).
+
+## Automatic Escalation
+
+If the same step fails **3 times**, automatically suggest:
+- Skipping the step (if non-critical)
+- Aborting and providing manual instructions
+- Asking the user for help with the specific error
+
+## Status
+
+Emit `[STATUS]` lines with **real** step names and option choices from this page—do not print bracketed placeholders literally. Examples:
+
+```
+[STATUS] Diagnosing failure in step: Validate
+[STATUS] Attempting recovery: Option 2 — verify credentials
+[STATUS] Resuming workflow from step: Validate
+```
+
+Another example:
+
+```
+[STATUS] Diagnosing failure in step: Apply
+[STATUS] Attempting recovery: Option 1 — retry current step
+[STATUS] Resuming workflow from step: Apply
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.7-mcp-setup.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.7-mcp-setup.md
@@ -1,0 +1,152 @@
+---
+title: MCP Server Setup
+description: Guide the user through installing and configuring the LaunchDarkly MCP server for enhanced agent workflows
+---
+
+# MCP Server Setup
+
+After the SDK is integrated and the first flag is working, offer to set up the LaunchDarkly MCP server. This enables richer agent-driven workflows like flag management, targeting, and experimentation directly from the editor.
+
+## Step 1: Check if MCP Server is Already Installed
+
+Look for `@launchdarkly/mcp-server` in the user's MCP configuration:
+
+- **Claude Code (CLI / Anthropic)**: Check **project** `.mcp.json` in the repo root, or **user** `~/.claude/settings.json` (and team overrides under `.claude/` if present). This skill often runs in Claude Code—treat these as first-class locations alongside Cursor.
+- **Cursor**: Check `.cursor/mcp.json` or the Cursor settings UI
+- **VS Code / Copilot**: Check `.vscode/mcp.json` or the MCP settings
+- **Claude Desktop**: Check `claude_desktop_config.json`
+- **Other agents**: Check the agent's MCP server configuration
+
+If already installed, skip this step and congratulate the user — they're all set.
+
+## Step 2: Ask the User
+
+If the MCP server is not installed, ask:
+
+> "Would you like to install the LaunchDarkly MCP server? It lets your AI agent create and manage feature flags, set up targeting rules, and more — all without leaving your editor."
+
+If the user declines, skip to the end. The SDK integration is complete without it.
+
+## Step 3: Install the MCP Server
+
+### For Claude Code (CLI)
+
+Prefer **project-local** config so the team shares the same server definition (commit `.mcp.json` without secrets—use env vars for tokens).
+
+**Option A — project:** create or merge into **`.mcp.json`** at the repository root:
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "${LAUNCHDARKLY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Set `LAUNCHDARKLY_ACCESS_TOKEN` in the shell environment (or replace the `${...}` reference with your preferred secret mechanism per [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp)).
+
+**Option B — user-wide:** add the same `mcpServers.launchdarkly` entry under **`~/.claude/settings.json`** if the user wants LaunchDarkly MCP in every project. Shape matches the `mcpServers` object above (follow current Claude Code settings schema for your version).
+
+After editing, restart the Claude Code session or reload MCP so the server is picked up.
+
+### For Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### For Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### For VS Code / Copilot
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_ACCESS_TOKEN` with the user's LaunchDarkly API access token. If they already used one during the onboarding flow, suggest reusing it.
+
+## Step 4: Verify the MCP Server
+
+After configuring:
+
+1. Restart the editor or reload MCP configuration (Claude Code: new session / MCP reload per product docs).
+2. **If you have MCP tool access:** invoke the LaunchDarkly tool **`list-feature-flags`** with the user’s **`projectKey`** (same LaunchDarkly project key used during onboarding), e.g. `request: { "projectKey": "YOUR_PROJECT_KEY" }`. A normal response (flag list or empty list) confirms the server and token work.
+3. **If MCP is not visible to you yet:** have the user run **`ldcli`** (or curl the REST API) as an independent check, for example:
+   ```bash
+   ldcli flags list --project YOUR_PROJECT_KEY --access-token YOUR_ACCESS_TOKEN
+   ```
+   That validates credentials and network; it does not prove MCP wiring, but it rules out bad tokens while the user restarts Claude Code.
+4. If step 2 succeeds, MCP setup is complete.
+
+## What the MCP Server Enables
+
+With the MCP server installed, agents can:
+
+- Create and manage feature flags
+- Configure targeting rules and percentage rollouts
+- Toggle flags on/off across environments
+- View flag status and evaluation insights
+- Manage AI configs and experiments
+
+## Status
+
+```
+[STATUS] Checking for existing MCP server installation
+[STATUS] Offering MCP server setup
+[STATUS] Configuring MCP server
+[STATUS] Verifying MCP server connection
+```
+
+---
+
+**Onboarding complete!** The user now has:
+1. A LaunchDarkly SDK integrated into their project
+2. A working feature flag they can toggle
+3. (Optionally) The MCP server for ongoing flag management

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.8-summary.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.8-summary.md
@@ -1,0 +1,148 @@
+---
+title: Onboarding Summary
+description: Generate a setup summary document the user can reference, with links to documentation and suggested next steps
+---
+
+# Onboarding Summary
+
+After completing the onboarding flow, leave behind a summary document in the user's repository so they (and their team) have a reference for how LaunchDarkly was set up and what to do next.
+
+## Step 1: Generate the Summary Document
+
+Create a file called `LAUNCHDARKLY.md` (or `docs/LAUNCHDARKLY.md` if the project has a `docs/` directory) in the user's repository with the following sections. Fill in the details based on what was done during onboarding. Collect the LaunchDarkly **project key** and **environment key** (`{PROJECT_KEY}` / `{ENV_KEY}`) from the same place you used for validation (`sdk-active`, dashboard URLs, or **Project settings → Environments**) if they were not written into the plan explicitly.
+
+### Template
+
+The wrapper below uses `~~~markdown` so a nested ` ```json ` block inside the template does not break Markdown rendering. (The generated `LAUNCHDARKLY.md` file itself may use normal ` ``` ` fences.)
+
+~~~markdown
+# LaunchDarkly Setup
+
+This project uses [LaunchDarkly](https://launchdarkly.com) for feature flag management.
+
+## SDK Details
+
+- **SDK**: {SDK_NAME} ({SDK_PACKAGE})
+- **SDK Type**: {server-side | client-side | mobile | edge}
+- **Key Type**: {SDK Key | Client-side ID | Mobile Key}
+- **Installed via**: {INSTALL_COMMAND}
+- **Initialization file**: {ENTRYPOINT_FILE}
+
+## Configuration
+
+The SDK key is configured via the `{ENV_VAR_NAME}` environment variable.
+
+- **Do not hardcode** the SDK key in source code.
+- Add the key to your `.env` file locally (already in `.gitignore`).
+- For production, set it in your deployment environment (e.g., CI/CD secrets, container env vars, cloud config).
+
+## Where to Find Things
+
+| What | Where |
+|------|-------|
+| Feature flags dashboard | https://app.launchdarkly.com/projects/{PROJECT_KEY}/flags |
+| Project settings | https://app.launchdarkly.com/settings/projects/{PROJECT_KEY} |
+| Environments | https://app.launchdarkly.com/settings/projects/{PROJECT_KEY}/environments |
+| API access tokens | https://app.launchdarkly.com/settings/authorization |
+| SDK documentation | {SDK_DOCS_URL} |
+| LaunchDarkly docs | https://launchdarkly.com/docs |
+
+## How Feature Flags Work in This Project
+
+1. Flags are evaluated using the LaunchDarkly SDK in `{ENTRYPOINT_FILE}`
+2. Flag values are fetched from LaunchDarkly based on the evaluation context (user/device/org)
+3. Changes to flags in the dashboard take effect immediately (server-side SDKs use streaming by default)
+
+### Example: Evaluating a Flag
+
+{INSERT_LANGUAGE_SPECIFIC_EXAMPLE}
+
+## Next Steps
+
+Here are some things you can do now that LaunchDarkly is set up:
+
+### Feature Flag Best Practices
+- **Use flags for every new feature**: Wrap new features in flags so you can release and roll back independently of deployments.
+- **Clean up temporary flags**: Mark flags as temporary during creation and archive them when no longer needed.
+- **Use descriptive flag keys**: e.g., `enable-checkout-v2` instead of `flag-1`.
+
+### Advanced Capabilities
+- **[Percentage Rollouts](https://launchdarkly.com/docs/home/targeting-flags/rollouts)** — Gradually roll out features to a percentage of users.
+- **[Targeting Rules](https://launchdarkly.com/docs/home/targeting-flags/targeting-rules)** — Target specific users, segments, or contexts.
+- **[Experimentation](https://launchdarkly.com/docs/home/about-experimentation)** — Run A/B tests and measure the impact of flag variations.
+- **[AI Configs](https://launchdarkly.com/docs/home/ai-configs)** — Manage AI model configurations and prompts with feature flags.
+- **[Guarded Rollouts](https://launchdarkly.com/docs/home/guarded-rollouts)** — Automatically roll back flag changes based on metric guardrails.
+- **[Observability](https://launchdarkly.com/docs/home/observability)** — Monitor flag evaluations and SDK performance with built-in telemetry.
+
+### AI Agent Integration (MCP Server)
+
+Install the [LaunchDarkly MCP server](https://github.com/launchdarkly/mcp-server) to let your AI agent manage feature flags directly from your editor. With it, your agent can:
+
+- **Create and manage flags** — Ask your agent to create a new feature flag, and it will handle the API calls for you.
+- **Toggle flags on/off** — Turn features on or off across environments without leaving your editor.
+- **Set up targeting rules** — Configure percentage rollouts, user targeting, and segment-based rules through natural language.
+- **Clean up stale flags** — Ask your agent to find temporary flags that are fully rolled out and ready to archive.
+- **Run experiments** — Set up A/B tests and monitor results through your agent.
+- **Manage AI configs** — Update model configurations and prompts managed by LaunchDarkly.
+
+To install, add to your editor's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+See the [MCP server docs](https://github.com/launchdarkly/mcp-server) for editor-specific setup instructions.
+
+### Useful CLI Commands
+
+If you have `ldcli` installed:
+
+| Command | Description |
+|---------|-------------|
+| `ldcli flags list --project {PROJECT_KEY}` | List all feature flags |
+| `ldcli flags toggle-on --project {PROJECT_KEY} --environment {ENV_KEY} --flag FLAG_KEY` | Turn a flag on |
+| `ldcli flags create --project {PROJECT_KEY} --data '{"name": "My Flag", "key": "my-flag", "kind": "boolean"}'` | Create a new flag |
+| `ldcli sdk-active --project {PROJECT_KEY} --environment {ENV_KEY}` | Check if the SDK is connected |
+~~~
+
+## Step 2: Fill in the Template
+
+Replace all `{PLACEHOLDER}` values with the actual values from the onboarding session (gather any you did not write down earlier from **Project settings → Environments** in LaunchDarkly or from the same keys used with `ldcli` / `sdk-active` during validation):
+
+- `{SDK_NAME}`: The human-readable SDK name (e.g., "Node.js Server SDK")
+- `{SDK_PACKAGE}`: The package name (e.g., `@launchdarkly/node-server-sdk`)
+- `{INSTALL_COMMAND}`: The install command used (e.g., `npm install @launchdarkly/node-server-sdk`)
+- `{ENTRYPOINT_FILE}`: The file where initialization code was added
+- `{ENV_VAR_NAME}`: The environment variable name used for the SDK key (or client-side ID env name)
+- `{PROJECT_KEY}`: The LaunchDarkly **project** key (URL segment and `ldcli --project`)
+- `{ENV_KEY}`: The LaunchDarkly **environment** key for the environment whose SDK key / client-side ID you used (e.g., `production`, `test`, `development`)—required for `ldcli` commands that take `--environment` and for the dashboard links that are scoped per environment where applicable
+- `{SDK_DOCS_URL}`: Link to the specific SDK documentation
+- `{INSERT_LANGUAGE_SPECIFIC_EXAMPLE}`: A short code snippet showing flag evaluation in the project's language
+
+## Step 3: Commit the Summary
+
+Add the file to version control so the whole team can reference it:
+
+```bash
+git add LAUNCHDARKLY.md
+git commit -m "docs: add LaunchDarkly setup reference"
+```
+
+Ask the user for permission before committing. If they prefer not to commit it, that's fine — they still have the file locally.
+
+## Status
+
+```
+[STATUS] Generating onboarding summary document
+[STATUS] Writing LAUNCHDARKLY.md
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/1.9-editor-rules.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/1.9-editor-rules.md
@@ -1,0 +1,188 @@
+---
+title: Editor Rules and Skills
+description: Leave behind editor-specific rules that point agents at LaunchDarkly agent skills (not doc URLs) for ongoing feature flag work
+---
+
+# Editor Rules and Skills
+
+After onboarding, do two things:
+
+1. **Ensure the user has the relevant LaunchDarkly agent skills installed** — The goal is not “a plugin” in the abstract: the user (or agent) should have the **same skills this repository ships**, so future sessions can load them by `name`. **Standard set (install all four):**
+   - `launchdarkly-flag-create`
+   - `launchdarkly-flag-discovery`
+   - `launchdarkly-flag-targeting`
+   - `launchdarkly-flag-cleanup`  
+   **Optional:** `launchdarkly-sdk-onboarding` (for more SDK onboarding later).  
+   **Preferred:** Install the **LaunchDarkly** plugin **`launchdarkly@launchdarkly-agent-skills`** from **[github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills)**, which packages these skills—then confirm in the UI or CLI that those skill names are available.
+   - **Claude Code:** After any required marketplace setup for that repo (see the repository README or `claude plugin` / Anthropic docs for your CLI version), install with:
+     ```bash
+     claude plugin install launchdarkly@launchdarkly-agent-skills
+     ```
+     If the command name or flags differ in your build, use `claude plugin --help` and match the plugin coordinate above. **Verify** the four standard skills (above) show up as usable after install.
+   - **Cursor:** Install or enable skills from the same distribution per current Cursor docs (marketplace / plugin UI pointing at this repo or copied folders). **Verify** the four `launchdarkly-flag-*` skills are listed or discoverable.
+   - **Fallback (no plugin):** Copy or symlink the **directories** from this repo into the user’s skills location so each folder contains a `SKILL.md`:
+     - `skills/feature-flags/launchdarkly-flag-create/`
+     - `skills/feature-flags/launchdarkly-flag-discovery/`
+     - `skills/feature-flags/launchdarkly-flag-targeting/`
+     - `skills/feature-flags/launchdarkly-flag-cleanup/`
+     - Optional: `skills/setup/launchdarkly-sdk-onboarding/`  
+     List any copied paths in the rules file so agents know where to read `SKILL.md`.
+2. **Write an editor rule** — The rule must tell *future* agents to **read and follow** those skills for flag work. Do **not** bake in SDK documentation URLs; procedures and compatibility live in each skill’s `SKILL.md`. Deep links to SDK docs belong in `LAUNCHDARKLY.md` if you already created that summary.
+
+## Default skill set (feature flags)
+
+Unless the user opts out, treat **all** of these as the standard kit and mention each one in the generated rule. They correspond to [`skills/feature-flags/`](../../../feature-flags/) in this repo (same four skills as in step 1 above):
+
+| Skill `name` (frontmatter) | Purpose |
+|----------------------------|---------|
+| `launchdarkly-flag-create` | Create and configure flags and wire evaluation to match the codebase (MCP when required). |
+| `launchdarkly-flag-discovery` | Audit flag inventory, stale or launched flags, and removal readiness. |
+| `launchdarkly-flag-targeting` | Toggle flags, percentage rollouts, targeting rules, and promote config between environments. |
+| `launchdarkly-flag-cleanup` | Safely remove flags from code, readiness checks, and MCP-driven cleanup workflows. |
+
+Optional skill if the user will onboard more services or re-run SDK setup later: `launchdarkly-sdk-onboarding` ([`skills/setup/launchdarkly-sdk-onboarding/`](..)).
+
+Adjust the table only if the user explicitly wants a smaller set.
+
+## Step 1: Detect the Editor
+
+Check for editor configuration files in the project root:
+
+| File/Directory | Editor |
+|----------------|--------|
+| `.cursor/` or `.cursorrules` | Cursor |
+| `.claude/` | Claude Code (Anthropic) |
+| `.github/copilot-instructions.md` | GitHub Copilot |
+| `.vscode/` (without Cursor indicators) | VS Code |
+| `.idea/` | JetBrains IDE — use [For JetBrains](#for-jetbrains-intellij-webstorm-rider-etc) (no dedicated template file path here) |
+
+If you can't detect the editor, default to Claude Code and create `.claude/rules/launchdarkly.md`.
+
+## Step 2: Create the Rules File
+
+Base the file on the templates below. **Substitute project facts** (`{SDK_NAME}`, `{ENTRYPOINT_FILE}`, `{ENV_VAR_NAME}`) from onboarding. **Do not** add `{SDK_DOCS_URL}` or a documentation links section to this file—that is intentionally omitted so agents rely on skills + MCP.
+
+The rule text must explicitly say: *when doing flag create, targeting, discovery, cleanup, or code removal, load the matching LaunchDarkly skill and execute its workflow* (not just “see links”).
+
+### Shared body (use in Cursor and Claude Code)
+
+Use this markdown block inside each template (Cursor: below the YAML frontmatter; Claude Code: from the first `#` heading).
+
+```markdown
+# LaunchDarkly Feature Flags
+
+This project uses LaunchDarkly for feature flag management.
+
+## SDK context (this repo)
+- SDK: {SDK_NAME}
+- Initialization: {ENTRYPOINT_FILE}
+- Key env var: {ENV_VAR_NAME} (never hardcode secrets in source)
+
+## Agent: use LaunchDarkly skills (required)
+
+Ensure the **LaunchDarkly** agent skills below are installed (`launchdarkly@launchdarkly-agent-skills` plugin from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills), or equivalent copies on disk). For any substantive flag work, **open that skill’s `SKILL.md` and follow it**—do not improvise from generic flag advice alone.
+
+| Skill | When to use it |
+|-------|------------------|
+| `launchdarkly-flag-create` | User wants a new flag, code wiring, feature toggle, or experiment setup. |
+| `launchdarkly-flag-discovery` | User wants flag inventory, debt/stale-flag audit, health, or removal readiness. |
+| `launchdarkly-flag-targeting` | User wants who sees a flag, rollouts, targeting rules, or environment promotion. |
+| `launchdarkly-flag-cleanup` | User wants a flag removed from code safely, archive/cleanup workflows, or MCP-driven removal. |
+
+**Invocation:** Match the user’s request to the skill `description` in each skill’s frontmatter, or use the editor’s slash / plugin command for that skill if configured.
+
+**Tools:** When a skill lists LaunchDarkly MCP tools as required, use MCP; do not skip validation steps.
+
+## Conventions (summary)
+- Prefer boolean flags unless multivariate is required; use descriptive kebab-case keys (e.g. `enable-checkout-v2`).
+- Always pass a fallback when evaluating flags; use a meaningful evaluation context (user key, org, etc.).
+- Server-side SDK keys stay secret; client-side IDs may appear in browser code.
+- Do not evaluate flags in tight loops without caching.
+- Archive or remove flag code when a flag is fully rolled out and the team agrees—use `launchdarkly-flag-cleanup` (and `launchdarkly-flag-discovery` first if assessing candidates).
+```
+
+### For Cursor (`.cursor/rules/launchdarkly.mdc`)
+
+Create `.cursor/rules/launchdarkly.mdc`:
+
+```markdown
+---
+description: LaunchDarkly feature flags — require LaunchDarkly agent skills for flag workflows
+globs: []
+alwaysApply: false
+---
+
+{PASTE_SHARED_BODY_HERE}
+```
+
+Replace `{PASTE_SHARED_BODY_HERE}` with the [shared body](#shared-body-use-in-cursor-and-claude-code) (no literal placeholder left in the file).
+
+### For Claude Code (`.claude/rules/launchdarkly.md`)
+
+Create `.claude/rules/launchdarkly.md` containing **only** the [shared body](#shared-body-use-in-cursor-and-claude-code) (no YAML frontmatter).
+
+### For GitHub Copilot (`.github/copilot-instructions.md`)
+
+Append to `.github/copilot-instructions.md` (create if it doesn't exist). Copilot may not load external skills the same way; still steer toward the same workflows and name the skills:
+
+```markdown
+## LaunchDarkly Feature Flags
+
+This project uses LaunchDarkly ({SDK_NAME}) for feature flag management.
+Initialization: {ENTRYPOINT_FILE}. SDK key / client ID: environment variable `{ENV_VAR_NAME}` only—never commit secrets.
+
+For flag work, follow the LaunchDarkly agent skills when available: **`launchdarkly-flag-create`** (create + code), **`launchdarkly-flag-discovery`** (audit / inventory), **`launchdarkly-flag-targeting`** (rollouts / targeting / env promotion), **`launchdarkly-flag-cleanup`** (code removal / cleanup / MCP workflows). Read each skill’s instructions instead of guessing flag lifecycle steps.
+```
+
+### For JetBrains (IntelliJ, WebStorm, Rider, etc.)
+
+There is **no** JetBrains-specific rules template in this reference (`.idea/` only indicates the IDE family). **Do not silently skip:** tell the user you detected JetBrains and that they should rely on **`LAUNCHDARKLY.md`** ([Onboarding Summary](1.8-summary.md)) plus installing **`launchdarkly@launchdarkly-agent-skills`** (same as Claude Code) or copying skill folders manually.
+
+Reasonable options to suggest:
+
+- Keep flag workflow guidance in **`LAUNCHDARKLY.md`** and team docs the IDE already opens.
+- If the team also uses GitHub Copilot in the same repo, reuse the **For GitHub Copilot** template above in `.github/copilot-instructions.md` so any tool that reads that file picks up the same guidance.
+- If their JetBrains AI plugin supports a **project-level instruction file**, paste the [shared body](#shared-body-use-in-cursor-and-claude-code) there (adapt paths to your product’s docs)—this doc does not name a single standard path for all JetBrains products.
+
+### For other editors (not Cursor, Claude Code, Copilot, VS Code, or JetBrains)
+
+If the editor doesn't have a rules system, skip creating a rules file. Rely on `LAUNCHDARKLY.md` and tell the user which LaunchDarkly skills to install (`launchdarkly@launchdarkly-agent-skills` or copied `skills/feature-flags/` folders).
+
+## Step 3: Fill in the Placeholders
+
+From the onboarding session, set:
+
+- `{SDK_NAME}` — e.g. `Node.js Server SDK`
+- `{ENTRYPOINT_FILE}` — e.g. `src/index.ts`
+- `{ENV_VAR_NAME}` — e.g. `LAUNCHDARKLY_SDK_KEY`
+
+**Do not** add documentation URLs to this rules file. If you need SDK doc links for humans, put them only in `LAUNCHDARKLY.md` ([Onboarding Summary](1.8-summary.md)).
+
+If you added or removed skills from the default table (user request), update the skill table in the shared body to match.
+
+## Step 4: Commit the Rules
+
+```bash
+# Claude Code (most common for this skill)
+git add .claude/rules/launchdarkly.md
+
+# Cursor
+git add .cursor/rules/launchdarkly.mdc
+
+# GitHub Copilot / shared instructions
+git add .github/copilot-instructions.md
+
+# Add only the file(s) you created or changed, then:
+git commit -m "chore: add LaunchDarkly feature flag management rules"
+```
+
+Ask the user for permission before committing.
+
+## Status
+
+```
+[STATUS] Detecting user's editor
+[STATUS] Confirming LaunchDarkly agent skills / plugin availability
+[STATUS] Creating editor-specific rules file (skills-first, no doc URLs)
+[STATUS] Committing rules to repository
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-recipes.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-recipes.md
@@ -1,0 +1,404 @@
+---
+title: SDK Recipes
+description: Detection patterns, install hints, official doc links, and a per-SDK detail file under sdk-snippets/ for every LaunchDarkly SDK in the index
+---
+
+# SDK Recipes
+
+Use this reference to match a detected tech stack to the correct LaunchDarkly SDK.
+
+**Field | Value** tables in this file are the **index layer**: package name, what to look for in the repo (detect files/patterns), a one-line install hint, and the official **Docs** link. Use them first to choose the right SDK and command—**before** opening a detail file.
+
+Each recipe links to an **SDK detail** file under [`sdk-snippets/`](sdk-snippets/). Open that file for curated links to official docs, samples, and package registries. Ten of those files also include a **copy-paste onboarding sample**; the rest are pointer-only—follow LaunchDarkly's docs for install and initialization. Never commit real keys. Treat each **Docs** link in the table as canonical for API details and migrations.
+
+> **Source of truth**: Official LaunchDarkly SDK documentation is authoritative. Prefer each recipe's **Docs** link over summaries here.
+
+## Top 10 SDKs (start here)
+
+These are the most common stacks—check here first before scanning less common SDKs below.
+
+### React (Web)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-react-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `react`, `react-dom`, `"react":` |
+| Install | `npm install launchdarkly-react-client-sdk` |
+| Docs | [React SDK reference](https://launchdarkly.com/docs/sdk/client-side/react) · [React Web SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-web) |
+
+**SDK detail:** [`sdk-snippets/react-web-sdk.md`](sdk-snippets/react-web-sdk.md) (includes onboarding sample)
+
+**API:** Prefer **`asyncWithLDProvider`** with **`timeout`** (seconds; recommend **1–5**) so the app renders after the JS client initializes; alternatively **`withLDProvider`** if you initialize after mount. See [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/react/react-web).
+
+**Next.js:** If `next` is present, this **client** recipe covers browser/client-component flows; server routes and Server Components usually also need **[Node.js (Server)](#nodejs-server)** and an **SDK key** there—see the **Next.js** note under that recipe and [Generate Integration Plan](1.1-plan.md).
+
+### JavaScript (Browser)
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/js-client-sdk` |
+| Detect files | `package.json`, `index.html` |
+| Detect patterns | `webpack`, `vite`, `parcel`, `rollup`; use when not using React / Vue wrappers |
+| Install | `npm install @launchdarkly/js-client-sdk` |
+| Docs | [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript) |
+
+**SDK detail:** [`sdk-snippets/javascript-browser-sdk.md`](sdk-snippets/javascript-browser-sdk.md) (includes onboarding sample)
+
+**API vs. other SDKs:** The current browser package is **`@launchdarkly/js-client-sdk`**: **`createClient`**, **`start()`**, then **`waitForInitialization({ timeout })`** (check `result.status`). See the [browser SDK API docs](https://launchdarkly.github.io/js-core/packages/sdk/browser/docs/). The legacy npm name `launchdarkly-js-client-sdk` (v3) used **`initialize()`** without `start()`—do not mix that flow with v4.
+
+### Node.js (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/node-server-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `express`, `fastify`, `koa`, `hapi`, `nestjs`, `next` (API routes), `"type": "module"` |
+| Install | `npm install @launchdarkly/node-server-sdk` |
+| Docs | [Node.js SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/node-js) |
+
+**SDK detail:** [`sdk-snippets/node-server-sdk.md`](sdk-snippets/node-server-sdk.md) (includes onboarding sample)
+
+**Next.js:** `next` in **Detect patterns** only signals that the **server-side** Node SDK may apply (API routes / Route Handlers, Server Components, server-only code). **Client components** in the browser still need the **[React (Web)](#react-web)** recipe (`launchdarkly-react-client-sdk` and a client-side ID)—do **not** silently pick only the Node server SDK for a full-stack Next app. Plan one or both SDKs depending on where flags are evaluated; align with [Generate Integration Plan](1.1-plan.md) (Next.js callout there).
+
+### Python (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` ([PyPI](https://pypi.org/project/launchdarkly-server-sdk/)) |
+| Detect files | `requirements.txt`, `pyproject.toml`, `setup.py`, `Pipfile` |
+| Detect patterns | `flask`, `django`, `fastapi`, `starlette` |
+| Install | `pip install launchdarkly-server-sdk` — optional: `pip install launchdarkly-observability` (requires SDK **9.12+**; see [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/python#install-the-sdk)) |
+| Docs | [Python SDK reference](https://launchdarkly.com/docs/sdk/server-side/python) |
+
+**SDK detail:** [`sdk-snippets/python-server-sdk.md`](sdk-snippets/python-server-sdk.md) (includes onboarding sample)
+
+**API:** **`ldclient.set_config(Config(sdk_key))`** then **`client = ldclient.get()`** (singleton). Optional **`plugins=[ObservabilityPlugin()]`** on **`Config`** with **`launchdarkly-observability`**. Forked workers: **`postfork()`**. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/python#initialize-the-client).
+
+### React Native
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/react-native-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `react-native` |
+| Install | `npm install @launchdarkly/react-native-client-sdk` |
+| Docs | [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native) |
+
+**SDK detail:** [`sdk-snippets/react-native-sdk.md`](sdk-snippets/react-native-sdk.md) (includes onboarding sample)
+
+**API:** **`@launchdarkly/react-native-client-sdk` v10** — **`ReactNativeLDClient`** (mobile key) + **`LDProvider`** + **`identify(context)`** on mount. Non-Expo: add **`@react-native-async-storage/async-storage`** and **`npx pod-install`**. See [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native).
+
+### .NET (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly.ServerSdk` ([NuGet](https://www.nuget.org/packages/LaunchDarkly.ServerSdk/)) |
+| Detect files | `*.csproj`, `*.sln`, `*.fsproj` (look for `BlazorWebAssembly`, `blazorwasm`, `UseBlazorWebAssembly`, `blazorserver`, or `Microsoft.AspNetCore.Components` / `Blazor` in the project) |
+| Detect patterns | `Microsoft.AspNetCore`, `Microsoft.NET`, `Blazor`, `blazor`, `blazorserver` (host/server UI—**not** WASM-only client projects) |
+| Install | `dotnet add package LaunchDarkly.ServerSdk` — optional: `dotnet add package LaunchDarkly.Observability` (requires server SDK **8.10+**; see [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)) |
+| Docs | [.NET SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/dotnet) |
+
+**SDK detail:** [`sdk-snippets/dotnet-server-sdk.md`](sdk-snippets/dotnet-server-sdk.md) (includes onboarding sample)
+
+**API (current docs):** **`LaunchDarkly.Sdk`** / **`LaunchDarkly.Sdk.Server`** — build config with **`Configuration.Builder(sdkKey).StartWaitTime(...).Build()`**, then **`new LdClient(config)`** before **`WebApplication.CreateBuilder` → `Build()`**. Prefer **`LdClient`** as a **singleton** in DI for real services. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client).
+
+**Blazor:** **Blazor Server** (and other server-hosted Blazor where .NET runs on the server) → this **server-side** SDK and an **SDK key**. **Blazor WebAssembly** runs in the browser → use **[.NET (Client)](#net-client)** (`LaunchDarkly.ClientSdk`, **Client-side ID**). Inspect `.csproj` / SDK props: WASM projects typically use the Blazor WebAssembly workload or `blazorwasm` / `UseBlazorWebAssembly`; do **not** treat those as server-only.
+
+### Java (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `com.launchdarkly:launchdarkly-java-server-sdk` ([Maven Central](https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk)) |
+| Detect files | `pom.xml`, `build.gradle`, `build.gradle.kts`, `*.kt` (JVM services—see note below) |
+| Detect patterns | `spring`, `quarkus`, `micronaut`, `dropwizard`, `kotlin`, `ktor`, `org.jetbrains.kotlin` |
+| Install | **Maven** (`pom.xml`) and **Gradle** (Groovy / Kotlin DSL)—see **Install (Maven and Gradle)** below; pin `version` from [SDK releases](https://github.com/launchdarkly/java-core/releases) |
+| Docs | [Java SDK reference](https://launchdarkly.com/docs/sdk/server-side/java) |
+
+**SDK detail:** [`sdk-snippets/java-server-sdk.md`](sdk-snippets/java-server-sdk.md) (includes onboarding sample)
+
+**Install (Maven and Gradle):** [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk) shows **XML** for Maven and **Gradle** coordinates. Match your build file (`pom.xml`, `build.gradle`, or `build.gradle.kts`). Example Gradle shortcut: `implementation 'com.launchdarkly:launchdarkly-java-server-sdk:7.+'` or `implementation("com.launchdarkly:launchdarkly-java-server-sdk:7.+")`.
+
+**API:** **`import com.launchdarkly.sdk.*`** / **`com.launchdarkly.sdk.server.*`** — **`new LDClient(sdkKey)`** (default startup wait), **`isInitialized()`**. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/java#initialize-the-client).
+
+**Kotlin (JVM) backends:** For **Ktor**, **Spring Boot + Kotlin**, or other **server-side Kotlin on the JVM**, use this **Java server SDK** (`launchdarkly-java-server-sdk`) from Kotlin code—LaunchDarkly does not ship a separate Kotlin server artifact. `build.gradle.kts` plus `.kt` sources without Android-only signals should still match here. **Android** apps (Kotlin or Java) that talk to LaunchDarkly from the device use the **[Android](#android)** client SDK recipe, not this server SDK.
+
+### Go (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `github.com/launchdarkly/go-server-sdk/v7` |
+| Detect files | `go.mod`, `go.sum` |
+| Detect patterns | `net/http`, `gin`, `echo`, `fiber`, `chi` |
+| Install | `go get github.com/launchdarkly/go-server-sdk/v7` |
+| Docs | [Go SDK reference](https://launchdarkly.com/docs/sdk/server-side/go) |
+
+**SDK detail:** [`sdk-snippets/go-server-sdk.md`](sdk-snippets/go-server-sdk.md) (includes onboarding sample)
+
+### Swift / iOS
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly` ([CocoaPods](https://cocoapods.org/pods/LaunchDarkly); SPM / Carthage via GitHub) |
+| Detect files | `Package.swift`, `Podfile`, `Cartfile`, `*.xcodeproj` |
+| Detect patterns | `UIKit`, `SwiftUI`, `ios` |
+| Install | **SPM**, **CocoaPods**, or **Carthage** — see [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#install-the-sdk) and [`ios-client-sdk.md`](sdk-snippets/ios-client-sdk.md); pin versions from [SDK releases](https://github.com/launchdarkly/ios-client-sdk/releases) |
+| Docs | [iOS SDK reference](https://launchdarkly.com/docs/sdk/client-side/ios) · [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) (onboarding) |
+
+**SDK detail:** [`sdk-snippets/ios-client-sdk.md`](sdk-snippets/ios-client-sdk.md) (includes onboarding sample)
+
+**API:** **`LDConfig(mobileKey:autoEnvAttributes:)`**, **`LDContextBuilder`**, **`LDClient.start(…, startWaitSeconds:completion:)`** — see [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client). Optional **`LaunchDarklyObservability`** (v9.14+).
+
+### Android
+
+| Field | Value |
+|-------|-------|
+| Package | `com.launchdarkly:launchdarkly-android-client-sdk` |
+| Detect files | `build.gradle`, `build.gradle.kts`, `AndroidManifest.xml` |
+| Detect patterns | `android`, `com.android`, `androidx` |
+| Install | See **Install (two Gradle DSLs)** below — same artifact, different syntax for Groovy vs Kotlin DSL |
+| Docs | [Android SDK reference](https://launchdarkly.com/docs/sdk/client-side/android) |
+
+**Install (two Gradle DSLs):** The [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/android#install-the-sdk) topic shows **both** forms. Use the one that matches the app module file you have:
+
+- **Gradle Groovy** (`build.gradle`): `implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'`
+- **Gradle Kotlin DSL** (`build.gradle.kts`): `implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")`
+
+**SDK detail:** [`sdk-snippets/android-client-sdk.md`](sdk-snippets/android-client-sdk.md) (includes onboarding sample)
+
+---
+
+## Server-side SDKs (other)
+
+Server-side SDKs use an **SDK Key** and are intended for backends where the key stays secret.
+
+The five most-used server runtimes (Node.js, Python, .NET, Java, Go) are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Apex (Salesforce)
+
+| Field | Value |
+|-------|-------|
+| Package | Deploy from [apex-server-sdk](https://github.com/launchdarkly/apex-server-sdk) (no NuGet/Maven module) |
+| Detect files | `sfdx-project.json`, `force-app`, `*.cls` |
+| Detect patterns | `salesforce`, `Salesforce`, `Apex` |
+| Install | Follow the docs (SFDX deploy and LaunchDarkly Salesforce bridge) |
+| Docs | [Apex SDK reference](https://launchdarkly.com/docs/sdk/server-side/apex) |
+
+**SDK detail:** [`sdk-snippets/apex-server-sdk.md`](sdk-snippets/apex-server-sdk.md)
+
+### C++ (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-cpp-server` (via CMake `FetchContent`, vcpkg, or vendor) |
+| Detect files | `CMakeLists.txt`, `Makefile`, `*.cpp`, `*.h` |
+| Detect patterns | `cmake`, server-side C++ services |
+| Install | See docs (CMake / vcpkg) |
+| Docs | [C++ SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/c-c--) |
+
+**SDK detail:** [`sdk-snippets/cpp-server-sdk.md`](sdk-snippets/cpp-server-sdk.md)
+
+### Erlang / Elixir
+
+| Field | Value |
+|-------|-------|
+| Package | Erlang: [launchdarkly_server_sdk](https://hex.pm/packages/launchdarkly_server_sdk) (Hex). Elixir: add the same dependency in `mix.exs` |
+| Detect files | `rebar.config`, `mix.exs` |
+| Detect patterns | `erlang`, `elixir`, `phoenix` |
+| Install | Rebar or Mix per docs |
+| Docs | [Erlang SDK reference](https://launchdarkly.com/docs/sdk/server-side/erlang) |
+
+**SDK detail:** [`sdk-snippets/erlang-server-sdk.md`](sdk-snippets/erlang-server-sdk.md)
+
+### Haskell (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` (Cabal / Stack / Hackage) |
+| Detect files | `*.cabal`, `stack.yaml`, `package.yaml` |
+| Detect patterns | `haskell`, `cabal`, `stack` |
+| Install | Add dependency per docs |
+| Docs | [Haskell SDK reference](https://launchdarkly.com/docs/sdk/server-side/haskell) |
+
+**SDK detail:** [`sdk-snippets/haskell-server-sdk.md`](sdk-snippets/haskell-server-sdk.md)
+
+### Lua (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` (LuaRocks) |
+| Detect files | `*.lua`, `*.rockspec` |
+| Detect patterns | `lua`, `luarocks`, OpenResty / NGINX / HAProxy Lua |
+| Install | `luarocks install launchdarkly-server-sdk` (see docs for your runtime) |
+| Docs | [Lua SDK reference](https://launchdarkly.com/docs/sdk/server-side/lua) |
+
+**SDK detail:** [`sdk-snippets/lua-server-sdk.md`](sdk-snippets/lua-server-sdk.md)
+
+### PHP (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly/server-sdk` |
+| Detect files | `composer.json` |
+| Detect patterns | `laravel`, `symfony`, `slim` |
+| Install | `composer require launchdarkly/server-sdk` |
+| Docs | [PHP SDK reference](https://launchdarkly.com/docs/sdk/server-side/php) |
+
+**SDK detail:** [`sdk-snippets/php-server-sdk.md`](sdk-snippets/php-server-sdk.md)
+
+### Ruby (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` |
+| Detect files | `Gemfile`, `*.gemspec` |
+| Detect patterns | `rails`, `sinatra`, `hanami` |
+| Install | `gem install launchdarkly-server-sdk` or add to Gemfile |
+| Docs | [Ruby SDK reference](https://launchdarkly.com/docs/sdk/server-side/ruby) |
+
+**SDK detail:** [`sdk-snippets/ruby-server-sdk.md`](sdk-snippets/ruby-server-sdk.md)
+
+### Rust (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` |
+| Detect files | `Cargo.toml` |
+| Detect patterns | `actix`, `rocket`, `axum`, `warp` |
+| Install | `cargo add launchdarkly-server-sdk` |
+| Docs | [Rust SDK reference](https://launchdarkly.com/docs/sdk/server-side/rust) |
+
+**SDK detail:** [`sdk-snippets/rust-server-sdk.md`](sdk-snippets/rust-server-sdk.md)
+
+---
+
+## Client-side SDKs (other)
+
+Client-side SDKs use a **Client-side ID** for browser and desktop clients where that credential is expected to be visible in the app. Use the linked reference for bootstrap, privacy, and flag delivery behavior.
+
+**React (Web)** and **JavaScript (browser)** are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Vue
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-vue-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `vue`, `"vue":` |
+| Install | `npm install launchdarkly-vue-client-sdk` |
+| Docs | [Vue SDK reference](https://launchdarkly.com/docs/sdk/client-side/vue) |
+
+**SDK detail:** [`sdk-snippets/vue-client-sdk.md`](sdk-snippets/vue-client-sdk.md)
+
+### Angular, Svelte, Preact, and other browser frameworks
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/js-client-sdk` |
+| Detect files | `package.json`, `angular.json`, `svelte.config.js` |
+| Detect patterns | `@angular`, `svelte`, `preact` |
+| Install | `npm install @launchdarkly/js-client-sdk` |
+| Docs | [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript) (no dedicated SDK; use the JS client) |
+
+**SDK detail:** [`sdk-snippets/browser-frameworks-sdk.md`](sdk-snippets/browser-frameworks-sdk.md)
+
+**API:** Same package and **`createClient`** / **`start()`** / **`waitForInitialization`** flow as [JavaScript (Browser)](#javascript-browser). Prefer [`javascript-browser-sdk.md`](sdk-snippets/javascript-browser-sdk.md) for a copy-paste sample.
+
+### .NET (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly.ClientSdk` |
+| Detect files | `*.csproj`, `*.sln` (WASM: `blazorwasm`, `BlazorWebAssembly`, `UseBlazorWebAssembly` in project) |
+| Detect patterns | `Xamarin`, `MAUI`, `WPF`, `UWP`, `Avalonia`, `Blazor`, `blazor`, `blazorwasm` |
+| Install | `dotnet add package LaunchDarkly.ClientSdk` |
+| Docs | [.NET SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/dotnet) |
+
+**SDK detail:** [`sdk-snippets/dotnet-client-sdk.md`](sdk-snippets/dotnet-client-sdk.md)
+
+**Blazor WebAssembly:** Use this **client** SDK and a **Client-side ID**. **Blazor Server** (and server-rendered interactive Blazor) → **[.NET (Server)](#net-server)** with `LaunchDarkly.ServerSdk`.
+
+### C++ (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-cpp-client` (CMake / vcpkg per docs) |
+| Detect files | `CMakeLists.txt`, `Makefile`, `*.cpp`, `*.h` |
+| Detect patterns | Desktop or embedded C++ clients |
+| Install | See docs |
+| Docs | [C++ SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/c-c--) |
+
+**SDK detail:** [`sdk-snippets/cpp-client-sdk.md`](sdk-snippets/cpp-client-sdk.md)
+
+### Electron
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-electron-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `electron` |
+| Install | `npm install launchdarkly-electron-client-sdk` |
+| Docs | [Electron SDK reference](https://launchdarkly.com/docs/sdk/client-side/electron) |
+
+**SDK detail:** [`sdk-snippets/electron-client-sdk.md`](sdk-snippets/electron-client-sdk.md)
+
+### Node.js (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-node-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | Node scripts or desktop tooling **without** Electron (see Electron above) |
+| Install | `npm install launchdarkly-node-client-sdk` |
+| Docs | [Node.js SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/node-js) |
+
+**SDK detail:** [`sdk-snippets/node-client-sdk.md`](sdk-snippets/node-client-sdk.md)
+
+### Roku (BrightScript)
+
+| Field | Value |
+|-------|-------|
+| Package | [roku-client-sdk](https://github.com/launchdarkly/roku-client-sdk) (GitHub releases) |
+| Detect files | `manifest`, `*.brs`, SceneGraph `*.xml` |
+| Detect patterns | `brightscript`, `roku`, `SceneGraph` |
+| Install | Add SDK components per docs |
+| Docs | [Roku SDK reference](https://launchdarkly.com/docs/sdk/client-side/roku) |
+
+**SDK detail:** [`sdk-snippets/roku-client-sdk.md`](sdk-snippets/roku-client-sdk.md)
+
+---
+
+## Mobile SDKs (other)
+
+These SDKs use a **Mobile key** for native or cross-platform mobile apps. Each **Docs** link points at the official reference (same pages as the client-side SDK family on launchdarkly.com/docs).
+
+**Swift / iOS**, **Android**, and **React Native** are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Flutter
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly_flutter_client_sdk` |
+| Detect files | `pubspec.yaml` |
+| Detect patterns | `flutter` |
+| Install | `flutter pub add launchdarkly_flutter_client_sdk` |
+| Docs | [Flutter SDK reference](https://launchdarkly.com/docs/sdk/client-side/flutter) |
+
+**SDK detail:** [`sdk-snippets/flutter-client-sdk.md`](sdk-snippets/flutter-client-sdk.md)
+
+---
+
+## Edge SDKs
+
+Edge SDKs run on edge platforms and use an **SDK Key** (see each platform's reference for environment and constraints).
+
+| Platform | Detect pattern | Docs |
+|----------|----------------|------|
+| Akamai EdgeWorkers | `bundle.json`, `edgeworkers` | [Akamai SDK reference](https://launchdarkly.com/docs/sdk/edge/akamai) |
+| Cloudflare Workers | `wrangler.toml`, `@cloudflare/workers-types` | [Cloudflare SDK reference](https://launchdarkly.com/docs/sdk/edge/cloudflare) |
+| Fastly Compute | Fastly service config, `@fastly/js-compute` (per your stack) | [Fastly SDK reference](https://launchdarkly.com/docs/sdk/edge/fastly) |
+| Vercel Edge | `vercel.json` with edge functions, `@vercel/edge` | [Vercel SDK reference](https://launchdarkly.com/docs/sdk/edge/vercel) |
+
+**SDK detail:** [`sdk-snippets/edge-sdks.md`](sdk-snippets/edge-sdks.md) (all edge platforms)
+
+---

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/android-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/android-client-sdk.md
@@ -1,0 +1,88 @@
+---
+title: Android Client SDK — SDK detail
+description: Kotlin onboarding sample and links for the LaunchDarkly Android SDK
+---
+
+# Android — SDK detail
+
+- Official docs: [Android SDK reference](https://launchdarkly.com/docs/sdk/client-side/android) · [Set up Android SDK](https://launchdarkly.com/docs/home/onboarding/android) (onboarding)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Android)
+
+**Install the dependency:** [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/android#install-the-sdk) documents **two** Gradle styles—the same Maven coordinate, different syntax. Pick the one that matches your app module:
+
+```groovy
+// Gradle Groovy — typically app/build.gradle
+implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'
+```
+
+```kotlin
+// Gradle Kotlin DSL — typically app/build.gradle.kts
+implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
+```
+
+**Import the SDK:** Use the imports that match your language ([Import the SDK](https://launchdarkly.com/docs/sdk/client-side/android#import-the-sdk)). Observability is **optional** (separate `launchdarkly-observability-android` dependency; requires Android client SDK **v5.9+**).
+
+Kotlin:
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability
+// import com.launchdarkly.sdk.android.integrations.Plugin
+```
+
+Java:
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.android.*;
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability;
+// import com.launchdarkly.sdk.android.integrations.Plugin;
+```
+
+The init snippet below matches the [onboarding initialization example](https://launchdarkly.com/docs/home/onboarding/android): use a placeholder mobile key first, then wire a real value from build configuration (see optional Gradle section). `BuildConfig.LAUNCHDARKLY_MOBILE_KEY` is **not** defined unless you add `buildConfigField` yourself—do not paste it without the Gradle setup.
+
+**Includes:** Copy-paste onboarding sample below (Kotlin). Place inside your `Application` subclass (for example `onCreate()`); `this` refers to that `Application` instance.
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability
+// import com.launchdarkly.sdk.android.integrations.Plugin
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("YOUR_MOBILE_KEY")
+    .build()
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+val context = LDContext.create("EXAMPLE_CONTEXT_KEY")
+
+// If you don't want to block execution while the SDK tries to get
+// latest flags, move this code into an async IO task and await on its completion.
+val client: LDClient = LDClient.init(this, ldConfig, context, 5)
+```
+
+Replace `"YOUR_MOBILE_KEY"` with your **Mobile key** from LaunchDarkly **Project settings > Environments** (see [Apply: environment configuration](../1.2-apply.md)). Never commit real keys in source.
+
+**Optional — `BuildConfig` + Gradle (Kotlin DSL):** Enable BuildConfig and pass the key from a non-committed `gradle.properties` or `local.properties` value:
+
+```kotlin
+// app/build.gradle.kts — excerpt
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+    defaultConfig {
+        val key = (project.findProperty("LAUNCHDARKLY_MOBILE_KEY") as String?)?.trim().orEmpty()
+        buildConfigField("String", "LAUNCHDARKLY_MOBILE_KEY", "\"$key\"")
+    }
+}
+```
+
+Then change `.mobileKey("YOUR_MOBILE_KEY")` to `.mobileKey(BuildConfig.LAUNCHDARKLY_MOBILE_KEY)` and set `LAUNCHDARKLY_MOBILE_KEY=…` where Gradle can read it (for example `~/.gradle/gradle.properties` or a CI secret), not in a committed file.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/apex-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/apex-server-sdk.md
@@ -1,0 +1,17 @@
+---
+title: Apex (Salesforce) Server SDK
+description: Where to find LaunchDarkly Apex server SDK setup and API documentation
+---
+
+# Apex (Salesforce) — SDK detail
+
+**Primary:** [Apex SDK reference](https://launchdarkly.com/docs/sdk/server-side/apex) — deployment (SFDX), Salesforce bridge, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [apex-server-sdk](https://github.com/launchdarkly/apex-server-sdk)
+- Sample: [hello-apex-server](https://github.com/launchdarkly/hello-apex-server)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Apex (Salesforce)
+
+There is no bundled onboarding code sample in this repo for Apex; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/browser-frameworks-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/browser-frameworks-sdk.md
@@ -1,0 +1,20 @@
+---
+title: Browser frameworks without a dedicated LaunchDarkly SDK
+description: Use the JavaScript client SDK for Angular, Svelte, Preact, and similar frontends
+---
+
+# Angular, Svelte, Preact, and other browser frameworks — SDK detail
+
+LaunchDarkly does not ship separate SDKs for every SPA framework. Use the **JavaScript (browser) SDK** and follow its reference for install, initialization, and evaluation.
+
+**Primary:** [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript)
+
+**Onboarding sample (JS browser) in this repo:** [`javascript-browser-sdk.md`](javascript-browser-sdk.md)
+
+**Also useful:**
+
+- npm: [launchdarkly-js-client-sdk](https://www.npmjs.com/package/launchdarkly-js-client-sdk)
+- GitHub: [js-client-sdk](https://github.com/launchdarkly/js-client-sdk)
+- API docs: [JavaScript SDK API](https://launchdarkly.github.io/js-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Angular, Svelte, Preact, and other browser frameworks

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/cpp-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/cpp-client-sdk.md
@@ -1,0 +1,18 @@
+---
+title: C++ Client SDK
+description: Where to find LaunchDarkly C++ client SDK setup and API documentation
+---
+
+# C++ (Client) — SDK detail
+
+**Primary:** [C++ SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/c-c--) — CMake, vcpkg, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [cpp-sdks / client-sdk](https://github.com/launchdarkly/cpp-sdks/tree/main/libs/client-sdk)
+- Samples: [hello-c-client](https://github.com/launchdarkly/cpp-sdks/tree/main/examples/hello-c-client), [hello-cpp-client](https://github.com/launchdarkly/cpp-sdks/tree/main/examples/hello-cpp-client)
+- API docs: [C++ client SDK API](https://launchdarkly.github.io/cpp-sdks/libs/client-sdk/docs/html/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — C++ (Client)
+
+There is no bundled onboarding code sample in this repo for C++ client; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/cpp-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/cpp-server-sdk.md
@@ -1,0 +1,17 @@
+---
+title: C++ Server SDK
+description: Where to find LaunchDarkly C++ server SDK setup and API documentation
+---
+
+# C++ (Server) — SDK detail
+
+**Primary:** [C++ SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/c-c--) — CMake, vcpkg, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [cpp-sdks](https://github.com/launchdarkly/cpp-sdks)
+- API docs: [C/C++ server SDK API](https://launchdarkly.github.io/cpp-sdks/libs/server-sdk/docs/html)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — C++ (Server)
+
+There is no bundled onboarding code sample in this repo for C++ server; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/dotnet-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/dotnet-client-sdk.md
@@ -1,0 +1,19 @@
+---
+title: .NET Client SDK
+description: Where to find LaunchDarkly .NET client SDK setup (Xamarin, MAUI, desktop, etc.)
+---
+
+# .NET (Client) — SDK detail
+
+**Primary:** [.NET SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/dotnet) — NuGet, initialization, and API.
+
+**Also useful:**
+
+- NuGet: [LaunchDarkly.ClientSdk](https://www.nuget.org/packages/LaunchDarkly.ClientSdk/)
+- GitHub: [.NET client SDK](https://github.com/launchdarkly/dotnet-core/tree/main/pkgs/sdk/client)
+- Sample: [hello-dotnet-client](https://github.com/launchdarkly/hello-dotnet-client)
+- API docs: [.NET client SDK API](https://launchdarkly.github.io/dotnet-core/pkgs/sdk/client/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — .NET (Client)
+
+There is no bundled onboarding code sample in this repo for .NET client; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/dotnet-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/dotnet-server-sdk.md
@@ -1,0 +1,78 @@
+---
+title: .NET Server SDK — SDK detail
+description: ASP.NET Core onboarding sample and links for the LaunchDarkly server-side .NET SDK
+---
+
+# .NET (Server) — SDK detail
+
+- Official docs: [.NET SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/dotnet)
+- API reference: [Server SDK API](https://launchdarkly.github.io/dotnet-core/pkgs/sdk/server/)
+- Published package: [LaunchDarkly.ServerSdk (NuGet)](https://www.nuget.org/packages/LaunchDarkly.ServerSdk/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (.NET Server)
+
+Target the **current major** server SDK on NuGet (`LaunchDarkly.ServerSdk`); follow the docs for version compatibility ([.NET SDK reference](https://launchdarkly.com/docs/sdk/server-side/dotnet)).
+
+**Install:** From the project directory ([Install the SDK](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)):
+
+```bash
+dotnet add package LaunchDarkly.ServerSdk
+```
+
+Optional observability ([.NET observability](https://launchdarkly.com/docs/sdk/observability/dotnet)) — requires server SDK **8.10+**:
+
+```bash
+dotnet add package LaunchDarkly.Observability
+```
+
+**Import:** Namespace differs from the package name ([same page — import](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)):
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+// Optional — LaunchDarkly.Observability package; requires server SDK 8.10+
+// using LaunchDarkly.Observability;
+```
+
+**Initialize:** Use **`Configuration.Builder(sdkKey)`** with **`StartWaitTime`** (docs recommend a short wait so a bad network does not hang forever). Construct **`LdClient`** **before** **`builder.Build()`** ([Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client)). In production, register **`LdClient`** as a **singleton** in DI instead of creating one per request.
+
+**Includes:** Minimal **ASP.NET Core** `Program.cs`–style sample. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../1.2-apply.md)).
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var sdkKey = Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY");
+if (string.IsNullOrWhiteSpace(sdkKey))
+{
+    Console.Error.WriteLine(
+        "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.");
+    Environment.Exit(1);
+}
+
+var ldConfig = Configuration.Builder(sdkKey)
+    .StartWaitTime(TimeSpan.FromSeconds(5))
+    .Build();
+
+// Construct the client before Build() per LaunchDarkly docs.
+using var ldClient = new LdClient(ldConfig);
+
+var app = builder.Build();
+
+if (!ldClient.Initialized)
+{
+    Console.Error.WriteLine("LaunchDarkly client did not initialize within StartWaitTime.");
+    Environment.Exit(1);
+}
+
+// For onboarding only — events are normally flushed in the background.
+ldClient.Flush();
+Console.WriteLine("LaunchDarkly client ready.");
+
+// app.MapGet(...);
+app.Run();
+```
+
+**Optional — observability (SDK 8.10+):** After adding **`LaunchDarkly.Observability`**, follow the **`ObservabilityPlugin.Builder(builder.Services)`** example in [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client) inside **`Configuration.Builder`’s** **`Plugins`** chain.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/edge-sdks.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/edge-sdks.md
@@ -1,0 +1,19 @@
+---
+title: Edge SDKs (Cloudflare, Vercel, Fastly, Akamai)
+description: Where to find LaunchDarkly edge platform SDK documentation and packages
+---
+
+# Edge SDKs — SDK detail
+
+Edge SDKs use an **SDK Key**. Use the platform-specific reference for constraints (e.g. KV, environment, bundling).
+
+| Platform | Detect pattern | Official docs | Package / repo |
+|----------|----------------|---------------|----------------|
+| Akamai EdgeWorkers | `bundle.json`, `edgeworkers` | [Akamai SDK reference](https://launchdarkly.com/docs/sdk/edge/akamai) | [js-core / akamai-edgekv](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/akamai-edgekv) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/akamai-edgekv/docs) |
+| Cloudflare Workers | `wrangler.toml`, `@cloudflare/workers-types` | [Cloudflare SDK reference](https://launchdarkly.com/docs/sdk/edge/cloudflare) | [js-core / cloudflare](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/cloudflare) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/cloudflare/docs/) |
+| Fastly Compute | Fastly config, `@fastly/js-compute` (typical) | [Fastly SDK reference](https://launchdarkly.com/docs/sdk/edge/fastly) | [js-core / fastly](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/fastly) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/fastly/docs/) |
+| Vercel Edge | `vercel.json` with edge functions, `@vercel/edge` | [Vercel SDK reference](https://launchdarkly.com/docs/sdk/edge/vercel) | [js-core / vercel](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/vercel) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/vercel/docs/) |
+
+**Recipe index:** [SDK Recipes](../sdk-recipes.md) — Edge SDKs
+
+There are no bundled onboarding code samples in this repo for edge SDKs; follow each platform’s official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/electron-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/electron-client-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Electron Client SDK
+description: Where to find LaunchDarkly Electron client SDK setup and API documentation
+---
+
+# Electron — SDK detail
+
+**Primary:** [Electron SDK reference](https://launchdarkly.com/docs/sdk/client-side/electron) — npm install, initialization, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-electron-client-sdk](https://www.npmjs.com/package/launchdarkly-electron-client-sdk)
+- GitHub: [electron-client-sdk](https://github.com/launchdarkly/electron-client-sdk)
+- Sample: [hello-electron](https://github.com/launchdarkly/hello-electron)
+- API docs: [Electron SDK API](https://launchdarkly.github.io/electron-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Electron
+
+There is no bundled onboarding code sample in this repo for Electron; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/erlang-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/erlang-server-sdk.md
@@ -1,0 +1,18 @@
+---
+title: Erlang / Elixir Server SDK
+description: Where to find LaunchDarkly Erlang server SDK setup (including Elixir via Hex)
+---
+
+# Erlang / Elixir — SDK detail
+
+**Primary:** [Erlang SDK reference](https://launchdarkly.com/docs/sdk/server-side/erlang) — Rebar, Mix, initialization, and API.
+
+**Also useful:**
+
+- Hex package: [launchdarkly_server_sdk](https://hex.pm/packages/launchdarkly_server_sdk)
+- GitHub: [erlang-server-sdk](https://github.com/launchdarkly/erlang-server-sdk/)
+- Samples: [hello-elixir](https://github.com/launchdarkly/hello-elixir), [hello-phoenix](https://github.com/launchdarkly/hello-phoenix)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Erlang / Elixir
+
+There is no bundled onboarding code sample in this repo for Erlang/Elixir; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/flutter-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/flutter-client-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Flutter Client SDK
+description: Where to find LaunchDarkly Flutter client SDK setup and API documentation
+---
+
+# Flutter — SDK detail
+
+**Primary:** [Flutter SDK reference](https://launchdarkly.com/docs/sdk/client-side/flutter) — `pubspec`, initialization, and API.
+
+**Also useful:**
+
+- pub.dev: [launchdarkly_flutter_client_sdk](https://pub.dev/packages/launchdarkly_flutter_client_sdk)
+- GitHub: [flutter-client-sdk](https://github.com/launchdarkly/flutter-client-sdk)
+- Example app: [flutter_client_sdk example](https://github.com/launchdarkly/flutter-client-sdk/tree/main/packages/flutter_client_sdk/example)
+- API docs: [Flutter SDK API](https://pub.dev/documentation/launchdarkly_flutter_client_sdk/latest/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Flutter
+
+There is no bundled onboarding code sample in this repo for Flutter; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/go-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/go-server-sdk.md
@@ -1,0 +1,40 @@
+---
+title: Go Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Go server-side SDK
+---
+
+# Go (Server) — SDK detail
+
+- Official docs: [Go SDK reference](https://launchdarkly.com/docs/sdk/server-side/go)
+- API reference: [`LDClient`, `MakeClient`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Go Server)
+
+The [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/go#initialize-the-client) chapter shows **`MakeClient`** / **`MakeCustomClient`** (and optional **`ldcontext`** + **`NewScopedClient`** for a scoped client). It does **not** use **`Initialized()`** in that section. The **`error`** from **`MakeClient`** is what signals construction-time failure (see the “Best practices for error handling” callout in those docs). If you need to branch on “fully ready” after the timeout window, use **[`Initialized`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7#LDClient.Initialized)** or **[Monitoring SDK status](https://launchdarkly.com/docs/sdk/features/monitoring#go)**—read **[`MakeClient`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7#MakeClient)** for how the **timeout** interacts with returning before the client has finished connecting.
+
+**Includes:** Minimal onboarding sample aligned with **“Go SDK, using LDClient and default configuration”** in the docs. For **`MakeCustomClient`**, **`ldcontext`**, **`LDScopedClient`**, or the **observability** plugin, follow the same page’s larger examples.
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+)
+
+func main() {
+	ldClient, err := ld.MakeClient(os.Getenv("LAUNCHDARKLY_SDK_KEY"), 5*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create LaunchDarkly client: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("LaunchDarkly client created.")
+
+	// For onboarding purposes only we flush events as soon as
+	// possible so we quickly detect your connection.
+	// You don't have to do this in practice because events are automatically flushed.
+	ldClient.Flush()
+}
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/haskell-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/haskell-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Haskell Server SDK
+description: Where to find LaunchDarkly Haskell server SDK setup and API documentation
+---
+
+# Haskell (Server) — SDK detail
+
+**Primary:** [Haskell SDK reference](https://launchdarkly.com/docs/sdk/server-side/haskell) — Cabal/Stack, initialization, and API.
+
+**Also useful:**
+
+- Hackage: [launchdarkly-server-sdk](https://hackage.haskell.org/package/launchdarkly-server-sdk)
+- GitHub: [haskell-server-sdk](https://github.com/launchdarkly/haskell-server-sdk)
+- Sample: [hello-haskell-server](https://github.com/launchdarkly/hello-haskell-server)
+- API docs: [Haskell SDK API](https://launchdarkly.github.io/haskell-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Haskell (Server)
+
+There is no bundled onboarding code sample in this repo for Haskell; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/ios-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/ios-client-sdk.md
@@ -1,0 +1,105 @@
+---
+title: iOS (Swift) Client SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly iOS SDK
+---
+
+# Swift / iOS — SDK detail
+
+- Official docs: [iOS SDK reference](https://launchdarkly.com/docs/sdk/client-side/ios) · [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) (onboarding)
+- API reference: [iOS SDK API docs](https://launchdarkly.github.io/ios-client-sdk/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Swift / iOS)
+
+**Why this differs from the home onboarding page:** [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) uses a **`"YOUR_MOBILE_KEY"`** literal and a linear script. This skill keeps the **same `LDConfig` / `LDContextBuilder` / `LDClient.start`…`startWaitSeconds`** flow as [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client), but resolves the mobile key from **Xcode scheme env** or **Info.plist** so archives are not missing the key. Substituting `LDConfig(mobileKey: "YOUR_MOBILE_KEY", …)` matches the docs verbatim when you only need a quick local paste.
+
+**Install the SDK:** LaunchDarkly documents **Swift Package Manager**, **CocoaPods**, and **Carthage** ([Install the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#install-the-sdk)). Pin versions from the [SDK releases](https://github.com/launchdarkly/ios-client-sdk/releases) page; the examples below follow the [onboarding install](https://launchdarkly.com/docs/home/onboarding/ios) style.
+
+**Swift Package Manager** (`Package.swift` excerpt):
+
+```swift
+// ...
+dependencies: [
+    .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", .upToNextMajor("9.15.0")),
+    // Optional observability — iOS SDK v9.14+; see reference Install the SDK
+    // .package(url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git", .upToNextMajor("1.0.0")),
+],
+targets: [
+    .target(
+        name: "YOUR_TARGET",
+        dependencies: ["LaunchDarkly"]
+    ),
+]
+// ...
+```
+
+**CocoaPods** (`Podfile`):
+
+```ruby
+use_frameworks!
+target 'YourTargetName' do
+  pod 'LaunchDarkly', '~> 9.15'
+  # Optional — LaunchDarklyObservability, iOS SDK v9.14+
+  # pod 'LaunchDarklyObservability', '~> 1.0'
+end
+```
+
+**Carthage** (`Cartfile`):
+
+```
+github "launchdarkly/ios-client-sdk" ~> 9.15
+```
+
+**Import** ([Import the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#import-the-sdk)):
+
+```swift
+import LaunchDarkly
+// Optional observability — iOS SDK v9.14+
+// import LaunchDarklyObservability
+```
+
+**Mobile key:** Never ship a real key in source. `ProcessInfo.processInfo.environment` is set from the **Xcode scheme** for local runs; **TestFlight / App Store** builds need **Info.plist** (e.g. `LaunchDarklyMobileKey`) or xcconfig. Logical name: [Apply: environment configuration](../1.2-apply.md).
+
+**Includes:** Call `configureLaunchDarkly()` from `application(_:didFinishLaunchingWithOptions:)` (UIKit) or your SwiftUI startup path.
+
+```swift
+import LaunchDarkly
+
+func configureLaunchDarkly() {
+    let mobileKey: String?
+    if let v = ProcessInfo.processInfo.environment["LAUNCHDARKLY_MOBILE_KEY"], !v.isEmpty {
+        mobileKey = v
+    } else if let v = Bundle.main.object(forInfoDictionaryKey: "LaunchDarklyMobileKey") as? String, !v.isEmpty {
+        mobileKey = v
+    } else {
+        mobileKey = nil
+    }
+
+    guard let mobileKey else {
+        print("LaunchDarkly: missing mobile key (scheme LAUNCHDARKLY_MOBILE_KEY for Xcode runs, or Info.plist LaunchDarklyMobileKey for archives).")
+        return
+    }
+
+    let config = LDConfig(mobileKey: mobileKey, autoEnvAttributes: .enabled)
+    // Optional observability — iOS SDK v9.14+; add package/pod and set config.plugins per
+    // https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client
+
+    let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    guard case .success(let context) = contextBuilder.build() else {
+        print("LaunchDarkly: could not build context")
+        return
+    }
+
+    LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+        if timedOut {
+            print("SDK didn't initialize in 5 seconds. SDK is still running and trying to get latest flags.")
+        } else {
+            print("SDK successfully initialized with the latest flags")
+            if let client = LDClient.get() {
+                // For onboarding only — events are flushed automatically in normal use.
+                client.flush()
+            }
+        }
+    }
+
+    print("SDK started.")
+}
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/java-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/java-server-sdk.md
@@ -1,0 +1,82 @@
+---
+title: Java Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Java server-side SDK
+---
+
+# Java (Server) — SDK detail
+
+- Official docs: [Java SDK reference](https://launchdarkly.com/docs/sdk/server-side/java)
+- API reference: [Java server SDK API](https://launchdarkly.github.io/java-core/lib/sdk/server/)
+- Published artifact: [Maven Central](https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Java Server)
+
+Pin **`version`** to a current release from the [SDK releases page](https://github.com/launchdarkly/java-core/releases). The blocks below mirror [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk) (Maven **XML** and **Gradle**); use the one that matches your build.
+
+**Maven** (`pom.xml`):
+
+```xml
+<dependency>
+  <groupId>com.launchdarkly</groupId>
+  <artifactId>launchdarkly-java-server-sdk</artifactId>
+  <version>7.0.0</version>
+</dependency>
+```
+
+**Gradle (Groovy)** — long form as in the docs:
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
+```
+
+**Gradle (Groovy)** — common shortcut (still set a concrete or ranged version you intend to support):
+
+```groovy
+implementation 'com.launchdarkly:launchdarkly-java-server-sdk:7.+'
+```
+
+**Gradle (Kotlin DSL)** (`build.gradle.kts`):
+
+```kotlin
+implementation("com.launchdarkly:launchdarkly-java-server-sdk:7.+")
+```
+
+**OSGi “all” classifier** (bundled Gson/SLF4J): see [Using the Java SDK in OSGi](https://launchdarkly.com/docs/sdk/server-side/java#using-the-java-sdk-in-osgi).
+
+**Import** ([same topic](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk)):
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+```
+
+**Initialize:** [`new LDClient(sdkKey)`](https://launchdarkly.com/docs/sdk/server-side/java#initialize-the-client) connects with a **default ~5s** wait; use [`isInitialized()`](https://launchdarkly.github.io/java-core/lib/sdk/server/com/launchdarkly/sdk/server/LDClient.html#isInitialized--) to see if startup succeeded. For custom timeouts and options, use [`LDConfig.Builder`](https://launchdarkly.github.io/java-core/lib/sdk/server/com/launchdarkly/sdk/server/LDConfig.Builder.html). **`LDClient` must be a singleton** per environment.
+
+**Includes:** Minimal `main` sample. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../1.2-apply.md)).
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
+public class Main {
+  public static void main(String[] args) {
+    String sdkKey = System.getenv("LAUNCHDARKLY_SDK_KEY");
+    if (sdkKey == null || sdkKey.trim().isEmpty()) {
+      System.err.println(
+          "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.");
+      System.exit(1);
+    }
+
+    try (LDClient client = new LDClient(sdkKey)) {
+      if (client.isInitialized()) {
+        // For onboarding only — events are normally flushed in the background.
+        client.flush();
+        System.out.println("LaunchDarkly client initialized.");
+      } else {
+        System.err.println(
+            "LaunchDarkly client did not initialize within the default wait; defaults apply until connected.");
+        System.exit(1);
+      }
+    }
+  }
+}
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/javascript-browser-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/javascript-browser-sdk.md
@@ -1,0 +1,49 @@
+---
+title: JavaScript Browser SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly JavaScript client-side (browser) SDK
+---
+
+# JavaScript (Browser) — SDK detail
+
+- Official docs: [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript)
+- API reference: [Browser client (`@launchdarkly/js-client-sdk`)](https://launchdarkly.github.io/js-core/packages/sdk/browser/docs/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (JavaScript Browser)
+
+Use **`@launchdarkly/js-client-sdk`**: **`createClient`**, **`start()`**, then **`waitForInitialization({ timeout })`**. Always pass a **timeout** (the docs recommend **1–5 seconds**); without one, connectivity issues can block your app. In v4, `waitForInitialization` **always settles** with a **status** (`complete`, `failed`, or `timeout`)—handle each path ([Use promises to determine when the client is ready](https://launchdarkly.com/docs/sdk/client-side/javascript)).
+
+**Client-side ID and env vars:** Use the **Client-side ID** from **Project settings > Environments** (not a server SDK key). Bundler prefixes: [Apply: environment configuration](../1.2-apply.md).
+
+Use this in an ES module context that supports top-level `await`, or wrap in an `async` function.
+
+**Includes:** Copy-paste onboarding sample below. After `status === 'complete'`, replace the flush/log block with your own logic (the docs’ `handleInitializedClient` is only an illustration).
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+const clientSideID = import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID;
+
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+};
+
+const client = createClient(clientSideID, context);
+client.start();
+
+const result = await client.waitForInitialization({ timeout: 5 });
+
+if (result.status === 'complete') {
+  await client.flush();
+  console.log('SDK successfully initialized!');
+} else if (result.status === 'failed') {
+  console.error('LaunchDarkly initialization failed:', result.error);
+} else if (result.status === 'timeout') {
+  console.error(
+    'LaunchDarkly initialization timed out; the client keeps retrying in the background.',
+  );
+}
+```
+
+For Create React App, replace `import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` with `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID`. For Next.js, use `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID`.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/lua-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/lua-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Lua Server SDK
+description: Where to find LaunchDarkly Lua server SDK setup and API documentation
+---
+
+# Lua (Server) — SDK detail
+
+**Primary:** [Lua SDK reference](https://launchdarkly.com/docs/sdk/server-side/lua) — LuaRocks, runtime integration (e.g. OpenResty, NGINX), initialization, and API.
+
+**Also useful:**
+
+- LuaRocks: [launchdarkly modules](https://luarocks.org/modules/launchdarkly)
+- GitHub: [lua-server-sdk](https://github.com/launchdarkly/lua-server-sdk)
+- Samples: [hello-lua-server](https://github.com/launchdarkly/hello-lua-server), [hello-haproxy](https://github.com/launchdarkly/hello-haproxy), [hello-nginx](https://github.com/launchdarkly/hello-nginx)
+- API docs: [Lua SDK modules](https://launchdarkly.github.io/lua-server-sdk/modules/launchdarkly-server-sdk.html)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Lua (Server)
+
+There is no bundled onboarding code sample in this repo for Lua; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/node-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/node-client-sdk.md
@@ -1,0 +1,21 @@
+---
+title: Node.js Client SDK
+description: Where to find LaunchDarkly Node.js client SDK setup (non-Electron Node apps)
+---
+
+# Node.js (Client) — SDK detail
+
+**Primary:** [Node.js SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/node-js) — npm install, initialization, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-node-client-sdk](https://www.npmjs.com/package/launchdarkly-node-client-sdk)
+- GitHub: [node-client-sdk](https://github.com/launchdarkly/node-client-sdk)
+- Sample: [hello-node-client](https://github.com/launchdarkly/hello-node-client)
+- API docs: [Node.js client SDK API](https://launchdarkly.github.io/node-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Node.js (Client)
+
+For **Electron**, use [`electron-client-sdk.md`](electron-client-sdk.md) instead.
+
+There is no bundled onboarding code sample in this repo for Node client; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/node-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/node-server-sdk.md
@@ -1,0 +1,68 @@
+---
+title: Node.js Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Node.js server-side SDK
+---
+
+# Node.js (Server) — SDK detail
+
+- Official docs: [Node.js SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/node-js)
+- API reference: [SDK API docs](https://launchdarkly.github.io/js-core/packages/sdk/server-node/docs/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Node.js Server)
+
+**Includes:** Patterns below follow the **Get started**, **Initialize the client**, **Evaluate a context**, and **Promises and async** sections of the [Node.js server-side SDK reference](https://launchdarkly.com/docs/sdk/server-side/node-js). Use **one** initialization strategy (`waitForInitialization` **or** the `ready` event—not both at once unless you know why). Aligns with [Create First Feature Flag](../1.5-first-flag.md) (evaluation uses **context** + default).
+
+### Singleton client
+
+`LDClient` must be a **singleton** per LaunchDarkly environment—do not create a new client per request. Use your real SDK key from env vars, not a literal in source.
+
+```javascript
+import { init } from '@launchdarkly/node-server-sdk';
+
+const client = init(process.env.LAUNCHDARKLY_SDK_KEY);
+```
+
+### Wait for initialization (startup)
+
+Run this **once** during process startup—for example before your HTTP server accepts connections, inside whatever async bootstrap your framework provides. The public docs use `{ timeout: 10 }` (seconds); adjust as needed.
+
+**Promise style** (from [Promises and async](https://launchdarkly.com/docs/sdk/server-side/node-js)):
+
+```javascript
+client
+  .waitForInitialization({ timeout: 5 })
+  .then(() => {
+    // Initialization complete — safe to evaluate flags and/or start serving traffic.
+  })
+  .catch((err) => {
+    // Timeout or initialization failed
+  });
+```
+
+**Async/await** (same topic—must live inside an `async` function your app already uses for startup):
+
+```javascript
+try {
+  await client.waitForInitialization({ timeout: 5 });
+  // Initialization complete
+} catch (err) {
+  // Timeout or initialization failed
+}
+```
+
+**Alternative:** the docs also document a `ready` event and callback-style `client.variation(..., (err, value) => { ... })` under **Evaluate a context**—use that form if it fits your codebase better.
+
+### Evaluate a flag (when handling work)
+
+The docs state that in production you should invoke `variation` **as needed** (not only once at import). Use `await` inside an `async` route handler, service method, job, etc.
+
+```javascript
+const context = {
+  kind: 'user',
+  key: 'example-user-key',
+  name: 'Example User',
+};
+
+const showFeature = await client.variation('example-flag-key', context, false);
+```
+
+For a boolean flag you may use `boolVariation` if you prefer; the official getting-started examples use `variation` with a boolean default.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/php-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/php-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: PHP Server SDK
+description: Where to find LaunchDarkly PHP server SDK setup and API documentation
+---
+
+# PHP (Server) — SDK detail
+
+**Primary:** [PHP SDK reference](https://launchdarkly.com/docs/sdk/server-side/php) — Composer, initialization, and API.
+
+**Also useful:**
+
+- Packagist: [launchdarkly/server-sdk](https://packagist.org/packages/launchdarkly/server-sdk)
+- GitHub: [php-server-sdk](https://github.com/launchdarkly/php-server-sdk)
+- Sample: [hello-php](https://github.com/launchdarkly/hello-php)
+- API docs: [PHP SDK API](https://launchdarkly.github.io/php-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — PHP (Server)
+
+There is no bundled onboarding code sample in this repo for PHP; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/python-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/python-server-sdk.md
@@ -1,0 +1,67 @@
+---
+title: Python Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Python server-side SDK
+---
+
+# Python (Server) — SDK detail
+
+- Official docs: [Python SDK reference](https://launchdarkly.com/docs/sdk/server-side/python)
+- API reference: [launchdarkly-server-sdk (Read the Docs)](https://launchdarkly-python-sdk.readthedocs.io/)
+- Published package: [launchdarkly-server-sdk (PyPI)](https://pypi.org/project/launchdarkly-server-sdk/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (Python Server)
+
+Use a **current** `launchdarkly-server-sdk` release; see the [SDK releases page](https://github.com/launchdarkly/python-server-sdk/releases) and [version compatibility](https://launchdarkly.com/docs/sdk/server-side/python) (Python **3.9+** from SDK **9.12+**).
+
+**Install** ([Install the SDK](https://launchdarkly.com/docs/sdk/server-side/python#install-the-sdk)):
+
+```bash
+pip install launchdarkly-server-sdk
+```
+
+Optional observability ([Python observability](https://launchdarkly.com/docs/sdk/observability/python)) — requires Python SDK **9.12+**:
+
+```bash
+pip install launchdarkly-observability
+```
+
+**Import** (same topic):
+
+```python
+import ldclient
+from ldclient.config import Config
+
+# Optional — launchdarkly-observability package; requires Python SDK v9.12+
+# from ldobserve import ObservabilityPlugin
+```
+
+**Initialize:** Call **`ldclient.set_config(Config(...))`** once, then **`ldclient.get()`** for the singleton client ([Initialize the client](https://launchdarkly.com/docs/sdk/server-side/python#initialize-the-client)). With observability: `Config(sdk_key, plugins=[ObservabilityPlugin()])`. Worker processes that **fork** may need **`postfork()`** ([Considerations with worker-based servers](https://launchdarkly.com/docs/sdk/server-side/python#considerations-with-worker-based-servers)).
+
+**Includes:** Minimal onboarding script. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../1.2-apply.md)).
+
+```python
+import os
+import sys
+
+import ldclient
+from ldclient.config import Config
+
+if __name__ == "__main__":
+    sdk_key = os.environ.get("LAUNCHDARKLY_SDK_KEY")
+    if not sdk_key or not sdk_key.strip():
+        print(
+            "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    ldclient.set_config(Config(sdk_key))
+    client = ldclient.get()
+
+    if not client.is_initialized():
+        print("LaunchDarkly client failed to initialize", file=sys.stderr)
+        raise SystemExit(1)
+
+    # For onboarding only — events are normally flushed in the background.
+    client.flush()
+    print("LaunchDarkly client ready.")
+```

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/react-native-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/react-native-sdk.md
@@ -1,0 +1,63 @@
+---
+title: React Native Client SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly React Native SDK
+---
+
+# React Native — SDK detail
+
+- Official docs: [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native)
+- API reference: [React Native SDK (`@launchdarkly/react-native-client-sdk`)](https://launchdarkly.github.io/js-core/packages/sdk/react-native/docs/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (React Native)
+
+**Current SDK:** **`@launchdarkly/react-native-client-sdk` v10** (TypeScript, [Expo-compatible](https://launchdarkly.com/docs/sdk/client-side/react/react-native); iOS and Android only—not web). Build **`ReactNativeLDClient`** with the **mobile key**, wrap the app in **`LDProvider`**, and call **`identify(context)`** after mount (no context at construction). **`identify`** uses a **5s timeout by default**; do not strip timeouts in custom configuration.
+
+**Install (non-Expo):** Add **`@react-native-async-storage/async-storage`**, then run **`npx pod-install`** for iOS ([Install the SDK](https://launchdarkly.com/docs/sdk/client-side/react/react-native)).
+
+**Mobile key:** Resolve a non-empty string at runtime (below uses Expo’s `EXPO_PUBLIC_` env). Bare React Native typically uses **react-native-config** or native build settings—never hardcode keys in source. Logical name: [Apply: environment configuration](../1.2-apply.md).
+
+**Includes:** Copy-paste onboarding sample below.
+
+```tsx
+import { useEffect } from 'react';
+import {
+  AutoEnvAttributes,
+  LDProvider,
+  ReactNativeLDClient,
+} from '@launchdarkly/react-native-client-sdk';
+
+const mobileKey = process.env.EXPO_PUBLIC_LAUNCHDARKLY_MOBILE_KEY?.trim();
+if (!mobileKey) {
+  throw new Error(
+    'LaunchDarkly: missing mobile key. For Expo, set EXPO_PUBLIC_LAUNCHDARKLY_MOBILE_KEY. For bare React Native, inject the key (for example react-native-config) and pass it here.',
+  );
+}
+
+const ldClient = new ReactNativeLDClient(mobileKey, AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY' };
+
+const App = () => {
+  useEffect(() => {
+    ldClient.identify(context).catch((e: unknown) => {
+      console.error('LaunchDarkly identify failed:', e);
+    });
+  }, []);
+
+  return (
+    <LDProvider client={ldClient}>
+      <YourComponent />
+    </LDProvider>
+  );
+};
+
+export default App;
+```
+
+Expo requires the **`EXPO_PUBLIC_`** prefix for `process.env` in app code; other setups should substitute their own resolved string for `mobileKey`.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/react-web-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/react-web-sdk.md
@@ -1,0 +1,63 @@
+---
+title: React Web SDK — SDK detail
+description: Root-level React onboarding sample and links for the LaunchDarkly React Web SDK
+---
+
+# React (Web) — SDK detail
+
+- Official docs: [React SDK reference](https://launchdarkly.com/docs/sdk/client-side/react) · [React Web SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-web)
+- API reference: [React Web SDK (`launchdarkly-react-client-sdk`)](https://launchdarkly.github.io/react-client-sdk/)
+- Recipe (detect / install): [SDK Recipes](../sdk-recipes.md) (React Web)
+
+**Initialization:** Prefer **`asyncWithLDProvider`** so the tree mounts after the underlying JavaScript client is ready (avoids startup flag flicker). Pass **`timeout`** in **seconds** (docs recommend **1–5**); it is forwarded to `waitForInitialization` on the JS client ([Configuration options](https://launchdarkly.com/docs/sdk/client-side/react/react-web)). **`withLDProvider`** is an alternative if you accept initializing after the first mount.
+
+**Credentials:** **Client-side ID** from **Project settings > Environments** (not a server SDK key). Bundler env prefixes: [Apply: environment configuration](../1.2-apply.md).
+
+**Includes:** Copy-paste sample for a Vite-style client entry (e.g. `main.tsx`). Requires **React 16.8+** (`asyncWithLDProvider` uses hooks).
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+
+function App() {
+  return <div>Let your feature flags fly!</div>;
+}
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'user@example.com',
+};
+
+const clientSideID = import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID?.trim();
+if (!clientSideID) {
+  throw new Error(
+    'LaunchDarkly: missing client-side ID. Set VITE_LAUNCHDARKLY_CLIENT_SIDE_ID (Vite), REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID (CRA), or NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID (Next.js client).',
+  );
+}
+
+void (async () => {
+  const LDProvider = await asyncWithLDProvider({
+    clientSideID,
+    context,
+    timeout: 5,
+  });
+
+  const rootEl = document.getElementById('root');
+  if (!rootEl) {
+    throw new Error('LaunchDarkly bootstrap: #root element not found');
+  }
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <LDProvider>
+        <App />
+      </LDProvider>
+    </StrictMode>,
+  );
+})();
+```
+
+For Create React App, read the ID from `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` instead of `import.meta.env.VITE_…`. For Next.js client bundles, use `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` in a client entry (`'use client'` as required).

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/roku-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/roku-client-sdk.md
@@ -1,0 +1,17 @@
+---
+title: Roku Client SDK
+description: Where to find LaunchDarkly Roku (BrightScript) SDK setup and releases
+---
+
+# Roku (BrightScript) — SDK detail
+
+**Primary:** [Roku SDK reference](https://launchdarkly.com/docs/sdk/client-side/roku) — component install, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [roku-client-sdk](https://github.com/launchdarkly/roku-client-sdk) (releases)
+- Sample: [hello-roku](https://github.com/launchdarkly/hello-roku)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Roku (BrightScript)
+
+There is no bundled onboarding code sample in this repo for Roku; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/ruby-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/ruby-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Ruby Server SDK
+description: Where to find LaunchDarkly Ruby server SDK setup and API documentation
+---
+
+# Ruby (Server) — SDK detail
+
+**Primary:** [Ruby SDK reference](https://launchdarkly.com/docs/sdk/server-side/ruby) — Gemfile, initialization, and API.
+
+**Also useful:**
+
+- RubyGems: [launchdarkly-server-sdk](https://rubygems.org/gems/launchdarkly-server-sdk)
+- GitHub: [ruby-server-sdk](https://github.com/launchdarkly/ruby-server-sdk)
+- Samples: [hello-ruby](https://github.com/launchdarkly/hello-ruby), [hello-bootstrap-rails](https://github.com/launchdarkly/hello-bootstrap-rails)
+- API docs: [Ruby SDK API](https://launchdarkly.github.io/ruby-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Ruby (Server)
+
+There is no bundled onboarding code sample in this repo for Ruby; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/rust-server-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/rust-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Rust Server SDK
+description: Where to find LaunchDarkly Rust server SDK setup and API documentation
+---
+
+# Rust (Server) — SDK detail
+
+**Primary:** [Rust SDK reference](https://launchdarkly.com/docs/sdk/server-side/rust) — crates.io, initialization, and API.
+
+**Also useful:**
+
+- crates.io: [launchdarkly-server-sdk](https://crates.io/crates/launchdarkly-server-sdk)
+- GitHub: [rust-server-sdk](https://github.com/launchdarkly/rust-server-sdk)
+- Sample: [hello-rust](https://github.com/launchdarkly/hello-rust)
+- API docs: [docs.rs launchdarkly-server-sdk](https://docs.rs/launchdarkly-server-sdk)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Rust (Server)
+
+There is no bundled onboarding code sample in this repo for Rust; follow the official reference.

--- a/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/vue-client-sdk.md
+++ b/skills/setup/launchdarkly-sdk-onboarding/references/sdk-snippets/vue-client-sdk.md
@@ -1,0 +1,18 @@
+---
+title: Vue Client SDK
+description: Where to find LaunchDarkly Vue client SDK setup and API documentation
+---
+
+# Vue — SDK detail
+
+**Primary:** [Vue SDK reference](https://launchdarkly.com/docs/sdk/client-side/vue) — npm install, plugin setup, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-vue-client-sdk](https://www.npmjs.com/package/launchdarkly-vue-client-sdk)
+- GitHub: [vue-client-sdk](https://github.com/launchdarkly/vue-client-sdk)
+- API docs: [Vue SDK API](https://launchdarkly.github.io/vue-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../sdk-recipes.md) — Vue
+
+There is no bundled onboarding code sample in this repo for Vue; follow the official reference.

--- a/skills/setup/launchdarkly/SKILL.md
+++ b/skills/setup/launchdarkly/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: launchdarkly-sdk-onboarding
+description: "Onboard a project to LaunchDarkly by detecting the tech stack, installing the right SDK, initializing it, validating the connection, and creating a first feature flag. Use when the user wants to add LaunchDarkly to their project, integrate an SDK, or says 'onboard me'."
+license: Apache-2.0
+compatibility: Requires LaunchDarkly API access token. Prefer the LaunchDarkly MCP server when configured for flags and validation.
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly SDK Onboarding
+
+You're using a skill that will guide you through adding LaunchDarkly to a project. Your job is to detect the tech stack, choose the right SDK, install and initialize it, validate the connection, and help the user create their first feature flag.
+
+## Account and Credentials
+
+Before starting the SDK integration, ensure the user has access to LaunchDarkly:
+
+1. **Check for existing credentials**: Ask the user if they have a LaunchDarkly access token or SDK key.
+2. **If the user has an account**: Use the LaunchDarkly API (`GET /api/v2/projects/PROJECT_KEY`) or `ldcli` to retrieve the project, environment, and SDK key automatically. Ask the user for permission before reading the SDK key.
+3. **If the user does NOT have an account**: Prompt them to sign up at https://launchdarkly.com or log in via `ldcli login`. Guide them through creating their first project and environment if needed.
+4. **SDK key types**: The project response will contain the keys you need. Use the correct key type for the SDK:
+   - **SDK Key** for server-side SDKs
+   - **Client-side ID** for client-side/browser SDKs
+   - **Mobile Key** for mobile SDKs
+
+## Core Principles
+
+1. **Detect, don't guess**: Always inspect the repo to determine the language, framework, and package manager. Never assume.
+2. **Minimal changes**: Add SDK code alongside existing code. Don't restructure or refactor the user's project.
+3. **Match existing patterns**: If the project already has conventions (env vars, config files, initialization patterns), follow them.
+4. **Validate end-to-end**: Don't stop at installation. Confirm the SDK is actually connected to LaunchDarkly.
+
+## Workflow
+
+Follow and enumerate **Steps 1-6** in order for the SDK integration and first flag. If any step fails, go to [Step 7: Recover](#step-7-recover).
+
+MCP setup, `LAUNCHDARKLY.md`, and editor rules are **not** listed below as steps—they are covered in [Default follow-through](#default-follow-through-not-numbered-steps).
+
+### Step 1: Detect Repository Stack
+
+Before doing anything, understand the project.
+
+1. Inspect the repo for language, framework, and package manager
+2. Check for existing LaunchDarkly SDK usage
+3. Identify the application entrypoint
+
+See [Detect Repository Stack](references/1.0-detect.md) for detailed instructions.
+
+### Step 2: Generate Integration Plan
+
+Based on what you found, choose the correct SDK and plan the integration.
+
+1. Match the detected stack to an SDK using the [SDK Recipes](references/sdk-recipes.md) (read **Top 10 SDKs (start here)** first when applicable)
+2. Identify which files need to change
+3. Determine if this is a server-side, client-side, or mobile integration
+
+See [Generate Integration Plan](references/1.1-plan.md) for detailed instructions.
+
+### Step 3: Install Dependencies and Apply Code
+
+Install the SDK and add initialization code to the project.
+
+1. Install the SDK package using the project's package manager
+2. Add SDK initialization code to the application entrypoint
+3. Configure the SDK key via environment variables
+
+See [Apply Code Changes](references/1.2-apply.md) for detailed instructions.
+
+### Step 4: Start the Application
+
+Verify the application runs with the SDK integrated.
+
+1. Start the application using its standard run command
+2. Confirm there are no import or initialization errors
+3. Look for SDK initialization success in logs
+
+See [Start the Application](references/1.3-run.md) for detailed instructions.
+
+### Step 5: Validate SDK Connection
+
+Confirm that LaunchDarkly sees the SDK connection.
+
+1. Check the SDK is active using the LaunchDarkly API or MCP
+2. Verify the connection in the LaunchDarkly dashboard
+
+See [Validate SDK Connection](references/1.4-validate.md) for detailed instructions.
+
+### Step 6: Create Your First Feature Flag
+
+Help the user create and evaluate a feature flag.
+
+1. Create a boolean feature flag
+2. Add flag evaluation code to the project
+3. Toggle the flag and observe the change
+
+See [Create First Feature Flag](references/1.5-first-flag.md) for detailed instructions.
+
+### Step 7: Recover
+
+If any step fails, diagnose the issue and resume.
+
+1. Identify the failed step and error
+2. Choose a recovery action
+3. Resume the workflow
+
+See [Recovery Procedures](references/1.6-recover.md) for detailed instructions.
+
+## Default follow-through (not numbered steps)
+
+Do these as part of finishing onboarding—same session when possible. They are **not** extra phases in the numbered workflow above; skip or defer only if the user declines or time runs out.
+
+**LaunchDarkly MCP**
+
+- Use MCP tools whenever they are available (flags, environments, validation).
+- If the MCP server is not configured, briefly offer optional setup; do **not** block completion of Steps 1–6 on it. See [MCP Server Setup](references/1.7-mcp-setup.md).
+
+**Setup summary (`LAUNCHDARKLY.md`)**
+
+- Generate the repo summary per [Onboarding Summary](references/1.8-summary.md). Ask permission before writing or committing.
+
+**Editor rules / skills**
+
+- Add editor-specific rules or skill hooks per [Editor Rules and Skills](references/1.9-editor-rules.md) so later agent sessions follow LaunchDarkly practices. Ask permission before writing or committing.
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| SDK already installed | Skip to Step 4 (Run) or Step 5 (Validate) |
+| Multiple languages in repo | Ask the user which target to integrate first (frontend vs backend vs mobile) |
+| Monorepo | Identify the specific package/service to integrate and work within that subtree |
+| No package manager detected | Ask the user which SDK they want to install and provide manual install instructions |
+| Application won't start | Use the recover step to diagnose; don't block on run if the user confirms the app runs separately |
+
+## What NOT to Do
+
+- Don't install an SDK without detecting the stack first
+- Don't hardcode SDK keys in source code — always use environment variables
+- Don't restructure the user's project or refactor existing code
+- Don't skip validation — always confirm the SDK is connected
+- Don't create flags before the SDK connection is validated
+
+## References
+
+**Core workflow (Steps 1-6, 7 recover)**
+
+- [Detect Repository Stack](references/1.0-detect.md) — How to identify language, framework, and existing SDK usage
+- [Generate Integration Plan](references/1.1-plan.md) — How to choose the right SDK and plan changes
+- [Apply Code Changes](references/1.2-apply.md) — How to install dependencies and add initialization code
+- [Start the Application](references/1.3-run.md) — How to run the app and confirm SDK initialization
+- [Validate SDK Connection](references/1.4-validate.md) — How to verify LaunchDarkly sees the SDK
+- [Create First Feature Flag](references/1.5-first-flag.md) — How to create, evaluate, and toggle a flag
+- [Recovery Procedures](references/1.6-recover.md) — How to diagnose failures and resume
+
+**Default follow-through**
+
+- [MCP Server Setup](references/1.7-mcp-setup.md) — Optional MCP installation when tools are missing
+- [Onboarding Summary](references/1.8-summary.md) — Template for `LAUNCHDARKLY.md`
+- [Editor Rules and Skills](references/1.9-editor-rules.md) — Editor rules for ongoing flag management
+
+**SDK index**
+
+- [SDK Recipes](references/sdk-recipes.md) — Detection patterns, install commands, and doc links for all SDKs
+- [SDK detail files](references/sdk-snippets/) — Per-SDK pointers (docs, samples, registries); ten files also include copy-paste onboarding samples (linked from each recipe in SDK Recipes)


### PR DESCRIPTION
## Summary

Adds the launchdarkly-sdk-onboarding agent skill,.a guided workflow to:
- detect the repo stack, pick the right LaunchDarkly SDK from SDK Recipes,
- install it
- initialize it
- run the app
- validate connectivity (sdk-active / API / documented UI fallback)
- create and toggle a first boolean flag
- recover when something fails.

Additional steps that are added:
- Prompt the user to install the MCP
- Documentation on the setup for the user to reference as part of the usage of the SDK
- Adding in agent-skills that are relevant for feature management

Bundled under the same skill root:

This change also includes sdk-recipes.md (stack → SDK index), and sdk-snippets/ (per-SDK doc links and onboarding-oriented samples where applicable) that are used to help guide the agent in initializing and installing the relevant SDK.

Together, skills/setup/ is the “wire LaunchDarkly into this codebase” setup domain for the repo’s agent skills. It should be accessible once it's published by running the `npx skills add launchdarkly/agent-skills onboarding -y` command

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- 
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12704: Implement Repo Evaluation Skill to Detect Likely Targets (Frontend/Backend)](https://launchdarkly.atlassian.net/browse/REL-12704)
<!-- end-ld-jira-link -->