### PR TITLE
[REL-13108] [nhironaka] OpenAI Codex listing compatibility

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/launchdarkly/mcp-server",
   "repository": "https://github.com/launchdarkly/mcp-server.git",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "launchdarkly",
     "feature-flags",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "LaunchDarkly",
     "url": "https://launchdarkly.com"
   },
-  "homepage": "https://github.com/launchdarkly/mcp-server",
-  "repository": "https://github.com/launchdarkly/mcp-server.git",
+  "homepage": "https://launchdarkly.com",
+  "repository": "https://github.com/launchdarkly/agent-skills.git",
   "license": "Apache-2.0",
   "keywords": [
     "launchdarkly",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "launchdarkly-mcp",
+  "version": "0.6.1",
+  "description": "Connect Codex to LaunchDarkly over MCP: AI Configs and feature management (FM) hosted endpoints, plus bundled guidance for using the tools.",
+  "author": {
+    "name": "LaunchDarkly",
+    "url": "https://launchdarkly.com"
+  },
+  "homepage": "https://github.com/launchdarkly/mcp-server",
+  "repository": "https://github.com/launchdarkly/mcp-server.git",
+  "license": "MIT",
+  "keywords": [
+    "launchdarkly",
+    "feature-flags",
+    "mcp",
+    "model-context-protocol",
+    "ai-configs"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "LaunchDarkly",
+    "shortDescription": "Feature flags, AI Configs, and environments via MCP.",
+    "longDescription": "Use LaunchDarkly’s hosted MCP servers for AI Configs and FM, or run the same surface locally with npx @launchdarkly/mcp-server (see repository README). Authenticate with your LaunchDarkly API access token when prompted.",
+    "developerName": "LaunchDarkly",
+    "category": "Developer tools",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://launchdarkly.com",
+    "defaultPrompt": [
+      "List my LaunchDarkly feature flags for this project.",
+      "Show AI Config targeting for the config I care about."
+    ],
+    "brandColor": "#3DD6F5"
+  }
+}


### PR DESCRIPTION
## Summary

Following https://developers.openai.com/codex/plugins/build for submission compatibility

## Testing

- [x] Not applicable
- [ ] Manual (describe below)

## Notes

- <!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/agent-skills/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
<!-- ld-jira-link -->
---
Related Jira issue: [REL-13108: [Tier 2] OpenAI Codex (recommended servers) — Ensure compatibility + outreach](https://launchdarkly.atlassian.net/browse/REL-13108)
<!-- end-ld-jira-link -->