### PR TITLE
REL-12704: port over the onboarding skill

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -54,6 +54,30 @@
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
     },
     {
+      "name": "apply",
+      "description": "Apply LaunchDarkly SDK onboarding: install dependency (or dual-SDK pair), configure env and secrets with consent, add init at entrypoint(s), verify compile. Nested under sdk-install; next is run.",
+      "path": "skills/onboarding/sdk-install/apply",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires integration plan and LaunchDarkly credentials (see parent onboarding)"
+    },
+    {
+      "name": "detect",
+      "description": "Detect repository stack for LaunchDarkly SDK onboarding: languages, frameworks, package managers, monorepo targets, entrypoints, existing LD usage. Nested under sdk-install; next is plan.",
+      "path": "skills/onboarding/sdk-install/detect",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires access to the project repository"
+    },
+    {
+      "name": "first-flag",
+      "description": "Create a boolean first flag, add evaluation, toggle on/off for end-to-end proof. Parent onboarding Step 6; uses MCP, API, or ldcli; optional flag-create skill.",
+      "path": "skills/onboarding/first-flag",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires SDK installed (parent Step 5) and LaunchDarkly project access"
+    },
+    {
       "name": "launchdarkly-flag-cleanup",
       "description": "Safely remove a feature flag from code while preserving production behavior. Use when the user wants to remove a flag from code, delete flag references, or create a PR that hardcodes the winning variation after a rollout is complete.",
       "path": "skills/feature-flags/launchdarkly-flag-cleanup",
@@ -151,6 +175,48 @@
       "version": "1.0.0-experimental",
       "license": "Apache-2.0",
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
+    },
+    {
+      "name": "mcp-configure",
+      "description": "Configure the LaunchDarkly hosted MCP server during onboarding. Use when the parent LaunchDarkly onboarding skill reaches Step 4 (MCP). Supports Cursor, Claude Code, Windsurf, GitHub Copilot, and other MCP-compatible agents. OAuth authentication; no API keys for the hosted server.",
+      "path": "skills/onboarding/mcp-configure",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires an MCP-compatible coding agent and a LaunchDarkly account"
+    },
+    {
+      "name": "onboarding",
+      "description": "Onboard a project to LaunchDarkly: kickoff roadmap, resumable log, explore repo, MCP, companion flag skills, nested SDK install (detect/plan/apply), first flag. Use when adding LaunchDarkly, setting up or integrating feature flags in a project, SDK integration, or 'onboard me'.",
+      "path": "skills/onboarding",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires an MCP-capable coding agent, `npx` on PATH for optional skill installs, and a LaunchDarkly account. SDK keys, client-side IDs, mobile keys, and API tokens are only needed when the step that uses them runs (see Prerequisites).",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feature-management",
+        "onboarding",
+        "sdk",
+        "mcp",
+        "getting-started",
+        "setup"
+      ]
+    },
+    {
+      "name": "plan",
+      "description": "Generate a minimal LaunchDarkly SDK integration plan from detected stack: choose SDK type(s), dual-SDK server+client when required, files to change, env conventions. Nested under sdk-install; follows detect, precedes apply.",
+      "path": "skills/onboarding/sdk-install/plan",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires completed or equivalent detect context (see sibling detect skill)"
+    },
+    {
+      "name": "sdk-install",
+      "description": "Install and initialize the correct LaunchDarkly SDK during onboarding by running nested skills in order: detect, plan, apply. Parent onboarding Step 6 is first flag.",
+      "path": "skills/onboarding/sdk-install",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires a supported language/framework in the project. SDK credentials are required by [Apply](apply/SKILL.md), not for [Detect](detect/SKILL.md) / [Plan](plan/SKILL.md) alone (see parent onboarding **Prerequisites**)."
     }
   ]
 }

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: onboarding
+description: "Onboard a project to LaunchDarkly: kickoff roadmap, resumable log, explore repo, MCP, companion flag skills, nested SDK install (detect/plan/apply), first flag. Use when adding LaunchDarkly, setting up or integrating feature flags in a project, SDK integration, or 'onboard me'."
+license: Apache-2.0
+compatibility: Requires an MCP-capable coding agent, `npx` on PATH for optional skill installs, and a LaunchDarkly account. SDK keys, client-side IDs, mobile keys, and API tokens are only needed when the step that uses them runs (see Prerequisites).
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly SDK Onboarding
+
+Orchestrates LaunchDarkly setup in an existing codebase: on kickoff, show a **roadmap** in chat (see [Kickoff: onboarding roadmap](#kickoff-onboarding-roadmap)); **Step 0** writes a living onboarding log so a new session or the user can resume; then explore the project, detect the agent, install flag-management skills, **configure the LaunchDarkly MCP server early**, install and initialize the SDK (**sdk-install** and nested detect/plan/apply), and create a **first feature flag**. Nested skills: [mcp-configure](mcp-configure/SKILL.md), [sdk-install](sdk-install/SKILL.md), [first-flag](first-flag/SKILL.md).
+
+## Prerequisites
+
+- **`npx`:** Available on PATH when using `npx skills add` to install companion skills (see Step 3).
+- **LaunchDarkly account (outset only):** Early in onboarding -- right after the [Kickoff roadmap](#kickoff-onboarding-roadmap) if the log does not already say -- ask **only** whether the user already has a LaunchDarkly account (they can sign in at [https://app.launchdarkly.com](https://app.launchdarkly.com)). **Do not** ask in the same turn for SDK keys, client-side IDs, mobile keys, API access tokens, or whether keys are in env; defer those until the step that needs them (below).
+  - **If they do not have an account yet:** Point them to https://app.launchdarkly.com/signup?source=agent. Continue with repo exploration, agent detection, and companion skills where those do not require LaunchDarkly API access; MCP OAuth and SDK work wait on account access.
+  - **If they have an account:** Proceed through the workflow. Still **do not** prompt for SDK key material until **Step 5** [Apply code changes](sdk-install/apply/SKILL.md) (or until **run** if they prefer to paste into env later).
+- **Keys and tokens (defer -- do not bundle with the account question):** Collect these only when the path requires them -- never as part of the initial "do you have an account?" prompt.
+  - **Step 4 -- MCP:** **Hosted MCP** uses OAuth; no API token or SDK key needed to configure it. **Local `npx` MCP** (federal/EU, etc.): API access token per [mcp-configure](mcp-configure/SKILL.md) and [MCP Config Templates](mcp-configure/references/mcp-config-templates.md).
+  - **Step 5 -- SDK:** **SDK keys / client-side ID / mobile key** when wiring env in [Apply code changes](sdk-install/apply/SKILL.md), after the integration plan is confirmed. **`ldcli` / REST** for discovery: use **`ldcli login`** or an access token when you first run those commands, not at hello.
+  - **Key type must match the integration:** server-side SDK -> **SDK key**; browser/client-side SDK -> **Client-side ID**; mobile -> **Mobile key**. Env variable names and bundler rules: [Apply code changes](sdk-install/apply/SKILL.md).
+
+**MCP (preferred):** Complete **Step 4** via [mcp-configure/SKILL.md](mcp-configure/SKILL.md) before SDK work when possible. If MCP is unavailable or the user opts out, use **ldcli** / **REST** fallbacks described in that skill (including [MCP Config Templates](mcp-configure/references/mcp-config-templates.md) for local `npx` fallback when hosted MCP does not apply) -- onboarding must still be completable.
+
+**Optional MCP tools (when configured):**
+
+- `get-environments` -- list environments for a project; the response includes SDK keys, client-side IDs, and mobile keys per environment. **Use this as the single source for all key types** -- do not make separate requests for individual keys.
+- `create-feature-flag` -- create the boolean flag for [Step 6: Create Your First Feature Flag](#step-6-create-your-first-feature-flag).
+- `update-feature-flag` -- toggle or patch flag configuration during Step 6; see [Create first feature flag](first-flag/SKILL.md) for ldcli/API fallbacks.
+
+**Other MCP tools you may use if present** (not required): `list-feature-flags`, `get-feature-flag`, `get-flag-status-across-environments`.
+
+## Agent Behavior Directives
+
+### Progress Tracking
+
+The roadmap (Steps 0-6 + follow-through) MUST be tracked using your agent's native task-tracking tool in addition to the onboarding log file.
+
+- **Cursor:** Use `TodoWrite` to create a todo for each step before beginning work. Update status as each step completes.
+- **Claude Code:** Use `TaskCreate` to create a task for each step (or `TodoWrite` if native tasks are unavailable).
+- **Other agents:** If your agent provides a native task list or progress tracking tool, use it. If not, present a numbered checklist in chat and update it after each step.
+
+Do NOT work through steps mentally or rely solely on the `LAUNCHDARKLY_ONBOARDING.md` log for in-session tracking.
+
+### Decision Points
+
+When a step requires user input to determine branching, you MUST collect the answer by calling a tool — do NOT write the question as prose text in your response.
+
+**Call the tool directly.** Use the first tool from this list that
+your environment provides:
+
+1. `AskQuestion` — call it with a `prompt` and `options` array
+2. `TaskAsk` or equivalent structured-input tool
+3. (fallback) If the tool call fails or no such tool exists, THEN
+   render the question as numbered options in text and wait.
+
+Do NOT decide in advance whether you have the tool. Attempt the call. The tool call IS the question — do not also write the question as text.
+
+Throughout this skill and its nested skills you will see decision-point markers formatted like this:
+
+```
+**D1 -- BLOCKING:** <instruction to call your question tool>
+- question: "<the question>"
+- options:
+  - "<option A>" -> <what happens>
+  - "<option B>" -> <what happens>
+- STOP. Do not continue until the user selects an option.
+```
+
+These are **instructions for you to follow**, not content to display. When you reach one: make the tool call (or render numbered options if no tool exists), then STOP and wait. Do NOT copy the marker text into your response.
+
+### User-Facing Communication
+
+Every reply during onboarding must sound like a friendly, knowledgeable colleague walking someone through setup — not a workflow engine quoting internal instructions. Follow these rules in all user-facing output:
+
+**Required response structure.** Every substantive onboarding reply must include:
+
+1. **What we just did** — one or two sentences summarizing the completed action and its result.
+2. **What we're doing next** — a plain-English preview of the next step.
+3. **What you need to do** (only when the user has a manual action) — a concrete instruction, not a vague label like "Your turn." Include **where** to perform the action (e.g. "in Cursor's integrated terminal," "in the project folder," "in your browser," "in macOS Terminal").
+
+**Forbidden in user-facing output:**
+
+- Internal decision-point IDs (D1, D5, D7, etc.), step numbers as labels (e.g. "Step 5 -- detect"), or skill file names (e.g. "sdk-install/apply/SKILL.md").
+- Quoting or paraphrasing raw skill instructions, directive headings, or markdown from these files.
+- Workflow-engine language ("BLOCKING," "STOP," "call your structured question tool," "proceed to the next nested skill").
+
+**When telling the user to run a command**, always say **where** to run it. Good examples:
+- "Run this in the integrated terminal in your editor"
+- "Run this from the project root in your terminal"
+- "Open a terminal in the `packages/api` folder and run …"
+
+Bad: "Run `npm install`" (without location context).
+
+**Tone:** Friendly, conversational, and confident — like a knowledgeable colleague, not a manual. Use first person naturally (e.g. "I just detected that the flag was created, now I'm going to …"). Assume the reader is an engineer so don't over-explain basic concepts (what a package manager is, what an environment variable does), but do explain LaunchDarkly-specific concepts briefly on first mention (what a context is, what an SDK key is for, why there are different key types).
+
+### Step Execution Rules
+
+Do NOT treat the user's initial request (e.g. "onboard me," "set up LaunchDarkly") as blanket permission for file writes, installs, or configuration changes. Each action that modifies the repo, installs packages, or writes secrets requires its own consent at the step where it occurs.
+
+**Blocking decision points** (you MUST halt and wait for the user's response before continuing):
+
+| ID | Location | Question |
+|----|----------|----------|
+| D1 | Kickoff | Do you have a LaunchDarkly account? |
+| D4-LOCAL | Step 4 (local MCP) | User chooses whether to handle the access token themselves (recommended) or let the agent help |
+| D5-NOAPP | Step 5 -- detect | No runnable app found: user points to app or requests demo |
+| D5-UNCLEAR | Step 5 -- detect | Weak evidence: user confirms the correct app folder |
+| D5 | Step 5 -- detect | SDK confirmation / one-vs-both-SDKs scope choice |
+| D6 | Step 5 -- plan | Approve the integration plan before any code changes |
+| D7 | Step 5 -- apply | User chooses how secrets are set up: user-specified location, user handles it, or `.env` fallback |
+| D8 | Step 5 -- apply | Approval before changing non-LaunchDarkly dependencies |
+| D9 | Step 6 | Auth errors (401/403): stop, do not retry automatically |
+
+**Non-blocking** (you may proceed automatically): Step 0 onboarding log (write it directly), Step 1 exploration (read-only), Step 3 skill install (installs to agent config, not the user's repo), Step 5 detect (file reads only), compile check (Step 5 apply Step 4), follow-through file writes (`LAUNCHDARKLY.md`, editor rules).
+
+## Core Principles
+
+1. **Detect, don't guess:** Inspect the repo for language, framework, and package manager.
+2. **Minimal changes:** Add SDK code alongside existing code; don't restructure the project.
+3. **Match existing patterns:** Follow env vars, config files, and initialization patterns already in use.
+4. **Validate end-to-end:** Confirm the SDK is connected before treating the first flag as proof of success.
+5. **Paper trail:** Keep the Step 0 onboarding log current so another agent or session can continue without re-deriving context.
+6. **Orient the user first:** On a fresh onboarding request, show the [Kickoff roadmap](#kickoff-onboarding-roadmap) before substantive work so the user knows the full arc.
+7. **Stage credential questions:** Confirm **account** at the outset; ask for **SDK keys / tokens** only in Step 4-5 when that step's skill says they are required ([Prerequisites](#prerequisites)).
+8. **Deep-link to the dashboard:** When generating LaunchDarkly dashboard URLs and the **project key** and/or **environment key** are known (from MCP tools, user input, or the onboarding log), construct the most specific URL possible instead of linking to a generic page. Use these patterns:
+
+   | What you need to show | URL pattern |
+   |-----------------------|-------------|
+   | Project flags list | `https://app.launchdarkly.com/projects/{projectKey}/flags` |
+   | Specific flag | `https://app.launchdarkly.com/projects/{projectKey}/flags/{flagKey}` |
+   | Environment keys / SDK keys | `https://app.launchdarkly.com/projects/{projectKey}/settings/environments/{envKey}/keys` |
+   | Project environments list | `https://app.launchdarkly.com/projects/{projectKey}/settings/environments` |
+   | All projects | `https://app.launchdarkly.com/projects` |
+
+   Only generate deep links when the required keys are known from tool responses or confirmed user input. If they are unknown, use the most specific generic path available and tell the user how to navigate from there (e.g. "Open your project in the LaunchDarkly dashboard, then go to **Settings > Environments** to find your SDK key").
+
+## Kickoff: onboarding roadmap
+
+When the user invokes this onboarding flow (for example by asking you to follow this skill, run LaunchDarkly onboarding, or set up feature flags in the project), treat it as a **fresh kickoff** unless you are clearly resuming (see **Resuming** below).
+
+### Kickoff sequence (new run — before any numbered step)
+
+Perform these in **order** in the **same assistant turn**, then **stop at D1** until the user answers:
+
+1. **Task list:** Call your native task tool ([Progress Tracking](#progress-tracking)) and create **one task per step for Steps 0 through 6** (seven tasks minimum — one for each numbered row in the table below). Do this **before** rendering the roadmap table so progress tracking is in place before you pause on D1.
+2. **Roadmap:** Render the roadmap table below in the user-visible reply (adjust row wording only if an [Edge case](#edge-cases) will obviously skip a step). The roadmap is a chat artifact only -- **do not** create a file for it unless the user asks.
+3. **D1:** Call your structured question tool for the account question (see **D1** below). **Do not** create or update `LAUNCHDARKLY_ONBOARDING.md`, explore the repo for Step 1, detect the agent for Step 2, or run **`npx`** (or any shell install) for Step 3 until the user has answered D1.
+
+- **Resuming:** If `LAUNCHDARKLY_ONBOARDING.md` already exists, read it first per [Step 0](#step-0-create-or-refresh-the-onboarding-log). Show the same roadmap with a **Status** column filled from the log, or a shorter "where we are" summary -- whichever keeps the user oriented. Refresh the task list to match the log if needed; if D1 (account status) is already recorded in the log, **do not** ask D1 again -- continue from the log's **Next step**.
+
+| Step | What happens | You get |
+|------|--------------|---------|
+| **0** -- Onboarding log | Create or refresh `LAUNCHDARKLY_ONBOARDING.md` (or `docs/...`) | Resumable checklist, context, next-step pointer |
+| **1** -- Explore project | Detect language, framework, existing LD usage, environment type | Stack summary for the user |
+| **2** -- Detect agent | Cursor, Claude Code, Copilot, etc. | Correct `--agent` for `npx skills add` |
+| **3** -- Companion skills | `npx skills add ...` flag skills from `launchdarkly/agent-skills` | `launchdarkly-flag-*` skills available |
+| **4** -- MCP | Configure LaunchDarkly MCP; user restarts; agent auto-verifies on next turn | MCP tools (or ldcli/API fallback) |
+| **5** -- SDK install | detect -> plan -> apply ([sdk-install](sdk-install/SKILL.md)) | Packages + init wired to env vars |
+| **6** -- First flag | Create boolean flag, evaluate, toggle, add interactive demo ([first-flag](first-flag/SKILL.md)) | End-to-end proof + visible "wow" moment |
+| **Follow-through** | Optional: `LAUNCHDARKLY.md`, editor rules ([1.8-summary](references/1.8-summary.md), [1.9-editor-rules](references/1.9-editor-rules.md)) | Durable docs for the repo |
+
+**D1 -- BLOCKING** (end of kickoff sequence): Call your structured question tool now.
+
+- question: "Do you already have a LaunchDarkly account you can sign into?"
+- options:
+  - "Yes, I have an account" -> proceed through full workflow
+  - "No / not yet" -> point to https://app.launchdarkly.com/signup?source=agent, continue Steps 1-3 only
+- STOP. Do not write the question as text. Do not continue until the user selects an option.
+
+If they need an account, point them to https://app.launchdarkly.com/signup?source=agent and explain which later steps (MCP, SDK keys) will wait on it. Then proceed with [Step 0](#step-0-create-or-refresh-the-onboarding-log) (or the log's **Next step** if resuming).
+
+## Workflow
+
+Follow **Steps 0-6** in order unless an **Edge case** says otherwise. When **Step 6** (first flag) completes successfully, continue with [Default follow-through](#default-follow-through-not-numbered-steps).
+
+### Step 0: Create or Refresh the Onboarding Log
+
+Before substantive work, give this run a **durable paper trail** so a new agent or a later session can see what was decided, what ran, and what is next.
+
+1. **Look for an existing log** at the repo root: `LAUNCHDARKLY_ONBOARDING.md`. If the project keeps docs under `docs/`, prefer `docs/LAUNCHDARKLY_ONBOARDING.md` when that folder already exists and the root file is absent.
+2. **Create or update the log file.** This is part of the onboarding workflow -- write it directly without asking for permission.
+3. **If resuming:** read the log first, align with the stated **next step**, and only redo work the log marks incomplete or invalid.
+4. **What to write** (update after each numbered step finishes or when something important changes):
+   - **Checklist:** Steps 0-6 with status (`not started` / `in progress` / `done` / `skipped` + brief reason).
+   - **Context:** coding agent id (once known), language/framework summary, monorepo target path if any, LaunchDarkly **project key** and **environment key** when known (never paste secrets or full SDK keys -- say "stored in env" or "user provided offline").
+   - **MCP:** configured yes/no, hosted vs fallback, link to config path if relevant.
+   - **Commands run:** e.g. `npx skills add ...` (no secrets).
+   - **Blockers / errors:** what failed and what was tried.
+   - **Next step:** single explicit step number and name (e.g. "Step 5: Install and Initialize the SDK").
+5. **After errors:** append or edit the log with what broke and where you are resuming.
+
+This file is a **working** log during onboarding. After success, the user may delete it, archive it, or fold facts into `LAUNCHDARKLY.md` ([Onboarding Summary](references/1.8-summary.md)).
+
+### Step 1: Explore the Project
+
+Understand what you are integrating before installing packages.
+
+1. **Identify language and framework.** Check dependency files: `package.json`, `go.mod`, `requirements.txt` / `pyproject.toml` / `Pipfile`, `pom.xml` / `build.gradle`, `Gemfile`, `*.csproj` / `*.sln`, `Cargo.toml`, etc.
+2. **Check for existing LaunchDarkly usage.** Search for `launchdarkly`, `ldclient`, `ld-client`, `LDClient`, `@launchdarkly`.
+   - If already present: note SDK version and patterns; you may shorten or skip [Step 5](#step-5-install-and-initialize-the-sdk) per edge cases.
+   - If not present: plan full SDK setup.
+3. **Identify environment type:** server-side app, client SPA, mobile, edge, etc. -- this drives SDK choice.
+4. **Summarize to the user:** language, framework, environment type, whether LD is already integrated.
+
+Deep detection details: [Detect repository stack](sdk-install/detect/SKILL.md) (nested under [sdk-install](sdk-install/SKILL.md)).
+
+### Step 2: Detect the Agent Environment
+
+Determine which coding agent is running so MCP config and `npx skills add --agent` use the right target. **Infer the agent silently — do not ask the user.**
+
+1. Check for indicators (in priority order — stop at the first strong match):
+   - **Cursor:** `.cursor/`, `.cursorrules`, or `CURSOR_` env vars
+   - **Claude Code:** `~/.claude/`, `CLAUDE.md`, or `CLAUDE_` env vars
+   - **Windsurf:** `.windsurfrules`
+   - **GitHub Copilot:** `.github/copilot/`
+   - **Codex:** `~/.codex/`, `AGENTS.md`
+
+2. If multiple indicators are present, pick the one whose runtime you are **currently executing inside** (e.g. if you have access to Cursor-specific tools like `AskQuestion` or `TodoWrite`, you are in Cursor). If none of the indicators match, default to the agent whose tool surface you observe at runtime.
+
+3. Remember the agent id for Step 3 (e.g. `cursor`, `claude-code`). Mention the detected agent briefly when presenting the Step 1/2 summary so the user can correct you if wrong, but do not block on a question.
+
+### Step 3: Install Companion Skills
+
+Install flag-management skills from the public repo so later steps can delegate when appropriate (see **Bundled vs public** below).
+
+**From `launchdarkly/agent-skills` (flag workflows):**
+
+```bash
+npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create launchdarkly-flag-discovery launchdarkly-flag-targeting launchdarkly-flag-cleanup -y --agent <detected-agent>
+```
+
+Replace `<detected-agent>` with the value from Step 2. Confirm success; skip skills already installed.
+
+**Bundled vs public:** Orchestration and setup for this flow live **in this folder** -- parent [SKILL.md](SKILL.md), nested [mcp-configure](mcp-configure/SKILL.md), [sdk-install](sdk-install/SKILL.md) (detect / plan / apply), [first-flag](first-flag/SKILL.md), and `references/` ([SDK recipes](references/sdk/recipes.md), [snippets](references/sdk/snippets/), summary, editor rules, etc.). The command above installs **flag-management** skills from the public [launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) repo only.
+
+### Step 4: Configure the MCP Server
+
+Hand off to [mcp-configure/SKILL.md](mcp-configure/SKILL.md) for setup (hosted MCP, quick install, manual JSON, agent authorization).
+
+MCP setup requires the user to act outside the agent (clicking a quick-install link, completing OAuth, enabling the server in editor settings). After presenting the instructions, **tell the user to restart or refresh the agent** so MCP tools become available. Then continue to Step 5 — do not block here with a confirmation question.
+
+**Auto-verify on next turn:** When the conversation resumes (after the user restarts or sends a message), probe for MCP by calling a lightweight MCP tool such as `list-feature-flags` with the known project key. If the tool responds normally, MCP is live — note it in the onboarding log and use MCP tools for later steps. If the call fails or no MCP tools are visible, fall back silently to ldcli/API for Steps 5-6 and note the fallback in the onboarding log. **Do not ask** the user whether MCP is working — find out by trying it.
+
+Do not duplicate MCP procedures in this file. Do not block Step 5 indefinitely on MCP.
+
+### Step 5: Install and Initialize the SDK
+
+If the project **already has LaunchDarkly installed and initialized** (see [detect decision tree](sdk-install/detect/SKILL.md#decision-tree)), skip to [Step 6: Create Your First Feature Flag](#step-6-create-your-first-feature-flag).
+
+Otherwise hand off to [LaunchDarkly SDK Install (onboarding)](sdk-install/SKILL.md), which runs nested skills in order: [Detect repository stack](sdk-install/detect/SKILL.md) -> [Generate integration plan](sdk-install/plan/SKILL.md) -> [Apply code changes](sdk-install/apply/SKILL.md), using [SDK recipes](references/sdk/recipes.md) and [SDK snippets](references/sdk/snippets/). If the user asked for **both** server and client (e.g. API + SPA, Next.js server + browser), follow [Dual SDK integrations](sdk-install/plan/SKILL.md#dual-sdk-integrations) through plan and apply so **both** SDKs are really installed and initialized.
+
+**Blocking decision points inside Step 5** (see nested skills): D5 (SDK scope), D6 (plan approval), D7 (secret consent), D8 (dependency changes). Do NOT batch tool calls across these boundaries.
+
+### Step 6: Create Your First Feature Flag
+
+Create and evaluate a boolean flag; toggle and observe end-to-end.
+
+1. Follow [Create first feature flag](first-flag/SKILL.md).
+2. If the **`launchdarkly-flag-create`** skill (installed in Step 3) is available, you may use it for create/evaluation wiring **only** while still completing the verify/toggle checklist in [Create first feature flag](first-flag/SKILL.md). Onboarding must remain completable without it.
+
+Install or refresh flag skills via:
+
+`npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <detected-agent>`
+
+See D9 in [first-flag](first-flag/SKILL.md) for the blocking stop on auth errors.
+
+## Default follow-through (not numbered steps)
+
+Do these when finishing onboarding -- same session when possible. They are **documentation and handoff** tasks, not repeats of Steps 0-6. **Do not skip this section** -- it is the primary deliverable the user keeps after onboarding.
+
+**Setup summary (`LAUNCHDARKLY.md`) -- REQUIRED**
+
+Generate the repo summary per [Onboarding Summary](references/1.8-summary.md). Write it directly -- this is part of the onboarding workflow. The generated `LAUNCHDARKLY.md` **must** include all of the following (see template in that reference):
+
+1. **SDK Details** -- which SDK(s) are installed, package names, key types, initialization files
+2. **Configuration** -- env var names, how secrets are managed, bundler-specific conventions
+3. **Where to Find Things** -- dashboard links with real project key substituted
+4. **How Feature Flags Work** -- a language-specific code example showing flag evaluation in this project's stack (not a generic snippet -- use the same pattern the agent wired during Step 5)
+5. **Next Steps / Advanced Capabilities** -- links to Percentage Rollouts, Targeting Rules, Experimentation, AI Configs, Guarded Rollouts, and Observability
+6. **AI Agent Integration** -- MCP server setup for continued agent-driven flag management
+
+This is **not** the same file as `LAUNCHDARKLY_ONBOARDING.md`. The onboarding log is a working checklist; `LAUNCHDARKLY.md` is the **permanent reference** for the team.
+
+**Clean up the onboarding log:** After writing `LAUNCHDARKLY.md`, **delete** `LAUNCHDARKLY_ONBOARDING.md` (or `docs/LAUNCHDARKLY_ONBOARDING.md` if that was the location used). This is part of the workflow -- do not ask for permission. Removing the working log avoids confusion from having two LaunchDarkly docs in the repo.
+
+**Editor rules / skills**
+
+- Add editor-specific rules or skill hooks per [Editor Rules and Skills](references/1.9-editor-rules.md). Write them directly -- this is part of the onboarding workflow.
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| SDK already installed **and** initialized (see [detect decision tree](sdk-install/detect/SKILL.md#decision-tree)) | Skip **Step 5**; go to **Step 6** (First flag) |
+| SDK in dependencies **but** not initialized | Continue **Step 5** from [apply](sdk-install/apply/SKILL.md) / init (see [sdk-install](sdk-install/SKILL.md)); do not skip validation |
+| SDK state unclear | Re-run [Detect repository stack](sdk-install/detect/SKILL.md), then follow its decision tree |
+| No runnable app found or app target unclear | Follow the workspace classification in [Detect: classify workspace confidence](sdk-install/detect/SKILL.md#5a-classify-workspace-confidence) — ask the user to point to the real app or offer to create a demo. Do not proceed to plan or apply without a confirmed app target. |
+| Multiple languages in repo | **Blocking (D5):** use question tool to ask which target to integrate first -- do not guess |
+| User wants **both** frontend and backend (or server + browser) in the same target | [Dual SDK plan](sdk-install/plan/SKILL.md#dual-sdk-integrations): two packages, two entrypoints, two inits; [apply](sdk-install/apply/SKILL.md) must complete **both** tracks |
+| Monorepo | **Blocking (D5):** use question tool to ask which package/service to integrate -- do not assume the root |
+| No package manager detected | **Blocking (D5):** use question tool to ask which SDK to install; provide manual install instructions from [SDK recipes](references/sdk/recipes.md) |
+| Companion flag skills already installed (Step 3) | Skip re-running `npx skills add` for those skill names |
+| Resuming after a break or new agent session | Read `LAUNCHDARKLY_ONBOARDING.md` (Step 0); continue from **Next step**; refresh the log as you go |
+| MCP configuration fails or user declines MCP | Continue with **Step 5** using ldcli/API/dashboard per [mcp-configure](mcp-configure/SKILL.md); note limitation for flag tooling |
+| User / repo already fully onboarded | Summarize state from Step 0 log and repo; offer next steps without redoing completed steps |
+
+## What NOT to Do
+
+- Don't install an SDK without exploring the project and detecting the stack (Steps 1 and 5); keep the Step 0 log updated as you go.
+- Don't upgrade, pin, or add **non-LaunchDarkly** dependencies (peer-deps, lockfile churn, "latest" bumps) to install or compile the SDK without **explicit user approval** -- see [Apply -- Permission before changing other dependencies](sdk-install/apply/SKILL.md#permission-before-changing-other-dependencies).
+- Don't hardcode SDK keys in source code -- always use environment variables (see [Apply code changes](sdk-install/apply/SKILL.md)).
+- Don't restructure the user's project or refactor unrelated code.
+- Don't create flags before **Step 5** (SDK install) completes.
+- Don't write decision-point questions as chat text -- use your structured question tool (see [Decision Points](#decision-points)).
+
+## References
+
+**Continuity**
+
+- Step 0 -- `LAUNCHDARKLY_ONBOARDING.md` (working log; see [Step 0](#step-0-create-or-refresh-the-onboarding-log))
+
+**Step 4 -- MCP (nested skill is primary)**
+
+- [mcp-configure/SKILL.md](mcp-configure/SKILL.md) -- hosted MCP, verify, edge cases (**follow this first**)
+- [MCP UI links](mcp-configure/references/mcp-ui-links.md) -- HTTPS + `command:` links to open MCP settings per editor
+- [MCP Config Templates](mcp-configure/references/mcp-config-templates.md) -- per-agent JSON; **Local server via `npx`** when hosted MCP is unavailable
+
+**Step 5 -- SDK install (nested skills)**
+
+- [sdk-install/SKILL.md](sdk-install/SKILL.md) -- orchestrates **detect -> plan -> apply** (**follow this first**)
+- [Detect repository stack](sdk-install/detect/SKILL.md)
+- [Generate integration plan](sdk-install/plan/SKILL.md)
+- [Apply code changes](sdk-install/apply/SKILL.md)
+
+**First flag (Step 6)**
+
+- [Create first feature flag](first-flag/SKILL.md)
+
+**Default follow-through**
+
+- [Onboarding Summary](references/1.8-summary.md) -- template for `LAUNCHDARKLY.md`
+- [Editor Rules and Skills](references/1.9-editor-rules.md)
+
+**SDK index**
+
+- [SDK recipes](references/sdk/recipes.md)
+- [SDK snippets](references/sdk/snippets/)
+
+**Public flag skills (install via Step 3)**
+
+- [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) -- `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, `launchdarkly-flag-cleanup`

--- a/skills/onboarding/first-flag/SKILL.md
+++ b/skills/onboarding/first-flag/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: launchdarkly-onboarding-first-flag
+description: "Create a boolean first flag, add evaluation, toggle on/off for end-to-end proof. Parent onboarding Step 6; uses MCP, API, or ldcli; optional flag-create skill."
+license: Apache-2.0
+compatibility: Requires SDK installed (parent Step 5) and LaunchDarkly project access
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# Create first feature flag
+
+The SDK is connected. Now help the user create their first feature flag and see it work end-to-end.
+
+This skill is nested under [LaunchDarkly onboarding](../SKILL.md); the parent **Step 6** is **first flag**. **Prior:** [Apply code changes](../sdk-install/apply/SKILL.md).
+
+**Optional -- Flag Create skill already installed:** If the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) is available in the session (install with `npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <agent>`), you may use it for **creating the flag** and **choosing evaluation code** that matches the repo. You must still complete **default off -> verify OFF -> toggle on -> verify ON** (Steps 3-5 below). **Do not** require that skill: this page stays the full fallback when it is missing or MCP-only flows conflict with the user's setup.
+
+## Security: Credential handling
+
+**Never substitute literal token values into commands.** Use environment variable references instead:
+
+- Shell commands: `$LAUNCHDARKLY_ACCESS_TOKEN` (expanded by the shell, not visible in `ps` output)
+- Set the variable in your session: `export LAUNCHDARKLY_ACCESS_TOKEN=<your-token>`
+
+This prevents tokens from appearing in process lists, shell history, and screen recordings.
+
+## Step 0: Consult SDK flag-key guidance
+
+Before creating the flag or wiring evaluation code, check the [Flag key behavior by SDK](#flag-key-behavior-by-sdk) table below. Some SDKs transform flag keys before exposing them in application code (e.g. the React SDK camelCases kebab-case keys). The flag key you create in LaunchDarkly, the SDK/framework configuration, and the key you reference in code must all align.
+
+- **If the SDK transforms keys** (e.g. React `useFlags()` camelCases `my-first-flag` → `myFirstFlag`): generate evaluation code using the **transformed** key. The flag key in LaunchDarkly stays as-is (kebab-case is conventional).
+- **If the SDK preserves keys as-is** (most server-side SDKs): use the exact LaunchDarkly flag key string in code.
+- **If the SDK supports both modes** (e.g. React allows disabling camelCase via provider options): decide which mode the project uses (check existing code or provider config), then generate code that matches.
+
+### Flag key behavior by SDK
+
+| SDK | Key transformation | Code key for `my-first-flag` | Notes |
+|-----|--------------------|------------------------------|-------|
+| React Web (`useFlags()`) | camelCase by default | `myFirstFlag` | `reactOptions: { useCamelCaseFlagKeys: false }` on the provider disables this |
+| React Native (`useFlags()`) | camelCase by default | `myFirstFlag` | Same `reactOptions` override available |
+| Vue (`useLDFlag()`) | None (pass original key) | `'my-first-flag'` | |
+| JavaScript Browser | None | `'my-first-flag'` | |
+| Node.js Server | None | `'my-first-flag'` | |
+| Python Server | None | `'my-first-flag'` | |
+| Go Server | None | `"my-first-flag"` | |
+| Java Server | None | `"my-first-flag"` | |
+| .NET Server | None | `"my-first-flag"` | |
+| Ruby Server | None | `'my-first-flag'` | |
+| Swift/iOS | None | `"my-first-flag"` | |
+| Android | None | `"my-first-flag"` | |
+| Flutter | None | `'my-first-flag'` | |
+
+When wiring the evaluation code in Step 2 below, use the **Code key** column value, not the raw LaunchDarkly key, whenever the SDK applies a transformation.
+
+## Step 1: Create the flag
+
+**REST / curl auth:** Use `$LAUNCHDARKLY_ACCESS_TOKEN` as the `Authorization` header value (LaunchDarkly uses the raw token, no `Bearer` prefix). The shell expands the variable but doesn't log it.
+
+### Via MCP (preferred)
+
+If the LaunchDarkly MCP server is available, use `create-feature-flag` (or the equivalent flag-creation tool your server exposes):
+
+- **Key**: `my-first-flag` (or a name relevant to the user's project)
+- **Name**: "My First Flag"
+- **Kind**: `boolean`
+- **Variations**: `true` / `false`
+- **Temporary**: `true`
+
+### Via LaunchDarkly API
+
+```bash
+curl -s -X POST \
+  "https://app.launchdarkly.com/api/v2/flags/PROJECT_KEY" \
+  -H "Authorization: $LAUNCHDARKLY_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My First Flag",
+    "key": "my-first-flag",
+    "kind": "boolean",
+    "variations": [
+      {"value": true},
+      {"value": false}
+    ],
+    "temporary": true
+  }'
+```
+
+### Via ldcli
+
+```bash
+ldcli flags create \
+  --access-token "$LAUNCHDARKLY_ACCESS_TOKEN" \
+  --project PROJECT_KEY \
+  --data '{"name": "My First Flag", "key": "my-first-flag", "kind": "boolean", "temporary": true}'
+```
+
+After creation, the flag starts with **targeting OFF**, serving the off variation (`false`) to everyone. When the project key is known, link the user to the flag's dashboard page: **`https://app.launchdarkly.com/projects/{projectKey}/flags/my-first-flag`** (substitute the real project key).
+
+## Step 2: Add flag evaluation code
+
+Add code to evaluate the flag in the application. Place this where it makes sense for the user's feature.
+
+### Server-side examples
+
+```javascript
+// Node.js (@launchdarkly/node-server-sdk) -- ldClient is your initialized server client after waitForInitialization
+const context = { kind: 'user', key: 'example-user-key', name: 'Example User' };
+const showFeature = await ldClient.boolVariation('my-first-flag', context, false);
+
+if (showFeature) {
+  console.log('Feature is ON');
+} else {
+  console.log('Feature is OFF');
+}
+```
+
+```python
+# Python (launchdarkly-server-sdk) -- client is ldclient.get() after set_config
+from ldclient import Context
+
+context = Context.builder("example-user-key").name("Example User").build()
+show_feature = client.variation("my-first-flag", context, False)
+
+if show_feature:
+    print("Feature is ON")
+else:
+    print("Feature is OFF")
+```
+
+```go
+// Go
+context := ldcontext.NewBuilder("example-user-key").Name("Example User").Build()
+showFeature, _ := ldClient.BoolVariation("my-first-flag", context, false)
+
+if showFeature {
+    fmt.Println("Feature is ON")
+} else {
+    fmt.Println("Feature is OFF")
+}
+```
+
+### Client-side examples
+
+```tsx
+// React — useFlags() camelCases keys: "my-first-flag" → myFirstFlag (see Step 0 table)
+import { useFlags } from 'launchdarkly-react-client-sdk';
+
+function MyComponent() {
+  const { myFirstFlag } = useFlags();
+
+  return (
+    <div>
+      {myFirstFlag ? <p>Feature is ON</p> : <p>Feature is OFF</p>}
+    </div>
+  );
+}
+```
+
+The React SDK's `useFlags()` hook camelCases kebab-case flag keys by default, so `my-first-flag` becomes `myFirstFlag`. If the project disables this via `reactOptions: { useCamelCaseFlagKeys: false }` on the provider, use the original key string instead. Always check the project's provider configuration before choosing which form to use — see the [Flag key behavior table](#flag-key-behavior-by-sdk) above.
+
+## Step 3: Verify the default value
+
+With targeting OFF, the flag should evaluate to `false`. Run the application and confirm:
+
+```
+Feature is OFF
+```
+
+## Step 4: Toggle the flag on
+
+### Via MCP
+
+The LaunchDarkly MCP server exposes **`update-feature-flag`** (JSON Patch), not a tool named `toggle-flag` -- use the tool names your MCP server lists.
+
+**Simplest path:** Prefer **ldcli** or the **LaunchDarkly API** block below when you only need to turn the flag on once.
+
+**If using `update-feature-flag`:** Call it with `projectKey`, `featureFlagKey`, and `PatchWithComment.patch` as a JSON Patch array. Turning the flag **on** for an environment typically uses a `replace` operation on that environment's `on` field (confirm the exact path from `get-feature-flag` for your account if needed):
+
+```json
+{
+  "projectKey": "PROJECT_KEY",
+  "featureFlagKey": "my-first-flag",
+  "PatchWithComment": {
+    "patch": [
+      {
+        "op": "replace",
+        "path": "/environments/ENVIRONMENT_KEY/on",
+        "value": true
+      }
+    ],
+    "comment": "Onboarding: turn on my-first-flag"
+  }
+}
+```
+
+Replace `ENVIRONMENT_KEY` with the environment key for the environment you are targeting (e.g. `test`, `production`).
+
+### Via LaunchDarkly API
+
+```bash
+curl -s -X PATCH \
+  "https://app.launchdarkly.com/api/v2/flags/PROJECT_KEY/my-first-flag" \
+  -H "Authorization: $LAUNCHDARKLY_ACCESS_TOKEN" \
+  -H "Content-Type: application/json; domain-model=launchdarkly.semanticpatch" \
+  -d '{
+    "environmentKey": "ENVIRONMENT_KEY",
+    "instructions": [
+      {"kind": "turnFlagOn"}
+    ]
+  }'
+```
+
+### Via ldcli
+
+```bash
+ldcli flags toggle-on \
+  --access-token "$LAUNCHDARKLY_ACCESS_TOKEN" \
+  --project PROJECT_KEY \
+  --environment ENVIRONMENT_KEY \
+  --flag my-first-flag
+```
+
+## Step 5: Verify the toggle
+
+After toggling the flag on, the application should now show:
+
+```
+Feature is ON
+```
+
+For server-side SDKs using streaming (the default), the change should be reflected within seconds. For client-side SDKs, the change appears on the next page load or when the SDK polls for updates.
+
+## Step 6: Add an interactive demo
+
+Now that the flag works, add a **visible, interactive element** so the user can see the flag in action -- not just a console log. This creates a "wow" moment and gives the user a tangible proof point they can show others.
+
+**Choose the right demo based on what you detected:**
+
+| App type | What to add | User experience |
+|----------|-------------|-----------------|
+| **Frontend (React, Vue, SPA)** | A banner, badge, or button gated by the flag | Toggle flag in dashboard → refresh page → element appears/disappears |
+| **Backend API (Node, Python, Go, etc.)** | A `/launchdarkly-demo` endpoint that returns flag state as JSON | `curl` the endpoint → toggle flag → `curl` again → response changes |
+| **Full-stack (Next.js SSR, Rails, etc.)** | Both: an API endpoint + a UI element that displays the flag state | Toggle flag → see both API and UI reflect the change |
+| **CLI / script** | A `--feature-demo` flag or distinct output mode | Run script → toggle flag → run again → output changes |
+
+### Frontend demo example (React)
+
+Add a component or element that's visually obvious when the flag is on:
+
+```tsx
+// Add to an existing page component
+import { useFlags } from 'launchdarkly-react-client-sdk';
+
+function FeatureFlagDemo() {
+  const { myFirstFlag } = useFlags();
+
+  if (!myFirstFlag) return null;
+
+  return (
+    <div style={{
+      padding: '12px 20px',
+      backgroundColor: '#405BFF',
+      color: 'white',
+      borderRadius: '8px',
+      margin: '16px 0',
+      fontWeight: 500
+    }}>
+      LaunchDarkly is working — this banner is controlled by a feature flag
+    </div>
+  );
+}
+```
+
+Place it somewhere visible (e.g., at the top of the main page or in a dashboard/header area).
+
+### Backend demo example (Node.js/Express)
+
+Add an endpoint that returns the flag state:
+
+```javascript
+// Add to your Express app (or equivalent for other frameworks)
+app.get('/launchdarkly-demo', async (req, res) => {
+  const context = { kind: 'user', key: 'demo-user' };
+  const flagValue = await ldClient.boolVariation('my-first-flag', context, false);
+  
+  res.json({
+    flag: 'my-first-flag',
+    enabled: flagValue,
+    message: flagValue 
+      ? 'LaunchDarkly is working — the flag is ON'
+      : 'LaunchDarkly is working — the flag is OFF'
+  });
+});
+```
+
+Tell the user to test with: `curl http://localhost:PORT/launchdarkly-demo`
+
+### Backend demo example (Python/Flask)
+
+```python
+@app.route('/launchdarkly-demo')
+def launchdarkly_demo():
+    context = Context.builder("demo-user").build()
+    flag_value = ld_client.variation("my-first-flag", context, False)
+    
+    return jsonify({
+        "flag": "my-first-flag",
+        "enabled": flag_value,
+        "message": "LaunchDarkly is working — the flag is ON" if flag_value 
+                   else "LaunchDarkly is working — the flag is OFF"
+    })
+```
+
+### Full-stack demo
+
+For apps with both server and client (e.g., Next.js, Remix, Rails with frontend):
+
+1. Add the API endpoint (backend example above)
+2. Add a UI component that either calls the endpoint or uses the client SDK directly
+3. The user can verify both paths work
+
+### Guidelines
+
+1. **Match existing patterns** -- use the same routing style, component conventions, and code style as the rest of the app
+2. **Make it obvious** -- use color, position, or text that clearly indicates this is the LaunchDarkly demo
+3. **Keep it removable** -- add a brief comment like `// LaunchDarkly demo - safe to remove` so the user knows they can delete it later (or keep it as a template)
+4. **Don't over-engineer** -- this is a demo, not a production feature; a few lines of code is ideal
+
+### Walk the user through it
+
+After adding the demo element:
+
+1. Tell the user where you added it and how to see it (URL, page location, command)
+2. Have them verify it shows the current flag state
+3. Ask them to toggle the flag in the dashboard (provide the deep link: `https://app.launchdarkly.com/projects/{projectKey}/flags/my-first-flag`)
+4. Have them refresh/re-run to see the change
+5. Celebrate the successful integration
+
+## Congratulations
+
+The user has successfully:
+
+1. Installed the LaunchDarkly SDK
+2. Connected it to LaunchDarkly
+3. Created a feature flag
+4. Evaluated it in code
+5. Toggled it and seen the result
+6. Added an interactive demo they can show others
+
+This is the "proof point" moment -- the user has a working feature flag they can toggle in real-time. The demo element makes it tangible and shareable.
+
+**Encourage the next skill:** Suggest they **install or enable** the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (`npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <agent>`) so future work -- creating flags that match repo conventions, wrapping features, and verifying wiring -- has a dedicated playbook. Offer to help them add it if they are unsure how.
+
+## Error handling
+
+### Authorization errors
+
+If any step returns a **401** or **403**:
+
+**D9 -- BLOCKING:** Call your structured question tool now.
+- question: "I received an authorization error ([specific status code and message]). This requires your action to resolve -- I cannot retry automatically."
+- options:
+  - "I'll re-authenticate -- run ldcli login or refresh my token"
+  - "Let me check my access token and try again"
+  - "I don't have an account -- help me sign up"
+  - "The project or environment doesn't exist -- help me create one"
+- STOP. Do not write the question as text. Do not retry authorization errors automatically -- they always require user action. Do not continue until the user selects an option.
+
+### Other errors
+
+For non-auth errors (flag creation failures, SDK key mismatches, flags returning fallback values, etc.), diagnose the issue using the error output, application logs, and your understanding of the project.
+
+**Next steps to suggest:**
+
+- **Install** **`launchdarkly-flag-create`** from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) if it is not already available -- this onboarding flow only covers a first boolean flag; that skill guides real-world flag creation aligned with existing code patterns (requires LaunchDarkly MCP per that skill's prerequisites).
+- Use **`launchdarkly-flag-targeting`** from the same distribution to set up percentage rollouts and targeting rules
+- Read the [LaunchDarkly docs](https://docs.launchdarkly.com) for advanced topics like contexts, experimentation, and metrics
+
+---
+
+**Upon completion, continue with:** [Onboarding summary](../references/1.8-summary.md) and [Editor rules and skills](../references/1.9-editor-rules.md) (default follow-through in the parent onboarding skill -- **not** MCP setup, which is Step 4). For MCP install or troubleshooting, use [mcp-configure](../mcp-configure/SKILL.md) and [MCP Config Templates](../mcp-configure/references/mcp-config-templates.md).

--- a/skills/onboarding/first-flag/SKILL.md
+++ b/skills/onboarding/first-flag/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-first-flag
+name: first-flag
 description: "Create a boolean first flag, add evaluation, toggle on/off for end-to-end proof. Parent onboarding Step 6; uses MCP, API, or ldcli; optional flag-create skill."
 license: Apache-2.0
 compatibility: Requires SDK installed (parent Step 5) and LaunchDarkly project access

--- a/skills/onboarding/marketplace.json
+++ b/skills/onboarding/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "onboarding",
+  "description": "Onboard a project to LaunchDarkly: kickoff roadmap, resumable log, explore repo, MCP, companion flag skills, nested SDK install (detect/plan/apply), first flag.",
+  "version": "0.1.0",
+  "author": "LaunchDarkly",
+  "repository": "https://github.com/launchdarkly/agent-skills",
+  "skills": ["./"],
+  "tags": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management",
+    "onboarding",
+    "sdk",
+    "mcp",
+    "getting-started",
+    "setup"
+  ],
+  "requirements": {
+    "mcp-servers": ["@launchdarkly/mcp-server"]
+  }
+}

--- a/skills/onboarding/mcp-configure/SKILL.md
+++ b/skills/onboarding/mcp-configure/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: launchdarkly-onboarding-mcp-configure
+description: "Configure the LaunchDarkly hosted MCP server during onboarding. Use when the parent LaunchDarkly onboarding skill reaches Step 4 (MCP). Supports Cursor, Claude Code, Windsurf, GitHub Copilot, and other MCP-compatible agents. OAuth authentication; no API keys for the hosted server."
+license: Apache-2.0
+compatibility: Requires an MCP-compatible coding agent and a LaunchDarkly account
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly MCP Server Configuration (onboarding)
+
+Configures the LaunchDarkly hosted MCP server so flag management skills and onboarding can use MCP tools. Uses OAuth for authentication — no API keys needed for the hosted server.
+
+This skill is nested under [LaunchDarkly onboarding](../SKILL.md); the parent skill's **Step 4** hands off here. **Hosted MCP** is the default. For **federal/EU** or other cases where hosted is unavailable, use the **Local server via `npx`** section in [MCP Config Templates](references/mcp-config-templates.md) and [local MCP server docs](https://launchdarkly.com/docs/home/getting-started/mcp-local).
+
+## Prerequisites
+
+- A LaunchDarkly account (sign up at [https://app.launchdarkly.com/signup?source=agent](https://app.launchdarkly.com/signup?source=agent))
+- An MCP-compatible coding agent
+
+## Hosted MCP Servers
+
+LaunchDarkly provides two hosted MCP servers. For onboarding, only the feature management server is required.
+
+| Server             | URL                                          | Purpose              |
+| ------------------ | -------------------------------------------- | -------------------- |
+| Feature management | `https://mcp.launchdarkly.com/mcp/fm`        | Manage feature flags |
+| AI Configs         | `https://mcp.launchdarkly.com/mcp/aiconfigs` | Manage AI Configs    |
+
+## Workflow
+
+### Step 1: Detect the Agent
+
+If the parent onboarding skill already identified the agent, use that context. Otherwise infer from agent-specific directories, config files, and the tools available to you at runtime. Do not ask the user — pick the strongest match.
+
+### Step 2: Try Quick Install
+
+The fastest path is the quick install link. Present it to the user:
+
+**Feature management:** [https://mcp.launchdarkly.com/mcp/fm/install](https://mcp.launchdarkly.com/mcp/fm/install)
+
+**AI Configs (optional):** [https://mcp.launchdarkly.com/mcp/aiconfigs/install](https://mcp.launchdarkly.com/mcp/aiconfigs/install)
+
+**Important: tell the user what to expect after clicking the link.** The install link may open in the browser, but the authorization or "add server" prompt typically appears **back in the coding environment** (the editor or host app where the agent runs), not in the browser. Immediately after presenting the link, include guidance like:
+
+- After clicking the link, watch your coding environment (the editor where this conversation is running) for an approval dialog, an "add MCP server" prompt, or a tools/integrations panel notification.
+- The browser may start the OAuth flow, but you'll likely need to confirm or approve the server in the editor itself.
+- **If no prompt appears:** check the editor's MCP, integrations, or tools settings area to see if the server was added but needs to be enabled. If it's not there at all, fall back to manual setup (Step 3 below).
+
+If the quick install link doesn't work (agent doesn't support it, or user prefers manual setup), proceed to Step 3.
+
+### Step 3: Manual Configuration
+
+Locate the MCP config file for the detected agent and add the hosted server entry. See [MCP Config Templates](references/mcp-config-templates.md) for the exact JSON per agent.
+
+| Agent          | Config file location                                       |
+| -------------- | ---------------------------------------------------------- |
+| Cursor         | `.cursor/mcp.json` (project) or global Cursor settings     |
+| Claude Code    | `.mcp.json` (project) or `~/.claude.json` (global)         |
+| GitHub Copilot | Repo **Settings** on GitHub.com → Copilot → Cloud agent → MCP (see [MCP UI links](references/mcp-ui-links.md)) |
+| Windsurf       | Agent-specific MCP config                                  |
+
+**Only add the feature management server for onboarding.** Add the AI Configs server only if the user explicitly needs it.
+
+### Step 4: Agent-Specific Authorization
+
+After writing the config, some agents need extra steps. **Do not** send users through long manual menu paths only—use [MCP UI links](references/mcp-ui-links.md) (HTTPS docs + `command:` shortcuts for VS Code / Cursor).
+
+**Cursor:**
+
+1. Open MCP in Cursor using the [Cursor MCP doc link and in-app shortcuts](references/mcp-ui-links.md#clients) (e.g. Settings search via `command:` link when clickable).
+2. Toggle on **LaunchDarkly feature management** (or the name from your config).
+3. Click **Connect** to authorize with the LaunchDarkly account.
+
+**VS Code (when applicable):**
+
+- Use [VS Code MCP doc + `mcp.json` / Settings links](references/mcp-ui-links.md#clients); trust or start the server if prompted.
+
+**Claude Code:**
+
+- Authorization happens automatically on first MCP tool call via OAuth prompt. File-based setup: [Claude Code MCP doc](https://docs.claude.com/en/docs/claude-code/mcp).
+
+**GitHub Copilot:**
+
+- Click **Save** after adding the MCP configuration in repo settings. Use the [GitHub Copilot MCP doc](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-coding-agent-with-mcp) for the exact **Settings** path on github.com.
+
+### Step 5: Restart and Auto-Verify
+
+MCP tools are only available to the agent after a restart or refresh — newly added MCP servers do not appear mid-session.
+
+1. **Tell the user to enable the server and restart.** Before restarting, they need to make sure the MCP server is toggled on and authorized in their editor's MCP settings (e.g. in Cursor: toggle on the LaunchDarkly server and click **Connect**). Then restart or refresh the agent — be specific about how: "Restart Cursor" / "reload Claude Code" / "refresh the Copilot agent" depending on what you detected in Step 1. After the user restarts, the conversation will resume in a new turn.
+2. **On the next turn, probe silently.** Call a lightweight MCP tool (e.g. `list-feature-flags` with the user's project key). Do not ask the user whether MCP is working — just try it.
+   - **Success** (normal response, even an empty flag list): MCP is live. Note it in the onboarding log and continue.
+   - **Failure** (tool not found, auth error, timeout): fall back to ldcli/API. Note the fallback in the onboarding log. Do **not** block the rest of onboarding — Steps 5-6 must still be completable without MCP.
+3. **If the probe fails**, briefly tell the user MCP isn't available yet and that you'll use ldcli/API instead. Offer a one-liner they can try later to re-enable MCP (e.g. "You can set up MCP anytime by clicking [quick install link] and restarting").
+4. If the failure looks like a config issue (wrong file path, missing OAuth, server not enabled), mention the likely cause so the user can fix it on their own time — but do not block progress.
+
+For **local `npx` server** verification, see [MCP Config Templates — Verify (local server)](references/mcp-config-templates.md#verify-local-server).
+
+## Local MCP: Access Token Setup
+
+When the user needs the **local `npx` server** (federal/EU or other cases where hosted MCP is unavailable), the server requires a `LAUNCHDARKLY_ACCESS_TOKEN`. This is a sensitive credential.
+
+First, tell the user how to create a token if they don't already have one:
+
+> Create an API access token at [app.launchdarkly.com/settings/authorization/tokens/new](https://app.launchdarkly.com/settings/authorization/tokens/new). Give it a descriptive name (e.g. "MCP server") and at minimum the **Reader** role. Copy the token — you won't be able to see it again after leaving the page.
+
+Then ask how they want to add the token to the MCP config:
+
+**D4-LOCAL -- BLOCKING:** Call your structured question tool now.
+- question: "The local MCP server needs an API access token to authenticate with LaunchDarkly. You can create one at app.launchdarkly.com/settings/authorization/tokens/new. Once you have the token, how would you like to add it to your MCP config? We recommend adding it yourself — there is a non-zero risk when an AI agent handles secrets, as tokens may persist in conversation history, logs, or model context."
+- options:
+  - "I'll add the token to the config myself — just tell me which file and variable"
+  - "I have the token ready — go ahead and help me wire up the config"
+- STOP. Do not write the question as text. Do not write any token value to a config file before the user selects an option.
+
+**If the user adds the token themselves:**
+1. Tell them the config file path for their agent (see [MCP Config Templates](references/mcp-config-templates.md))
+2. Tell them to set `LAUNCHDARKLY_ACCESS_TOKEN` as the value — either as an environment variable or directly in the config file
+3. Remind them to add the config file to `.gitignore` if the token is inline
+4. Wait for them to confirm, then proceed to Step 5 (Restart and Auto-Verify)
+
+**If the user wants agent-assisted setup:**
+1. Ensure the config file is in `.gitignore` before writing
+2. Write the config per [MCP Config Templates](references/mcp-config-templates.md)
+3. Remind the user that the token will be visible in the config file and conversation history
+4. Proceed to Step 5 (Restart and Auto-Verify)
+
+## Edge Cases
+
+- **User already has MCP configured:** Verify by checking for existing LD MCP entries in the config. If present and working, skip configuration.
+- **User has the old npx-based local server:** Migrate them. Remove the old `npx @launchdarkly/mcp-server` entry and any `LD_ACCESS_TOKEN` env vars. Replace with the hosted server config.
+- **Federal or EU instances:** The hosted MCP server is not available for federal or EU environments. Use [local MCP server docs](https://launchdarkly.com/docs/home/getting-started/mcp-local) and the **Local server via `npx`** section in [MCP Config Templates](references/mcp-config-templates.md). Follow the [Local MCP: Access Token Setup](#local-mcp-access-token-setup) flow for token handling.
+- **Agent not in known list:** Provide the generic pattern: the user needs to add an MCP server entry pointing to `https://mcp.launchdarkly.com/mcp/fm` using whatever format their agent expects.
+- **User opts out of MCP during onboarding:** Document that choice and continue with the parent skill's ldcli/API fallbacks for environments and flags; do not block SDK work.
+
+## What NOT to Do
+
+- Don't configure the old npx-based local server by default. Prefer the hosted server for standard regions.
+- Don't ask for or store API keys for the hosted server. The hosted server uses OAuth.
+- Don't add both servers by default. Only add AI Configs if the user asks for it.
+- Don't handle the access token for local MCP without asking the user first via the D4-LOCAL decision point.
+
+## References
+
+- [MCP UI links](references/mcp-ui-links.md) — HTTPS + `command:` links to open MCP settings (Cursor, VS Code, Claude Code, Windsurf, GitHub)
+- [MCP Config Templates](references/mcp-config-templates.md) — hosted OAuth JSON per agent; **Local server via `npx`** fallback; migration from old local server
+- [Official MCP docs](https://launchdarkly.com/docs/home/getting-started/mcp-hosted) — full hosted setup guide

--- a/skills/onboarding/mcp-configure/SKILL.md
+++ b/skills/onboarding/mcp-configure/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-mcp-configure
+name: mcp-configure
 description: "Configure the LaunchDarkly hosted MCP server during onboarding. Use when the parent LaunchDarkly onboarding skill reaches Step 4 (MCP). Supports Cursor, Claude Code, Windsurf, GitHub Copilot, and other MCP-compatible agents. OAuth authentication; no API keys for the hosted server."
 license: Apache-2.0
 compatibility: Requires an MCP-compatible coding agent and a LaunchDarkly account

--- a/skills/onboarding/mcp-configure/references/mcp-config-templates.md
+++ b/skills/onboarding/mcp-configure/references/mcp-config-templates.md
@@ -1,0 +1,236 @@
+# MCP Config Templates
+
+Per-agent JSON snippets for configuring the LaunchDarkly hosted MCP server. All configurations use OAuth -- no API keys required.
+
+Source: https://launchdarkly.com/docs/home/getting-started/mcp-hosted
+
+## Cursor
+
+Config file: `.cursor/mcp.json` in the project root.
+
+### Feature management only
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "url": "https://mcp.launchdarkly.com/mcp/fm",
+      "headers": {}
+    }
+  }
+}
+```
+
+### Both servers
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "url": "https://mcp.launchdarkly.com/mcp/fm",
+      "headers": {}
+    },
+    "LaunchDarkly AI Configs": {
+      "url": "https://mcp.launchdarkly.com/mcp/aiconfigs",
+      "headers": {}
+    }
+  }
+}
+```
+
+**After adding the config:** enable the servers and complete OAuth in Cursor's MCP UI. Use [MCP UI links — Cursor](mcp-ui-links.md#clients) (HTTPS doc + optional `command:` links); do not rely only on nested Settings menu paths.
+
+## Claude Code
+
+Config file: `.mcp.json` in the project root, or `~/.claude.json` for global config.
+
+### Feature management only
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "type": "http",
+      "url": "https://mcp.launchdarkly.com/mcp/fm"
+    }
+  }
+}
+```
+
+### Both servers
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "type": "http",
+      "url": "https://mcp.launchdarkly.com/mcp/fm"
+    },
+    "LaunchDarkly AI Configs": {
+      "type": "http",
+      "url": "https://mcp.launchdarkly.com/mcp/aiconfigs"
+    }
+  }
+}
+```
+
+Authorization happens automatically via OAuth prompt on first MCP tool call.
+
+## GitHub Copilot
+
+Configured via the GitHub web UI, not a local config file.
+
+1. Navigate to the target repository on GitHub
+2. Go to **Settings > Code and automation > Copilot > Coding agent**
+3. In the **MCP configuration** section, add:
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "url": "https://mcp.launchdarkly.com/mcp/fm",
+      "headers": {}
+    }
+  }
+}
+```
+
+4. Click **Save**
+
+## Windsurf
+
+Windsurf uses a similar MCP configuration format. Add to the agent's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly feature management": {
+      "url": "https://mcp.launchdarkly.com/mcp/fm"
+    }
+  }
+}
+```
+
+Consult Windsurf's documentation for the exact config file location.
+
+## Migrating from the Old Local Server
+
+If the user has the old npx-based server configured, replace it:
+
+**Remove this:**
+
+```json
+{
+  "mcpServers": {
+    "LaunchDarkly": {
+      "command": "npx",
+      "args": [
+        "-y", "--package", "@launchdarkly/mcp-server",
+        "--", "mcp", "start",
+        "--api-key", "api-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      ]
+    }
+  }
+}
+```
+
+**Replace with the hosted config for the relevant agent** (see sections above).
+
+Also remove any `LD_ACCESS_TOKEN` or `LAUNCHDARKLY_API_KEY` environment variables that were used for the local server. The hosted server handles authentication via OAuth.
+
+## Local server via `npx`
+
+Use the local MCP server when hosted MCP is not available — for example, **EU or Federal** environments — or when your setup requires it. See [local MCP server docs](https://launchdarkly.com/docs/home/getting-started/mcp-local). This path uses **`LAUNCHDARKLY_ACCESS_TOKEN`** (API access token) instead of OAuth.
+
+### Security: Protect tokens in MCP config files
+
+Most editors (Cursor, VS Code, Claude Desktop) require **literal tokens** in MCP config — they don't expand `${VAR}` syntax. To prevent accidental commits:
+
+1. **Add MCP config files to `.gitignore`:**
+   ```
+   .cursor/mcp.json
+   .vscode/mcp.json
+   ```
+2. **Or use user-level config** (outside the repo) where the editor supports it
+
+**Exception:** Claude Code supports `${LAUNCHDARKLY_ACCESS_TOKEN}` env var syntax — use it when available.
+
+### Claude Code (project `.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "${LAUNCHDARKLY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Set `LAUNCHDARKLY_ACCESS_TOKEN` in the environment or use your agent’s secret mechanism per [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp). For user-wide config, merge the same `mcpServers.launchdarkly` entry into `~/.claude/settings.json` if appropriate.
+
+### Cursor (`.cursor/mcp.json`)
+
+**Add `.cursor/mcp.json` to `.gitignore`** — Cursor requires a literal token value.
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+Claude Desktop config is user-level (not in repos), so token exposure risk is lower.
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### VS Code / Copilot (`.vscode/mcp.json`)
+
+**Add `.vscode/mcp.json` to `.gitignore`** — VS Code requires a literal token value.
+
+```json
+{
+  "servers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": ["-y", "@launchdarkly/mcp-server"],
+      "env": {
+        "LAUNCHDARKLY_ACCESS_TOKEN": "YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_ACCESS_TOKEN` with the user’s LaunchDarkly API access token. After editing, restart the editor or reload MCP.
+
+### Verify (local server)
+
+1. If you have MCP tool access, call **`list-feature-flags`** with the user’s `projectKey` (e.g. `request: { "projectKey": "YOUR_PROJECT_KEY" }`). A normal response confirms the server and token.
+2. If MCP tools are not visible yet, have the user run **`ldcli flags list`** (or curl the REST API) to validate credentials independently while MCP reloads.

--- a/skills/onboarding/mcp-configure/references/mcp-ui-links.md
+++ b/skills/onboarding/mcp-configure/references/mcp-ui-links.md
@@ -1,0 +1,31 @@
+# Open MCP settings (links instead of menu paths)
+
+Use this reference when onboarding tells the user to enable MCP, connect OAuth, or open MCP configuration. **Give clickable links**—do not rely only on "Settings → … → Tools & MCP" prose.
+
+## How to use (agents)
+
+1. Use the row for the detected client (see parent onboarding **Step 2: Detect the Agent**).
+2. **Always include the HTTPS documentation link** for that client—it opens in the browser and works from any environment.
+3. When the user is in **VS Code or Cursor**, also include the **`command:` links** on their own lines so they can click in the editor chat (same scheme VS Code uses for trusted markdown). If a `command:` link is not clickable or does nothing, fall back to the doc link or Command Palette text below.
+4. **Path caveat:** LaunchDarkly's Cursor template uses **project** `.cursor/mcp.json`. VS Code's **MCP: Open User/Workspace Configuration** commands open VS Code's `mcp.json` locations (often under `.vscode/` or the user profile)—not `.cursor/mcp.json`. If the user edited `.cursor/mcp.json`, point them at the **Cursor doc link** or "open `.cursor/mcp.json` in the editor" plus Cursor's MCP panel.
+
+## Clients
+
+| Client | Documentation (open in browser) | In-app shortcuts (VS Code–compatible hosts) |
+|--------|----------------------------------|---------------------------------------------|
+| **Cursor** | [Model Context Protocol (MCP) — Cursor Docs](https://cursor.com/docs/context/mcp) | [Open Settings (filtered search: `mcp`)](command:workbench.action.openSettings?%5B%22mcp%22%5D) |
+| **VS Code** (GitHub Copilot Chat, built-in MCP, etc.) | [Add and manage MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) | [Open user `mcp.json`](command:workbench.mcp.openUserMcpJson) · [Open workspace folder `mcp.json`](command:workbench.mcp.openWorkspaceFolderMcpJson) · [Open Settings (filtered search: `mcp`)](command:workbench.action.openSettings?%5B%22mcp%22%5D) |
+| **Claude Code** | [Connect Claude Code to tools through MCP](https://docs.claude.com/en/docs/claude-code/mcp) | Config is file-based (project `.mcp.json` or user config)—open those files in the editor; no shared `command:` URI across versions. |
+| **Windsurf** | [MCP — Windsurf Docs](https://docs.windsurf.com/windsurf/mcp) | Use Windsurf's documented MCP / Cascade UI. |
+| **GitHub Copilot (cloud agent, repo settings)** | [Extend Copilot coding agent with MCP — GitHub Docs](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-coding-agent-with-mcp) | Configuration is on **github.com** under the repository's **Settings** (see doc). Optional: [MCP and Copilot coding agent (concepts)](https://docs.github.com/en/copilot/concepts/coding-agent/mcp-and-coding-agent). |
+
+## Command Palette text (fallback)
+
+If links are not clickable:
+
+- **VS Code / Cursor:** Run **MCP: Open User Configuration**, **MCP: Open Workspace Folder Configuration**, or **MCP: List Servers** from the Command Palette (`⇧⌘P` / `Ctrl+Shift+P`). Alternatively **Preferences: Open Settings (UI)** and search **`mcp`**.
+- **Cursor:** See the [Cursor MCP doc](https://cursor.com/docs/context/mcp) for the current location of the MCP tools list and OAuth **Connect** (labels such as **Tools & MCP** or **MCP** vary by version).
+
+## Command link encoding note
+
+`command:workbench.action.openSettings?` links pass a JSON array argument (URL-encoded). Example: query `mcp` → `?%5B%22mcp%22%5D` is `["mcp"]`. Adjust the search string if the UI does not filter as expected (e.g. try `"Tools MCP"`).

--- a/skills/onboarding/references/1.8-summary.md
+++ b/skills/onboarding/references/1.8-summary.md
@@ -1,0 +1,138 @@
+---
+title: Onboarding Summary
+description: Generate a setup summary document the user can reference, with links to documentation and suggested next steps
+---
+
+# Onboarding Summary
+
+After completing the onboarding flow, leave behind a summary document in the user's repository so they (and their team) have a reference for how LaunchDarkly was set up and what to do next.
+
+## Step 1: Generate the Summary Document
+
+Create a file called `LAUNCHDARKLY.md` (or `docs/LAUNCHDARKLY.md` if the project has a `docs/` directory) in the user's repository with the following sections. Fill in the details based on what was done during onboarding. Collect the LaunchDarkly **project key** and **environment key** (`{PROJECT_KEY}` / `{ENV_KEY}`) from the same place you used during onboarding (dashboard URLs, MCP tools, or **Project settings → Environments**) if they were not written into the plan explicitly.
+
+### Template
+
+The wrapper below uses `~~~markdown` so a nested ` ```json ` block inside the template does not break Markdown rendering. (The generated `LAUNCHDARKLY.md` file itself may use normal ` ``` ` fences.)
+
+~~~markdown
+# LaunchDarkly Setup
+
+This project uses [LaunchDarkly](https://launchdarkly.com) for feature flag management.
+
+## SDK Details
+
+- **SDK**: {SDK_NAME} ({SDK_PACKAGE})
+- **SDK Type**: {server-side | client-side | mobile | edge}
+- **Key Type**: {SDK Key | Client-side ID | Mobile Key}
+- **Installed via**: {INSTALL_COMMAND}
+- **Initialization file**: {ENTRYPOINT_FILE}
+
+## Configuration
+
+The SDK key is configured via the `{ENV_VAR_NAME}` environment variable.
+
+- **Do not hardcode** the SDK key in source code.
+- Add the key to your `.env` file locally (already in `.gitignore`).
+- For production, set it in your deployment environment (e.g., CI/CD secrets, container env vars, cloud config).
+
+## Where to Find Things
+
+| What | Where |
+|------|-------|
+| Feature flags dashboard | https://app.launchdarkly.com/projects/{PROJECT_KEY}/flags |
+| Project settings | https://app.launchdarkly.com/settings/projects/{PROJECT_KEY} |
+| Environments | https://app.launchdarkly.com/settings/projects/{PROJECT_KEY}/environments |
+| API access tokens | https://app.launchdarkly.com/settings/authorization |
+| SDK documentation | {SDK_DOCS_URL} |
+| LaunchDarkly docs | https://launchdarkly.com/docs |
+
+## How Feature Flags Work in This Project
+
+1. Flags are evaluated using the LaunchDarkly SDK in `{ENTRYPOINT_FILE}`
+2. Flag values are fetched from LaunchDarkly based on the evaluation context (user/device/org)
+3. Changes to flags in the dashboard take effect immediately (server-side SDKs use streaming by default)
+
+### Example: Evaluating a Flag
+
+{INSERT_LANGUAGE_SPECIFIC_EXAMPLE}
+
+## Next Steps
+
+Here are some things you can do now that LaunchDarkly is set up:
+
+### Feature Flag Best Practices
+- **Use flags for every new feature**: Wrap new features in flags so you can release and roll back independently of deployments.
+- **Clean up temporary flags**: Mark flags as temporary during creation and archive them when no longer needed.
+- **Use descriptive flag keys**: e.g., `enable-checkout-v2` instead of `flag-1`.
+
+### Advanced Capabilities
+- **[Percentage Rollouts](https://launchdarkly.com/docs/home/targeting-flags/rollouts)** — Gradually roll out features to a percentage of users.
+- **[Targeting Rules](https://launchdarkly.com/docs/home/targeting-flags/targeting-rules)** — Target specific users, segments, or contexts.
+- **[Experimentation](https://launchdarkly.com/docs/home/about-experimentation)** — Run A/B tests and measure the impact of flag variations.
+- **[AI Configs](https://launchdarkly.com/docs/home/ai-configs)** — Manage AI model configurations and prompts with feature flags.
+- **[Guarded Rollouts](https://launchdarkly.com/docs/home/guarded-rollouts)** — Automatically roll back flag changes based on metric guardrails.
+- **[Observability](https://launchdarkly.com/docs/home/observability)** — Monitor flag evaluations and SDK performance with built-in telemetry.
+
+### AI Agent Integration (MCP Server)
+
+Install the [LaunchDarkly MCP server](https://github.com/launchdarkly/mcp-server) to let your AI agent manage feature flags directly from your editor. With it, your agent can:
+
+- **Create and manage flags** — Ask your agent to create a new feature flag, and it will handle the API calls for you.
+- **Toggle flags on/off** — Turn features on or off across environments without leaving your editor.
+- **Set up targeting rules** — Configure percentage rollouts, user targeting, and segment-based rules through natural language.
+- **Clean up stale flags** — Ask your agent to find temporary flags that are fully rolled out and ready to archive.
+- **Run experiments** — Set up A/B tests and monitor results through your agent.
+- **Manage AI configs** — Update model configurations and prompts managed by LaunchDarkly.
+
+**Two setup options:**
+
+- **[Hosted MCP](https://launchdarkly.com/docs/home/getting-started/mcp-hosted)** — Uses OAuth; no tokens stored in config files
+- **[Local MCP](https://launchdarkly.com/docs/home/getting-started/mcp-local)** — Uses API access token; required for EU/Federal environments
+
+If using local MCP, add your editor's MCP config file to `.gitignore` since it will contain your access token:
+
+```
+# Add to .gitignore (if using local MCP with tokens)
+.cursor/mcp.json
+.vscode/mcp.json
+```
+
+See the [MCP server docs](https://github.com/launchdarkly/mcp-server) for editor-specific setup instructions.
+
+### Useful CLI Commands
+
+If you have `ldcli` installed:
+
+| Command | Description |
+|---------|-------------|
+| `ldcli flags list --project {PROJECT_KEY}` | List all feature flags |
+| `ldcli flags toggle-on --project {PROJECT_KEY} --environment {ENV_KEY} --flag FLAG_KEY` | Turn a flag on |
+| `ldcli flags create --project {PROJECT_KEY} --data '{"name": "My Flag", "key": "my-flag", "kind": "boolean"}'` | Create a new flag |
+| `ldcli environments list --project {PROJECT_KEY}` | List environments and SDK keys |
+~~~
+
+## Step 2: Fill in the Template
+
+Replace all `{PLACEHOLDER}` values with the actual values from the onboarding session (gather any you did not write down earlier from **Project settings → Environments** in LaunchDarkly or from MCP tools / `ldcli`):
+
+- `{SDK_NAME}`: The human-readable SDK name (e.g., "Node.js Server SDK")
+- `{SDK_PACKAGE}`: The package name (e.g., `@launchdarkly/node-server-sdk`)
+- `{INSTALL_COMMAND}`: The install command used (e.g., `npm install @launchdarkly/node-server-sdk`)
+- `{ENTRYPOINT_FILE}`: The file where initialization code was added
+- `{ENV_VAR_NAME}`: The environment variable name used for the SDK key (or client-side ID env name)
+- `{PROJECT_KEY}`: The LaunchDarkly **project** key (URL segment and `ldcli --project`)
+- `{ENV_KEY}`: The LaunchDarkly **environment** key for the environment whose SDK key / client-side ID you used (e.g., `production`, `test`, `development`)—required for `ldcli` commands that take `--environment` and for the dashboard links that are scoped per environment where applicable
+- `{SDK_DOCS_URL}`: Link to the specific SDK documentation
+- `{INSERT_LANGUAGE_SPECIFIC_EXAMPLE}`: A short code snippet showing flag evaluation in the project's language
+
+## Step 3: Commit the Summary
+
+Add the file to version control so the whole team can reference it:
+
+```bash
+git add LAUNCHDARKLY.md
+git commit -m "docs: add LaunchDarkly setup reference"
+```
+
+Ask the user for permission before committing. If they prefer not to commit it, that's fine — they still have the file locally.

--- a/skills/onboarding/references/1.9-editor-rules.md
+++ b/skills/onboarding/references/1.9-editor-rules.md
@@ -1,0 +1,172 @@
+---
+title: Editor Rules and Skills
+description: Leave behind editor-specific rules that point agents at LaunchDarkly agent skills (not doc URLs) for ongoing feature flag work
+---
+
+# Editor Rules and Skills
+
+After onboarding, do two things:
+
+1. **Ensure the user has the relevant LaunchDarkly agent skills installed** — The goal is not “a plugin” in the abstract: the user (or agent) should have the **same skills this repository ships**, so future sessions can load them by `name`. **Standard set (install all four):**
+   - `launchdarkly-flag-create`
+   - `launchdarkly-flag-discovery`
+   - `launchdarkly-flag-targeting`
+   - `launchdarkly-flag-cleanup`  
+   **Optional:** `onboarding` (for more SDK onboarding later).  
+   **Preferred:** Install the **LaunchDarkly** plugin **`launchdarkly@launchdarkly-agent-skills`** from **[github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills)**, which packages these skills—then confirm in the UI or CLI that those skill names are available.
+   - **Claude Code:** After any required marketplace setup for that repo (see the repository README or `claude plugin` / Anthropic docs for your CLI version), install with:
+     ```bash
+     claude plugin install launchdarkly@launchdarkly-agent-skills
+     ```
+     If the command name or flags differ in your build, use `claude plugin --help` and match the plugin coordinate above. **Verify** the four standard skills (above) show up as usable after install.
+   - **Cursor:** Install or enable skills from the same distribution per current Cursor docs (marketplace / plugin UI pointing at this repo or copied folders). **Verify** the four `launchdarkly-flag-*` skills are listed or discoverable.
+   - **Fallback (no plugin):** Copy skill directories from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (or this monorepo’s published plugin) into the user’s skills location so each folder contains a `SKILL.md` for `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, and `launchdarkly-flag-cleanup`. Optional: include **`onboarding`** from this repo’s onboarding path. List any copied paths in the rules file so agents know where to read `SKILL.md`.
+2. **Write an editor rule** — The rule must tell *future* agents to **read and follow** those skills for flag work. Do **not** bake in SDK documentation URLs; procedures and compatibility live in each skill’s `SKILL.md`. Deep links to SDK docs belong in `LAUNCHDARKLY.md` if you already created that summary.
+
+## Default skill set (feature flags)
+
+Unless the user opts out, treat **all** of these as the standard kit and mention each one in the generated rule. They are published in [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (same four skills as in step 1 above):
+
+| Skill `name` (frontmatter) | Purpose |
+|----------------------------|---------|
+| `launchdarkly-flag-create` | Create and configure flags and wire evaluation to match the codebase (MCP when required). |
+| `launchdarkly-flag-discovery` | Audit flag inventory, stale or launched flags, and removal readiness. |
+| `launchdarkly-flag-targeting` | Toggle flags, percentage rollouts, targeting rules, and promote config between environments. |
+| `launchdarkly-flag-cleanup` | Safely remove flags from code, readiness checks, and MCP-driven cleanup workflows. |
+
+
+Adjust the table only if the user explicitly wants a smaller set.
+
+## Step 1: Detect the Editor
+
+Check for editor configuration files in the project root:
+
+| File/Directory | Editor |
+|----------------|--------|
+| `.cursor/` or `.cursorrules` | Cursor |
+| `.claude/` | Claude Code (Anthropic) |
+| `.github/copilot-instructions.md` | GitHub Copilot |
+| `.vscode/` (without Cursor indicators) | VS Code |
+| `.idea/` | JetBrains IDE — use [For JetBrains](#for-jetbrains-intellij-webstorm-rider-etc) (no dedicated template file path here) |
+
+If you can't detect the editor, default to Claude Code and create `.claude/rules/launchdarkly.md`.
+
+## Step 2: Create the Rules File
+
+Base the file on the templates below. **Substitute project facts** (`{SDK_NAME}`, `{ENTRYPOINT_FILE}`, `{ENV_VAR_NAME}`) from onboarding. **Do not** add `{SDK_DOCS_URL}` or a documentation links section to this file—that is intentionally omitted so agents rely on skills + MCP.
+
+The rule text must explicitly say: *when doing flag create, targeting, discovery, cleanup, or code removal, load the matching LaunchDarkly skill and execute its workflow* (not just “see links”).
+
+### Shared body (use in Cursor and Claude Code)
+
+Use this markdown block inside each template (Cursor: below the YAML frontmatter; Claude Code: from the first `#` heading).
+
+```markdown
+# LaunchDarkly Feature Flags
+
+This project uses LaunchDarkly for feature flag management.
+
+## SDK context (this repo)
+- SDK: {SDK_NAME}
+- Initialization: {ENTRYPOINT_FILE}
+- Key env var: {ENV_VAR_NAME} (never hardcode secrets in source)
+
+## Agent: use LaunchDarkly skills (required)
+
+Ensure the **LaunchDarkly** agent skills below are installed (`launchdarkly@launchdarkly-agent-skills` plugin from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills), or equivalent copies on disk). For any substantive flag work, **open that skill’s `SKILL.md` and follow it**—do not improvise from generic flag advice alone.
+
+| Skill | When to use it |
+|-------|------------------|
+| `launchdarkly-flag-create` | User wants a new flag, code wiring, feature toggle, or experiment setup. |
+| `launchdarkly-flag-discovery` | User wants flag inventory, debt/stale-flag audit, health, or removal readiness. |
+| `launchdarkly-flag-targeting` | User wants who sees a flag, rollouts, targeting rules, or environment promotion. |
+| `launchdarkly-flag-cleanup` | User wants a flag removed from code safely, archive/cleanup workflows, or MCP-driven removal. |
+
+**Invocation:** Match the user’s request to the skill `description` in each skill’s frontmatter, or use the editor’s slash / plugin command for that skill if configured.
+
+**Tools:** When a skill lists LaunchDarkly MCP tools as required, use MCP; do not skip validation steps.
+
+## Conventions (summary)
+- Prefer boolean flags unless multivariate is required; use descriptive kebab-case keys (e.g. `enable-checkout-v2`).
+- Always pass a fallback when evaluating flags; use a meaningful evaluation context (user key, org, etc.).
+- Server-side SDK keys stay secret; client-side IDs may appear in browser code.
+- Do not evaluate flags in tight loops without caching.
+- Archive or remove flag code when a flag is fully rolled out and the team agrees—use `launchdarkly-flag-cleanup` (and `launchdarkly-flag-discovery` first if assessing candidates).
+```
+
+### For Cursor (`.cursor/rules/launchdarkly.mdc`)
+
+Create `.cursor/rules/launchdarkly.mdc`:
+
+```markdown
+---
+description: LaunchDarkly feature flags — require LaunchDarkly agent skills for flag workflows
+globs: []
+alwaysApply: false
+---
+
+{PASTE_SHARED_BODY_HERE}
+```
+
+Replace `{PASTE_SHARED_BODY_HERE}` with the [shared body](#shared-body-use-in-cursor-and-claude-code) (no literal placeholder left in the file).
+
+### For Claude Code (`.claude/rules/launchdarkly.md`)
+
+Create `.claude/rules/launchdarkly.md` containing **only** the [shared body](#shared-body-use-in-cursor-and-claude-code) (no YAML frontmatter).
+
+### For GitHub Copilot (`.github/copilot-instructions.md`)
+
+Append to `.github/copilot-instructions.md` (create if it doesn't exist). Copilot may not load external skills the same way; still steer toward the same workflows and name the skills:
+
+```markdown
+## LaunchDarkly Feature Flags
+
+This project uses LaunchDarkly ({SDK_NAME}) for feature flag management.
+Initialization: {ENTRYPOINT_FILE}. SDK key / client ID: environment variable `{ENV_VAR_NAME}` only—never commit secrets.
+
+For flag work, follow the LaunchDarkly agent skills when available: **`launchdarkly-flag-create`** (create + code), **`launchdarkly-flag-discovery`** (audit / inventory), **`launchdarkly-flag-targeting`** (rollouts / targeting / env promotion), **`launchdarkly-flag-cleanup`** (code removal / cleanup / MCP workflows). Read each skill’s instructions instead of guessing flag lifecycle steps.
+```
+
+### For JetBrains (IntelliJ, WebStorm, Rider, etc.)
+
+There is **no** JetBrains-specific rules template in this reference (`.idea/` only indicates the IDE family). **Do not silently skip:** tell the user you detected JetBrains and that they should rely on **`LAUNCHDARKLY.md`** ([Onboarding Summary](1.8-summary.md)) plus installing **`launchdarkly@launchdarkly-agent-skills`** (same as Claude Code) or copying skill folders manually.
+
+Reasonable options to suggest:
+
+- Keep flag workflow guidance in **`LAUNCHDARKLY.md`** and team docs the IDE already opens.
+- If the team also uses GitHub Copilot in the same repo, reuse the **For GitHub Copilot** template above in `.github/copilot-instructions.md` so any tool that reads that file picks up the same guidance.
+- If their JetBrains AI plugin supports a **project-level instruction file**, paste the [shared body](#shared-body-use-in-cursor-and-claude-code) there (adapt paths to your product’s docs)—this doc does not name a single standard path for all JetBrains products.
+
+### For other editors (not Cursor, Claude Code, Copilot, VS Code, or JetBrains)
+
+If the editor doesn't have a rules system, skip creating a rules file. Rely on `LAUNCHDARKLY.md` and tell the user which LaunchDarkly skills to install (`launchdarkly@launchdarkly-agent-skills` or copied skill folders from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills)).
+
+## Step 3: Fill in the Placeholders
+
+From the onboarding session, set:
+
+- `{SDK_NAME}` — e.g. `Node.js Server SDK`
+- `{ENTRYPOINT_FILE}` — e.g. `src/index.ts`
+- `{ENV_VAR_NAME}` — e.g. `LAUNCHDARKLY_SDK_KEY`
+
+**Do not** add documentation URLs to this rules file. If you need SDK doc links for humans, put them only in `LAUNCHDARKLY.md` ([Onboarding Summary](1.8-summary.md)).
+
+If you added or removed skills from the default table (user request), update the skill table in the shared body to match.
+
+## Step 4: Commit the Rules
+
+```bash
+# Claude Code (most common for this skill)
+git add .claude/rules/launchdarkly.md
+
+# Cursor
+git add .cursor/rules/launchdarkly.mdc
+
+# GitHub Copilot / shared instructions
+git add .github/copilot-instructions.md
+
+# Add only the file(s) you created or changed, then:
+git commit -m "chore: add LaunchDarkly feature flag management rules"
+```
+
+Ask the user for permission before committing.

--- a/skills/onboarding/references/sdk/recipes.md
+++ b/skills/onboarding/references/sdk/recipes.md
@@ -1,0 +1,410 @@
+---
+title: SDK Recipes
+description: "Detection patterns, install hints, official doc links, and a per-SDK detail file under references/sdk/snippets/ for every LaunchDarkly SDK in the index"
+---
+
+# SDK Recipes
+
+Use this reference to match a detected tech stack to the correct LaunchDarkly SDK.
+
+**Field | Value** tables in this file are the **index layer**: package name, what to look for in the repo (detect files/patterns), a one-line install hint, and the official **Docs** link. Use them first to choose the right SDK and command—**before** opening a detail file.
+
+Each recipe links to an **SDK detail** file under [`snippets/`](snippets/). Open that file for curated links to official docs, samples, and package registries. Ten of those files also include a **copy-paste onboarding sample**; the rest are pointer-only—follow LaunchDarkly's docs for install and initialization. Never commit real keys. Treat each **Docs** link in the table as canonical for API details and migrations.
+
+> **Source of truth**: Official LaunchDarkly SDK documentation is authoritative. Prefer each recipe's **Docs** link over summaries here.
+
+## Top 10 SDKs (start here)
+
+These are the most common stacks—check here first before scanning less common SDKs below.
+
+### React (Web)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-react-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `react`, `react-dom`, `"react":` |
+| Install | `npm install launchdarkly-react-client-sdk` |
+| Flag key behavior | **camelCase by default.** `useFlags()` transforms `my-flag-key` → `myFlagKey`. Disable with `reactOptions: { useCamelCaseFlagKeys: false }` on the provider. When wiring first-flag code, use the camelCased form unless the project disables it. |
+| Docs | [React SDK reference](https://launchdarkly.com/docs/sdk/client-side/react) · [React Web SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-web) |
+
+**SDK detail:** [`snippets/react-web-sdk.md`](snippets/react-web-sdk.md) (includes onboarding sample)
+
+**API:** Prefer **`asyncWithLDProvider`** with **`timeout`** (seconds; recommend **1–5**) so the app renders after the JS client initializes; alternatively **`withLDProvider`** if you initialize after mount. See [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/react/react-web).
+
+**Next.js:** If `next` is present, this **client** recipe covers browser/client-component flows; server routes and Server Components usually also need **[Node.js (Server)](#nodejs-server)** and an **SDK key** there—see the **Next.js** note under that recipe and [Generate integration plan](../../sdk-install/plan/SKILL.md).
+
+### JavaScript (Browser)
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/js-client-sdk` |
+| Detect files | `package.json`, `index.html` |
+| Detect patterns | `webpack`, `vite`, `parcel`, `rollup`; use when not using React / Vue wrappers |
+| Install | `npm install @launchdarkly/js-client-sdk` |
+| Docs | [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript) |
+
+**SDK detail:** [`snippets/javascript-browser-sdk.md`](snippets/javascript-browser-sdk.md) (includes onboarding sample)
+
+**API vs. other SDKs:** The current browser package is **`@launchdarkly/js-client-sdk`**: **`createClient`**, **`start()`**, then **`waitForInitialization({ timeout })`** (check `result.status`). See the [browser SDK API docs](https://launchdarkly.github.io/js-core/packages/sdk/browser/docs/). The legacy npm name `launchdarkly-js-client-sdk` (v3) used **`initialize()`** without `start()`—do not mix that flow with v4.
+
+### Node.js (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/node-server-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `express`, `fastify`, `koa`, `hapi`, `nestjs`, `next` (API routes), `"type": "module"` |
+| Install | `npm install @launchdarkly/node-server-sdk` |
+| Docs | [Node.js SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/node-js) |
+
+**SDK detail:** [`snippets/node-server-sdk.md`](snippets/node-server-sdk.md) (includes onboarding sample)
+
+**Next.js:** `next` in **Detect patterns** only signals that the **server-side** Node SDK may apply (API routes / Route Handlers, Server Components, server-only code). **Client components** in the browser still need the **[React (Web)](#react-web)** recipe (`launchdarkly-react-client-sdk` and a client-side ID)—do **not** silently pick only the Node server SDK for a full-stack Next app. Plan one or both SDKs depending on where flags are evaluated; align with [Generate integration plan](../../sdk-install/plan/SKILL.md) (Next.js callout there).
+
+### Python (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` ([PyPI](https://pypi.org/project/launchdarkly-server-sdk/)) |
+| Detect files | `requirements.txt`, `pyproject.toml`, `setup.py`, `Pipfile` |
+| Detect patterns | `flask`, `django`, `fastapi`, `starlette` |
+| Install | `pip install launchdarkly-server-sdk` — optional: `pip install launchdarkly-observability` (requires SDK **9.12+**; see [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/python#install-the-sdk)) |
+| Docs | [Python SDK reference](https://launchdarkly.com/docs/sdk/server-side/python) |
+
+**SDK detail:** [`snippets/python-server-sdk.md`](snippets/python-server-sdk.md) (includes onboarding sample)
+
+**API:** **`ldclient.set_config(Config(sdk_key))`** then **`client = ldclient.get()`** (singleton). Optional **`plugins=[ObservabilityPlugin()]`** on **`Config`** with **`launchdarkly-observability`**. Forked workers: **`postfork()`**. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/python#initialize-the-client).
+
+### React Native
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/react-native-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `react-native` |
+| Install | `npm install @launchdarkly/react-native-client-sdk` |
+| Flag key behavior | **camelCase by default.** Same behavior as React Web: `useFlags()` transforms `my-flag-key` → `myFlagKey`. Disable with `reactOptions: { useCamelCaseFlagKeys: false }`. |
+| Docs | [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native) |
+
+**SDK detail:** [`snippets/react-native-sdk.md`](snippets/react-native-sdk.md) (includes onboarding sample)
+
+**API:** **`@launchdarkly/react-native-client-sdk` v10** — **`ReactNativeLDClient`** (mobile key) + **`LDProvider`** + **`identify(context)`** on mount. Non-Expo: add **`@react-native-async-storage/async-storage`** and **`npx pod-install`**. See [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native).
+
+### .NET (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly.ServerSdk` ([NuGet](https://www.nuget.org/packages/LaunchDarkly.ServerSdk/)) |
+| Detect files | `*.csproj`, `*.sln`, `*.fsproj` (look for `BlazorWebAssembly`, `blazorwasm`, `UseBlazorWebAssembly`, `blazorserver`, or `Microsoft.AspNetCore.Components` / `Blazor` in the project) |
+| Detect patterns | `Microsoft.AspNetCore`, `Microsoft.NET`, `Blazor`, `blazor`, `blazorserver` (host/server UI—**not** WASM-only client projects) |
+| Install | `dotnet add package LaunchDarkly.ServerSdk` — optional: `dotnet add package LaunchDarkly.Observability` (requires server SDK **8.10+**; see [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)) |
+| Docs | [.NET SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/dotnet) |
+
+**SDK detail:** [`snippets/dotnet-server-sdk.md`](snippets/dotnet-server-sdk.md) (includes onboarding sample)
+
+**API (current docs):** **`LaunchDarkly.Sdk`** / **`LaunchDarkly.Sdk.Server`** — build config with **`Configuration.Builder(sdkKey).StartWaitTime(...).Build()`**, then **`new LdClient(config)`** before **`WebApplication.CreateBuilder` → `Build()`**. Prefer **`LdClient`** as a **singleton** in DI for real services. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client).
+
+**Blazor:** **Blazor Server** (and other server-hosted Blazor where .NET runs on the server) → this **server-side** SDK and an **SDK key**. **Blazor WebAssembly** runs in the browser → use **[.NET (Client)](#net-client)** (`LaunchDarkly.ClientSdk`, **Client-side ID**). Inspect `.csproj` / SDK props: WASM projects typically use the Blazor WebAssembly workload or `blazorwasm` / `UseBlazorWebAssembly`; do **not** treat those as server-only.
+
+### Java (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `com.launchdarkly:launchdarkly-java-server-sdk` ([Maven Central](https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk)) |
+| Detect files | `pom.xml`, `build.gradle`, `build.gradle.kts`, `*.kt` (JVM services—see note below) |
+| Detect patterns | `spring`, `quarkus`, `micronaut`, `dropwizard`, `kotlin`, `ktor`, `org.jetbrains.kotlin` |
+| Install | **Maven** (`pom.xml`) and **Gradle** (Groovy / Kotlin DSL)—see **Install (Maven and Gradle)** below; pin `version` from [SDK releases](https://github.com/launchdarkly/java-core/releases) |
+| Docs | [Java SDK reference](https://launchdarkly.com/docs/sdk/server-side/java) |
+
+**SDK detail:** [`snippets/java-server-sdk.md`](snippets/java-server-sdk.md) (includes onboarding sample)
+
+**Install (Maven and Gradle):** [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk) shows **XML** for Maven and **Gradle** coordinates. Match your build file (`pom.xml`, `build.gradle`, or `build.gradle.kts`). Example Gradle shortcut: `implementation 'com.launchdarkly:launchdarkly-java-server-sdk:7.+'` or `implementation("com.launchdarkly:launchdarkly-java-server-sdk:7.+")`.
+
+**API:** **`import com.launchdarkly.sdk.*`** / **`com.launchdarkly.sdk.server.*`** — **`new LDClient(sdkKey)`** (default startup wait), **`isInitialized()`**. See [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/java#initialize-the-client).
+
+**Kotlin (JVM) backends:** For **Ktor**, **Spring Boot + Kotlin**, or other **server-side Kotlin on the JVM**, use this **Java server SDK** (`launchdarkly-java-server-sdk`) from Kotlin code—LaunchDarkly does not ship a separate Kotlin server artifact. `build.gradle.kts` plus `.kt` sources without Android-only signals should still match here. **Android** apps (Kotlin or Java) that talk to LaunchDarkly from the device use the **[Android](#android)** client SDK recipe, not this server SDK.
+
+### Go (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `github.com/launchdarkly/go-server-sdk/v7` |
+| Detect files | `go.mod`, `go.sum` |
+| Detect patterns | `net/http`, `gin`, `echo`, `fiber`, `chi` |
+| Install | `go get github.com/launchdarkly/go-server-sdk/v7` |
+| Docs | [Go SDK reference](https://launchdarkly.com/docs/sdk/server-side/go) |
+
+**SDK detail:** [`snippets/go-server-sdk.md`](snippets/go-server-sdk.md) (includes onboarding sample)
+
+### Swift / iOS
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly` ([CocoaPods](https://cocoapods.org/pods/LaunchDarkly); SPM / Carthage via GitHub) |
+| Detect files | `Package.swift`, `Podfile`, `Cartfile`, `*.xcodeproj` |
+| Detect patterns | `UIKit`, `SwiftUI`, `ios` |
+| Install | **SPM**, **CocoaPods**, or **Carthage** — see [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#install-the-sdk) and [`ios-client-sdk.md`](snippets/ios-client-sdk.md); pin versions from [SDK releases](https://github.com/launchdarkly/ios-client-sdk/releases) |
+| Docs | [iOS SDK reference](https://launchdarkly.com/docs/sdk/client-side/ios) · [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) (onboarding) |
+
+**SDK detail:** [`snippets/ios-client-sdk.md`](snippets/ios-client-sdk.md) (includes onboarding sample)
+
+**API:** **`LDConfig(mobileKey:autoEnvAttributes:)`**, **`LDContextBuilder`**, **`LDClient.start(…, startWaitSeconds:completion:)`** — see [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client). Optional **`LaunchDarklyObservability`** (v9.14+).
+
+### Android
+
+| Field | Value |
+|-------|-------|
+| Package | `com.launchdarkly:launchdarkly-android-client-sdk` |
+| Detect files | `build.gradle`, `build.gradle.kts`, `AndroidManifest.xml` |
+| Detect patterns | `android`, `com.android`, `androidx` |
+| Install | See **Install (two Gradle DSLs)** below — same artifact, different syntax for Groovy vs Kotlin DSL |
+| Docs | [Android SDK reference](https://launchdarkly.com/docs/sdk/client-side/android) |
+
+**Install (two Gradle DSLs):** The [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/android#install-the-sdk) topic shows **both** forms. Use the one that matches the app module file you have:
+
+- **Gradle Groovy** (`build.gradle`): `implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'`
+- **Gradle Kotlin DSL** (`build.gradle.kts`): `implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")`
+
+**SDK detail:** [`snippets/android-client-sdk.md`](snippets/android-client-sdk.md) (includes onboarding sample)
+
+---
+
+## Server-side SDKs (other)
+
+Server-side SDKs use an **SDK Key** and are intended for backends where the key stays secret.
+
+The five most-used server runtimes (Node.js, Python, .NET, Java, Go) are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Apex (Salesforce)
+
+| Field | Value |
+|-------|-------|
+| Package | Deploy from [apex-server-sdk](https://github.com/launchdarkly/apex-server-sdk) (no NuGet/Maven module) |
+| Detect files | `sfdx-project.json`, `force-app`, `*.cls` |
+| Detect patterns | `salesforce`, `Salesforce`, `Apex` |
+| Install | Follow the docs (SFDX deploy and LaunchDarkly Salesforce bridge) |
+| Docs | [Apex SDK reference](https://launchdarkly.com/docs/sdk/server-side/apex) |
+
+**SDK detail:** [`snippets/apex-server-sdk.md`](snippets/apex-server-sdk.md)
+
+### C++ (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-cpp-server` (via CMake `FetchContent`, vcpkg, or vendor) |
+| Detect files | `CMakeLists.txt`, `Makefile`, `*.cpp`, `*.h` |
+| Detect patterns | `cmake`, server-side C++ services |
+| Install | See docs (CMake / vcpkg) |
+| Docs | [C++ SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/c-c--) |
+
+**SDK detail:** [`snippets/cpp-server-sdk.md`](snippets/cpp-server-sdk.md)
+
+### Erlang / Elixir
+
+| Field | Value |
+|-------|-------|
+| Package | Erlang: [launchdarkly_server_sdk](https://hex.pm/packages/launchdarkly_server_sdk) (Hex). Elixir: add the same dependency in `mix.exs` |
+| Detect files | `rebar.config`, `mix.exs` |
+| Detect patterns | `erlang`, `elixir`, `phoenix` |
+| Install | Rebar or Mix per docs |
+| Docs | [Erlang SDK reference](https://launchdarkly.com/docs/sdk/server-side/erlang) |
+
+**SDK detail:** [`snippets/erlang-server-sdk.md`](snippets/erlang-server-sdk.md)
+
+### Haskell (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` (Cabal / Stack / Hackage) |
+| Detect files | `*.cabal`, `stack.yaml`, `package.yaml` |
+| Detect patterns | `haskell`, `cabal`, `stack` |
+| Install | Add dependency per docs |
+| Docs | [Haskell SDK reference](https://launchdarkly.com/docs/sdk/server-side/haskell) |
+
+**SDK detail:** [`snippets/haskell-server-sdk.md`](snippets/haskell-server-sdk.md)
+
+### Lua (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` (LuaRocks) |
+| Detect files | `*.lua`, `*.rockspec` |
+| Detect patterns | `lua`, `luarocks`, OpenResty / NGINX / HAProxy Lua |
+| Install | `luarocks install launchdarkly-server-sdk` (see docs for your runtime) |
+| Docs | [Lua SDK reference](https://launchdarkly.com/docs/sdk/server-side/lua) |
+
+**SDK detail:** [`snippets/lua-server-sdk.md`](snippets/lua-server-sdk.md)
+
+### PHP (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly/server-sdk` |
+| Detect files | `composer.json` |
+| Detect patterns | `laravel`, `symfony`, `slim` |
+| Install | `composer require launchdarkly/server-sdk` |
+| Docs | [PHP SDK reference](https://launchdarkly.com/docs/sdk/server-side/php) |
+
+**SDK detail:** [`snippets/php-server-sdk.md`](snippets/php-server-sdk.md)
+
+### Ruby (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` |
+| Detect files | `Gemfile`, `*.gemspec` |
+| Detect patterns | `rails`, `sinatra`, `hanami` |
+| Install | `gem install launchdarkly-server-sdk` or add to Gemfile |
+| Docs | [Ruby SDK reference](https://launchdarkly.com/docs/sdk/server-side/ruby) |
+
+**SDK detail:** [`snippets/ruby-server-sdk.md`](snippets/ruby-server-sdk.md)
+
+### Rust (Server)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-server-sdk` |
+| Detect files | `Cargo.toml` |
+| Detect patterns | `actix`, `rocket`, `axum`, `warp` |
+| Install | `cargo add launchdarkly-server-sdk` |
+| Docs | [Rust SDK reference](https://launchdarkly.com/docs/sdk/server-side/rust) |
+
+**SDK detail:** [`snippets/rust-server-sdk.md`](snippets/rust-server-sdk.md)
+
+---
+
+## Client-side SDKs (other)
+
+Client-side SDKs use a **Client-side ID** for browser and desktop clients where that credential is expected to be visible in the app. Use the linked reference for bootstrap, privacy, and flag delivery behavior.
+
+**React (Web)** and **JavaScript (browser)** are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Vue
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-vue-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `vue`, `"vue":` |
+| Install | `npm install launchdarkly-vue-client-sdk` |
+| Docs | [Vue SDK reference](https://launchdarkly.com/docs/sdk/client-side/vue) |
+
+**SDK detail:** [`snippets/vue-client-sdk.md`](snippets/vue-client-sdk.md)
+
+### Angular, Svelte, Preact, and other browser frameworks
+
+| Field | Value |
+|-------|-------|
+| Package | `@launchdarkly/js-client-sdk` |
+| Detect files | `package.json`, `angular.json`, `svelte.config.js` |
+| Detect patterns | `@angular`, `svelte`, `preact` |
+| Install | `npm install @launchdarkly/js-client-sdk` |
+| Docs | [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript) (no dedicated SDK; use the JS client) |
+
+**SDK detail:** [`snippets/browser-frameworks-sdk.md`](snippets/browser-frameworks-sdk.md)
+
+**API:** Same package and **`createClient`** / **`start()`** / **`waitForInitialization`** flow as [JavaScript (Browser)](#javascript-browser). Prefer [`javascript-browser-sdk.md`](snippets/javascript-browser-sdk.md) for a copy-paste sample.
+
+### .NET (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `LaunchDarkly.ClientSdk` |
+| Detect files | `*.csproj`, `*.sln` (WASM: `blazorwasm`, `BlazorWebAssembly`, `UseBlazorWebAssembly` in project) |
+| Detect patterns | `Xamarin`, `MAUI`, `WPF`, `UWP`, `Avalonia`, `Blazor`, `blazor`, `blazorwasm` |
+| Install | `dotnet add package LaunchDarkly.ClientSdk` |
+| Docs | [.NET SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/dotnet) |
+
+**SDK detail:** [`snippets/dotnet-client-sdk.md`](snippets/dotnet-client-sdk.md)
+
+**Keys:** **MAUI, Xamarin, WPF, UWP** (and similar native/desktop shells) use this package as LaunchDarkly’s **.NET mobile client SDK** with a **mobile key**. **Blazor WebAssembly** (browser-hosted UI) uses the same package with a **Client-side ID**. **Blazor Server** (and server-rendered interactive Blazor) → **[.NET (Server)](#net-server)** with `LaunchDarkly.ServerSdk`. See [Generate integration plan](../../sdk-install/plan/SKILL.md).
+
+### C++ (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-cpp-client` (CMake / vcpkg per docs) |
+| Detect files | `CMakeLists.txt`, `Makefile`, `*.cpp`, `*.h` |
+| Detect patterns | Desktop or embedded C++ clients |
+| Install | See docs |
+| Docs | [C++ SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/c-c--) |
+
+**SDK detail:** [`snippets/cpp-client-sdk.md`](snippets/cpp-client-sdk.md)
+
+### Electron
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-electron-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | `electron` |
+| Install | `npm install launchdarkly-electron-client-sdk` |
+| Docs | [Electron SDK reference](https://launchdarkly.com/docs/sdk/client-side/electron) |
+
+**SDK detail:** [`snippets/electron-client-sdk.md`](snippets/electron-client-sdk.md)
+
+### Node.js (Client)
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly-node-client-sdk` |
+| Detect files | `package.json` |
+| Detect patterns | Node scripts or desktop tooling **without** Electron (see Electron above) |
+| Install | `npm install launchdarkly-node-client-sdk` |
+| Docs | [Node.js SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/node-js) |
+
+**SDK detail:** [`snippets/node-client-sdk.md`](snippets/node-client-sdk.md)
+
+### Roku (BrightScript)
+
+| Field | Value |
+|-------|-------|
+| Package | [roku-client-sdk](https://github.com/launchdarkly/roku-client-sdk) (GitHub releases) |
+| Detect files | `manifest`, `*.brs`, SceneGraph `*.xml` |
+| Detect patterns | `brightscript`, `roku`, `SceneGraph` |
+| Install | Add SDK components per docs |
+| Docs | [Roku SDK reference](https://launchdarkly.com/docs/sdk/client-side/roku) |
+
+**SDK detail:** [`snippets/roku-client-sdk.md`](snippets/roku-client-sdk.md)
+
+---
+
+## Mobile SDKs (other)
+
+These entries are **mobile or app-embedded** targets. Most use a **Mobile key**; **Flutter web** is an exception (see below). Each **Docs** link points at the official reference (same pages as the client-side SDK family on launchdarkly.com/docs).
+
+**Swift / iOS**, **Android**, and **React Native** are in **[Top 10 SDKs (start here)](#top-10-sdks-start-here)** above.
+
+### Flutter
+
+LaunchDarkly documents this as the **Flutter client SDK** (`launchdarkly_flutter_client_sdk`); it is listed here because **iOS, Android, and typical desktop app** builds use a **Mobile key**.
+
+| Field | Value |
+|-------|-------|
+| Package | `launchdarkly_flutter_client_sdk` |
+| Detect files | `pubspec.yaml` |
+| Detect patterns | `flutter` |
+| Install | `flutter pub add launchdarkly_flutter_client_sdk` |
+| Docs | [Flutter SDK reference](https://launchdarkly.com/docs/sdk/client-side/flutter) |
+
+**SDK detail:** [`snippets/flutter-client-sdk.md`](snippets/flutter-client-sdk.md)
+
+**Keys:** **Mobile key** for iOS, Android, and typical **desktop app** targets; **Client-side ID** (and your bundler’s public env pattern) for **Flutter web**. Multi-target apps may need separate config per surface—see [Generate integration plan](../../sdk-install/plan/SKILL.md).
+
+---
+
+## Edge SDKs
+
+Edge SDKs run on edge platforms and use an **SDK Key** (see each platform's reference for environment and constraints).
+
+| Platform | Detect pattern | Docs |
+|----------|----------------|------|
+| Akamai EdgeWorkers | `bundle.json`, `edgeworkers` | [Akamai SDK reference](https://launchdarkly.com/docs/sdk/edge/akamai) |
+| Cloudflare Workers | `wrangler.toml`, `@cloudflare/workers-types` | [Cloudflare SDK reference](https://launchdarkly.com/docs/sdk/edge/cloudflare) |
+| Fastly Compute | Fastly service config, `@fastly/js-compute` (per your stack) | [Fastly SDK reference](https://launchdarkly.com/docs/sdk/edge/fastly) |
+| Vercel Edge | `vercel.json` with edge functions, `@vercel/edge` | [Vercel SDK reference](https://launchdarkly.com/docs/sdk/edge/vercel) |
+
+**SDK detail:** [`snippets/edge-sdks.md`](snippets/edge-sdks.md) (all edge platforms)
+
+---

--- a/skills/onboarding/references/sdk/snippets/android-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/android-client-sdk.md
@@ -1,0 +1,88 @@
+---
+title: Android Client SDK — SDK detail
+description: Kotlin onboarding sample and links for the LaunchDarkly Android SDK
+---
+
+# Android — SDK detail
+
+- Official docs: [Android SDK reference](https://launchdarkly.com/docs/sdk/client-side/android) · [Set up Android SDK](https://launchdarkly.com/docs/home/onboarding/android) (onboarding)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Android)
+
+**Install the dependency:** [Install the SDK](https://launchdarkly.com/docs/sdk/client-side/android#install-the-sdk) documents **two** Gradle styles—the same Maven coordinate, different syntax. Pick the one that matches your app module:
+
+```groovy
+// Gradle Groovy — typically app/build.gradle
+implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'
+```
+
+```kotlin
+// Gradle Kotlin DSL — typically app/build.gradle.kts
+implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
+```
+
+**Import the SDK:** Use the imports that match your language ([Import the SDK](https://launchdarkly.com/docs/sdk/client-side/android#import-the-sdk)). Observability is **optional** (separate `launchdarkly-observability-android` dependency; requires Android client SDK **v5.9+**).
+
+Kotlin:
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability
+// import com.launchdarkly.sdk.android.integrations.Plugin
+```
+
+Java:
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.android.*;
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability;
+// import com.launchdarkly.sdk.android.integrations.Plugin;
+```
+
+The init snippet below matches the [onboarding initialization example](https://launchdarkly.com/docs/home/onboarding/android): use a placeholder mobile key first, then wire a real value from build configuration (see optional Gradle section). `BuildConfig.LAUNCHDARKLY_MOBILE_KEY` is **not** defined unless you add `buildConfigField` yourself—do not paste it without the Gradle setup.
+
+**Includes:** Copy-paste onboarding sample below (Kotlin). Place inside your `Application` subclass (for example `onCreate()`); `this` refers to that `Application` instance.
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+
+// Optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
+// import com.launchdarkly.observability.plugin.Observability
+// import com.launchdarkly.sdk.android.integrations.Plugin
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("YOUR_MOBILE_KEY")
+    .build()
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+val context = LDContext.create("EXAMPLE_CONTEXT_KEY")
+
+// If you don't want to block execution while the SDK tries to get
+// latest flags, move this code into an async IO task and await on its completion.
+val client: LDClient = LDClient.init(this, ldConfig, context, 5)
+```
+
+Replace `"YOUR_MOBILE_KEY"` with your **Mobile key** from LaunchDarkly **Project settings > Environments** (see [Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration)). Never commit real keys in source.
+
+**Optional — `BuildConfig` + Gradle (Kotlin DSL):** Enable BuildConfig and pass the key from a non-committed `gradle.properties` or `local.properties` value:
+
+```kotlin
+// app/build.gradle.kts — excerpt
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+    defaultConfig {
+        val key = (project.findProperty("LAUNCHDARKLY_MOBILE_KEY") as String?)?.trim().orEmpty()
+        buildConfigField("String", "LAUNCHDARKLY_MOBILE_KEY", "\"$key\"")
+    }
+}
+```
+
+Then change `.mobileKey("YOUR_MOBILE_KEY")` to `.mobileKey(BuildConfig.LAUNCHDARKLY_MOBILE_KEY)` and set `LAUNCHDARKLY_MOBILE_KEY=…` where Gradle can read it (for example `~/.gradle/gradle.properties` or a CI secret), not in a committed file.

--- a/skills/onboarding/references/sdk/snippets/apex-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/apex-server-sdk.md
@@ -1,0 +1,17 @@
+---
+title: Apex (Salesforce) Server SDK
+description: Where to find LaunchDarkly Apex server SDK setup and API documentation
+---
+
+# Apex (Salesforce) — SDK detail
+
+**Primary:** [Apex SDK reference](https://launchdarkly.com/docs/sdk/server-side/apex) — deployment (SFDX), Salesforce bridge, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [apex-server-sdk](https://github.com/launchdarkly/apex-server-sdk)
+- Sample: [hello-apex-server](https://github.com/launchdarkly/hello-apex-server)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Apex (Salesforce)
+
+There is no bundled onboarding code sample in this repo for Apex; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/browser-frameworks-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/browser-frameworks-sdk.md
@@ -1,0 +1,20 @@
+---
+title: Browser frameworks without a dedicated LaunchDarkly SDK
+description: Use the JavaScript client SDK for Angular, Svelte, Preact, and similar frontends
+---
+
+# Angular, Svelte, Preact, and other browser frameworks — SDK detail
+
+LaunchDarkly does not ship separate SDKs for every SPA framework. Use the **JavaScript (browser) SDK** and follow its reference for install, initialization, and evaluation.
+
+**Primary:** [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript)
+
+**Onboarding sample (JS browser) in this repo:** [`javascript-browser-sdk.md`](javascript-browser-sdk.md)
+
+**Also useful:**
+
+- npm: [launchdarkly-js-client-sdk](https://www.npmjs.com/package/launchdarkly-js-client-sdk)
+- GitHub: [js-client-sdk](https://github.com/launchdarkly/js-client-sdk)
+- API docs: [JavaScript SDK API](https://launchdarkly.github.io/js-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Angular, Svelte, Preact, and other browser frameworks

--- a/skills/onboarding/references/sdk/snippets/cpp-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/cpp-client-sdk.md
@@ -1,0 +1,18 @@
+---
+title: C++ Client SDK
+description: Where to find LaunchDarkly C++ client SDK setup and API documentation
+---
+
+# C++ (Client) — SDK detail
+
+**Primary:** [C++ SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/c-c--) — CMake, vcpkg, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [cpp-sdks / client-sdk](https://github.com/launchdarkly/cpp-sdks/tree/main/libs/client-sdk)
+- Samples: [hello-c-client](https://github.com/launchdarkly/cpp-sdks/tree/main/examples/hello-c-client), [hello-cpp-client](https://github.com/launchdarkly/cpp-sdks/tree/main/examples/hello-cpp-client)
+- API docs: [C++ client SDK API](https://launchdarkly.github.io/cpp-sdks/libs/client-sdk/docs/html/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — C++ (Client)
+
+There is no bundled onboarding code sample in this repo for C++ client; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/cpp-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/cpp-server-sdk.md
@@ -1,0 +1,17 @@
+---
+title: C++ Server SDK
+description: Where to find LaunchDarkly C++ server SDK setup and API documentation
+---
+
+# C++ (Server) — SDK detail
+
+**Primary:** [C++ SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/c-c--) — CMake, vcpkg, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [cpp-sdks](https://github.com/launchdarkly/cpp-sdks)
+- API docs: [C/C++ server SDK API](https://launchdarkly.github.io/cpp-sdks/libs/server-sdk/docs/html)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — C++ (Server)
+
+There is no bundled onboarding code sample in this repo for C++ server; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/dotnet-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/dotnet-client-sdk.md
@@ -1,0 +1,21 @@
+---
+title: .NET Client SDK
+description: Where to find LaunchDarkly .NET client SDK setup (Xamarin, MAUI, desktop, Blazor WASM, etc.)
+---
+
+# .NET (Client) — SDK detail
+
+Same NuGet package (`LaunchDarkly.ClientSdk`) is used for **mobile-style apps** (MAUI, Xamarin, WPF, UWP, etc.) with a **mobile key** and for **Blazor WebAssembly** / browser-hosted UI with a **Client-side ID**. See [Generate integration plan](../../../sdk-install/plan/SKILL.md).
+
+**Primary:** [.NET SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/dotnet) — NuGet, initialization, and API.
+
+**Also useful:**
+
+- NuGet: [LaunchDarkly.ClientSdk](https://www.nuget.org/packages/LaunchDarkly.ClientSdk/)
+- GitHub: [.NET client SDK](https://github.com/launchdarkly/dotnet-core/tree/main/pkgs/sdk/client)
+- Sample: [hello-dotnet-client](https://github.com/launchdarkly/hello-dotnet-client)
+- API docs: [.NET client SDK API](https://launchdarkly.github.io/dotnet-core/pkgs/sdk/client/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — .NET (Client)
+
+There is no bundled onboarding code sample in this repo for .NET client; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/dotnet-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/dotnet-server-sdk.md
@@ -1,0 +1,78 @@
+---
+title: .NET Server SDK — SDK detail
+description: ASP.NET Core onboarding sample and links for the LaunchDarkly server-side .NET SDK
+---
+
+# .NET (Server) — SDK detail
+
+- Official docs: [.NET SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/dotnet)
+- API reference: [Server SDK API](https://launchdarkly.github.io/dotnet-core/pkgs/sdk/server/)
+- Published package: [LaunchDarkly.ServerSdk (NuGet)](https://www.nuget.org/packages/LaunchDarkly.ServerSdk/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (.NET Server)
+
+Target the **current major** server SDK on NuGet (`LaunchDarkly.ServerSdk`); follow the docs for version compatibility ([.NET SDK reference](https://launchdarkly.com/docs/sdk/server-side/dotnet)).
+
+**Install:** From the project directory ([Install the SDK](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)):
+
+```bash
+dotnet add package LaunchDarkly.ServerSdk
+```
+
+Optional observability ([.NET observability](https://launchdarkly.com/docs/sdk/observability/dotnet)) — requires server SDK **8.10+**:
+
+```bash
+dotnet add package LaunchDarkly.Observability
+```
+
+**Import:** Namespace differs from the package name ([same page — import](https://launchdarkly.com/docs/sdk/server-side/dotnet#install-the-sdk)):
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+// Optional — LaunchDarkly.Observability package; requires server SDK 8.10+
+// using LaunchDarkly.Observability;
+```
+
+**Initialize:** Use **`Configuration.Builder(sdkKey)`** with **`StartWaitTime`** (docs recommend a short wait so a bad network does not hang forever). Construct **`LdClient`** **before** **`builder.Build()`** ([Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client)). In production, register **`LdClient`** as a **singleton** in DI instead of creating one per request.
+
+**Includes:** Minimal **ASP.NET Core** `Program.cs`–style sample. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration)).
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var sdkKey = Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY");
+if (string.IsNullOrWhiteSpace(sdkKey))
+{
+    Console.Error.WriteLine(
+        "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.");
+    Environment.Exit(1);
+}
+
+var ldConfig = Configuration.Builder(sdkKey)
+    .StartWaitTime(TimeSpan.FromSeconds(5))
+    .Build();
+
+// Construct the client before Build() per LaunchDarkly docs.
+using var ldClient = new LdClient(ldConfig);
+
+var app = builder.Build();
+
+if (!ldClient.Initialized)
+{
+    Console.Error.WriteLine("LaunchDarkly client did not initialize within StartWaitTime.");
+    Environment.Exit(1);
+}
+
+// For onboarding only — events are normally flushed in the background.
+ldClient.Flush();
+Console.WriteLine("LaunchDarkly client ready.");
+
+// app.MapGet(...);
+app.Run();
+```
+
+**Optional — observability (SDK 8.10+):** After adding **`LaunchDarkly.Observability`**, follow the **`ObservabilityPlugin.Builder(builder.Services)`** example in [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/dotnet#initialize-the-client) inside **`Configuration.Builder`’s** **`Plugins`** chain.

--- a/skills/onboarding/references/sdk/snippets/edge-sdks.md
+++ b/skills/onboarding/references/sdk/snippets/edge-sdks.md
@@ -1,0 +1,19 @@
+---
+title: Edge SDKs (Cloudflare, Vercel, Fastly, Akamai)
+description: Where to find LaunchDarkly edge platform SDK documentation and packages
+---
+
+# Edge SDKs — SDK detail
+
+Edge SDKs use an **SDK Key**. Use the platform-specific reference for constraints (e.g. KV, environment, bundling).
+
+| Platform | Detect pattern | Official docs | Package / repo |
+|----------|----------------|---------------|----------------|
+| Akamai EdgeWorkers | `bundle.json`, `edgeworkers` | [Akamai SDK reference](https://launchdarkly.com/docs/sdk/edge/akamai) | [js-core / akamai-edgekv](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/akamai-edgekv) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/akamai-edgekv/docs) |
+| Cloudflare Workers | `wrangler.toml`, `@cloudflare/workers-types` | [Cloudflare SDK reference](https://launchdarkly.com/docs/sdk/edge/cloudflare) | [js-core / cloudflare](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/cloudflare) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/cloudflare/docs/) |
+| Fastly Compute | Fastly config, `@fastly/js-compute` (typical) | [Fastly SDK reference](https://launchdarkly.com/docs/sdk/edge/fastly) | [js-core / fastly](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/fastly) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/fastly/docs/) |
+| Vercel Edge | `vercel.json` with edge functions, `@vercel/edge` | [Vercel SDK reference](https://launchdarkly.com/docs/sdk/edge/vercel) | [js-core / vercel](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/vercel) · [API docs](https://launchdarkly.github.io/js-core/packages/sdk/vercel/docs/) |
+
+**Recipe index:** [SDK Recipes](../recipes.md) — Edge SDKs
+
+There are no bundled onboarding code samples in this repo for edge SDKs; follow each platform’s official reference.

--- a/skills/onboarding/references/sdk/snippets/electron-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/electron-client-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Electron Client SDK
+description: Where to find LaunchDarkly Electron client SDK setup and API documentation
+---
+
+# Electron — SDK detail
+
+**Primary:** [Electron SDK reference](https://launchdarkly.com/docs/sdk/client-side/electron) — npm install, initialization, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-electron-client-sdk](https://www.npmjs.com/package/launchdarkly-electron-client-sdk)
+- GitHub: [electron-client-sdk](https://github.com/launchdarkly/electron-client-sdk)
+- Sample: [hello-electron](https://github.com/launchdarkly/hello-electron)
+- API docs: [Electron SDK API](https://launchdarkly.github.io/electron-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Electron
+
+There is no bundled onboarding code sample in this repo for Electron; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/erlang-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/erlang-server-sdk.md
@@ -1,0 +1,18 @@
+---
+title: Erlang / Elixir Server SDK
+description: Where to find LaunchDarkly Erlang server SDK setup (including Elixir via Hex)
+---
+
+# Erlang / Elixir — SDK detail
+
+**Primary:** [Erlang SDK reference](https://launchdarkly.com/docs/sdk/server-side/erlang) — Rebar, Mix, initialization, and API.
+
+**Also useful:**
+
+- Hex package: [launchdarkly_server_sdk](https://hex.pm/packages/launchdarkly_server_sdk)
+- GitHub: [erlang-server-sdk](https://github.com/launchdarkly/erlang-server-sdk/)
+- Samples: [hello-elixir](https://github.com/launchdarkly/hello-elixir), [hello-phoenix](https://github.com/launchdarkly/hello-phoenix)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Erlang / Elixir
+
+There is no bundled onboarding code sample in this repo for Erlang/Elixir; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/flutter-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/flutter-client-sdk.md
@@ -1,0 +1,21 @@
+---
+title: Flutter Client SDK
+description: Where to find LaunchDarkly Flutter client SDK setup and API documentation
+---
+
+# Flutter — SDK detail
+
+Official docs are the **Flutter client SDK** (`launchdarkly_flutter_client_sdk`). Use a **mobile key** for typical **iOS, Android, and desktop app** builds; use a **Client-side ID** (and public env naming for web) for **Flutter web**. Multi-target apps: see [Generate integration plan](../../../sdk-install/plan/SKILL.md).
+
+**Primary:** [Flutter SDK reference](https://launchdarkly.com/docs/sdk/client-side/flutter) — `pubspec`, initialization, and API.
+
+**Also useful:**
+
+- pub.dev: [launchdarkly_flutter_client_sdk](https://pub.dev/packages/launchdarkly_flutter_client_sdk)
+- GitHub: [flutter-client-sdk](https://github.com/launchdarkly/flutter-client-sdk)
+- Example app: [flutter_client_sdk example](https://github.com/launchdarkly/flutter-client-sdk/tree/main/packages/flutter_client_sdk/example)
+- API docs: [Flutter SDK API](https://pub.dev/documentation/launchdarkly_flutter_client_sdk/latest/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Flutter
+
+There is no bundled onboarding code sample in this repo for Flutter; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/go-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/go-server-sdk.md
@@ -1,0 +1,40 @@
+---
+title: Go Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Go server-side SDK
+---
+
+# Go (Server) — SDK detail
+
+- Official docs: [Go SDK reference](https://launchdarkly.com/docs/sdk/server-side/go)
+- API reference: [`LDClient`, `MakeClient`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Go Server)
+
+The [Initialize the client](https://launchdarkly.com/docs/sdk/server-side/go#initialize-the-client) chapter shows **`MakeClient`** / **`MakeCustomClient`** (and optional **`ldcontext`** + **`NewScopedClient`** for a scoped client). It does **not** use **`Initialized()`** in that section. The **`error`** from **`MakeClient`** is what signals construction-time failure (see the “Best practices for error handling” callout in those docs). If you need to branch on “fully ready” after the timeout window, use **[`Initialized`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7#LDClient.Initialized)** or **[Monitoring SDK status](https://launchdarkly.com/docs/sdk/features/monitoring#go)**—read **[`MakeClient`](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7#MakeClient)** for how the **timeout** interacts with returning before the client has finished connecting.
+
+**Includes:** Minimal onboarding sample aligned with **“Go SDK, using LDClient and default configuration”** in the docs. For **`MakeCustomClient`**, **`ldcontext`**, **`LDScopedClient`**, or the **observability** plugin, follow the same page’s larger examples.
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+)
+
+func main() {
+	ldClient, err := ld.MakeClient(os.Getenv("LAUNCHDARKLY_SDK_KEY"), 5*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create LaunchDarkly client: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("LaunchDarkly client created.")
+
+	// For onboarding purposes only we flush events as soon as
+	// possible so we quickly detect your connection.
+	// You don't have to do this in practice because events are automatically flushed.
+	ldClient.Flush()
+}
+```

--- a/skills/onboarding/references/sdk/snippets/haskell-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/haskell-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Haskell Server SDK
+description: Where to find LaunchDarkly Haskell server SDK setup and API documentation
+---
+
+# Haskell (Server) — SDK detail
+
+**Primary:** [Haskell SDK reference](https://launchdarkly.com/docs/sdk/server-side/haskell) — Cabal/Stack, initialization, and API.
+
+**Also useful:**
+
+- Hackage: [launchdarkly-server-sdk](https://hackage.haskell.org/package/launchdarkly-server-sdk)
+- GitHub: [haskell-server-sdk](https://github.com/launchdarkly/haskell-server-sdk)
+- Sample: [hello-haskell-server](https://github.com/launchdarkly/hello-haskell-server)
+- API docs: [Haskell SDK API](https://launchdarkly.github.io/haskell-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Haskell (Server)
+
+There is no bundled onboarding code sample in this repo for Haskell; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/ios-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/ios-client-sdk.md
@@ -1,0 +1,105 @@
+---
+title: iOS (Swift) Client SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly iOS SDK
+---
+
+# Swift / iOS — SDK detail
+
+- Official docs: [iOS SDK reference](https://launchdarkly.com/docs/sdk/client-side/ios) · [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) (onboarding)
+- API reference: [iOS SDK API docs](https://launchdarkly.github.io/ios-client-sdk/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Swift / iOS)
+
+**Why this differs from the home onboarding page:** [Set up iOS SDK](https://launchdarkly.com/docs/home/onboarding/ios) uses a **`"YOUR_MOBILE_KEY"`** literal and a linear script. This skill keeps the **same `LDConfig` / `LDContextBuilder` / `LDClient.start`…`startWaitSeconds`** flow as [Initialize the client](https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client), but resolves the mobile key from **Xcode scheme env** or **Info.plist** so archives are not missing the key. Substituting `LDConfig(mobileKey: "YOUR_MOBILE_KEY", …)` matches the docs verbatim when you only need a quick local paste.
+
+**Install the SDK:** LaunchDarkly documents **Swift Package Manager**, **CocoaPods**, and **Carthage** ([Install the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#install-the-sdk)). Pin versions from the [SDK releases](https://github.com/launchdarkly/ios-client-sdk/releases) page; the examples below follow the [onboarding install](https://launchdarkly.com/docs/home/onboarding/ios) style.
+
+**Swift Package Manager** (`Package.swift` excerpt):
+
+```swift
+// ...
+dependencies: [
+    .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", .upToNextMajor("9.15.0")),
+    // Optional observability — iOS SDK v9.14+; see reference Install the SDK
+    // .package(url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git", .upToNextMajor("1.0.0")),
+],
+targets: [
+    .target(
+        name: "YOUR_TARGET",
+        dependencies: ["LaunchDarkly"]
+    ),
+]
+// ...
+```
+
+**CocoaPods** (`Podfile`):
+
+```ruby
+use_frameworks!
+target 'YourTargetName' do
+  pod 'LaunchDarkly', '~> 9.15'
+  # Optional — LaunchDarklyObservability, iOS SDK v9.14+
+  # pod 'LaunchDarklyObservability', '~> 1.0'
+end
+```
+
+**Carthage** (`Cartfile`):
+
+```
+github "launchdarkly/ios-client-sdk" ~> 9.15
+```
+
+**Import** ([Import the SDK](https://launchdarkly.com/docs/sdk/client-side/ios#import-the-sdk)):
+
+```swift
+import LaunchDarkly
+// Optional observability — iOS SDK v9.14+
+// import LaunchDarklyObservability
+```
+
+**Mobile key:** Never ship a real key in source. `ProcessInfo.processInfo.environment` is set from the **Xcode scheme** for local runs; **TestFlight / App Store** builds need **Info.plist** (e.g. `LaunchDarklyMobileKey`) or xcconfig. Logical name: [Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration).
+
+**Includes:** Call `configureLaunchDarkly()` from `application(_:didFinishLaunchingWithOptions:)` (UIKit) or your SwiftUI startup path.
+
+```swift
+import LaunchDarkly
+
+func configureLaunchDarkly() {
+    let mobileKey: String?
+    if let v = ProcessInfo.processInfo.environment["LAUNCHDARKLY_MOBILE_KEY"], !v.isEmpty {
+        mobileKey = v
+    } else if let v = Bundle.main.object(forInfoDictionaryKey: "LaunchDarklyMobileKey") as? String, !v.isEmpty {
+        mobileKey = v
+    } else {
+        mobileKey = nil
+    }
+
+    guard let mobileKey else {
+        print("LaunchDarkly: missing mobile key (scheme LAUNCHDARKLY_MOBILE_KEY for Xcode runs, or Info.plist LaunchDarklyMobileKey for archives).")
+        return
+    }
+
+    let config = LDConfig(mobileKey: mobileKey, autoEnvAttributes: .enabled)
+    // Optional observability — iOS SDK v9.14+; add package/pod and set config.plugins per
+    // https://launchdarkly.com/docs/sdk/client-side/ios#initialize-the-client
+
+    let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    guard case .success(let context) = contextBuilder.build() else {
+        print("LaunchDarkly: could not build context")
+        return
+    }
+
+    LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+        if timedOut {
+            print("SDK didn't initialize in 5 seconds. SDK is still running and trying to get latest flags.")
+        } else {
+            print("SDK successfully initialized with the latest flags")
+            if let client = LDClient.get() {
+                // For onboarding only — events are flushed automatically in normal use.
+                client.flush()
+            }
+        }
+    }
+
+    print("SDK started.")
+}
+```

--- a/skills/onboarding/references/sdk/snippets/java-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/java-server-sdk.md
@@ -1,0 +1,82 @@
+---
+title: Java Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Java server-side SDK
+---
+
+# Java (Server) — SDK detail
+
+- Official docs: [Java SDK reference](https://launchdarkly.com/docs/sdk/server-side/java)
+- API reference: [Java server SDK API](https://launchdarkly.github.io/java-core/lib/sdk/server/)
+- Published artifact: [Maven Central](https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Java Server)
+
+Pin **`version`** to a current release from the [SDK releases page](https://github.com/launchdarkly/java-core/releases). The blocks below mirror [Install the SDK](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk) (Maven **XML** and **Gradle**); use the one that matches your build.
+
+**Maven** (`pom.xml`):
+
+```xml
+<dependency>
+  <groupId>com.launchdarkly</groupId>
+  <artifactId>launchdarkly-java-server-sdk</artifactId>
+  <version>7.0.0</version>
+</dependency>
+```
+
+**Gradle (Groovy)** — long form as in the docs:
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
+```
+
+**Gradle (Groovy)** — common shortcut (still set a concrete or ranged version you intend to support):
+
+```groovy
+implementation 'com.launchdarkly:launchdarkly-java-server-sdk:7.+'
+```
+
+**Gradle (Kotlin DSL)** (`build.gradle.kts`):
+
+```kotlin
+implementation("com.launchdarkly:launchdarkly-java-server-sdk:7.+")
+```
+
+**OSGi “all” classifier** (bundled Gson/SLF4J): see [Using the Java SDK in OSGi](https://launchdarkly.com/docs/sdk/server-side/java#using-the-java-sdk-in-osgi).
+
+**Import** ([same topic](https://launchdarkly.com/docs/sdk/server-side/java#install-the-sdk)):
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+```
+
+**Initialize:** [`new LDClient(sdkKey)`](https://launchdarkly.com/docs/sdk/server-side/java#initialize-the-client) connects with a **default ~5s** wait; use [`isInitialized()`](https://launchdarkly.github.io/java-core/lib/sdk/server/com/launchdarkly/sdk/server/LDClient.html#isInitialized--) to see if startup succeeded. For custom timeouts and options, use [`LDConfig.Builder`](https://launchdarkly.github.io/java-core/lib/sdk/server/com/launchdarkly/sdk/server/LDConfig.Builder.html). **`LDClient` must be a singleton** per environment.
+
+**Includes:** Minimal `main` sample. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration)).
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
+public class Main {
+  public static void main(String[] args) {
+    String sdkKey = System.getenv("LAUNCHDARKLY_SDK_KEY");
+    if (sdkKey == null || sdkKey.trim().isEmpty()) {
+      System.err.println(
+          "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.");
+      System.exit(1);
+    }
+
+    try (LDClient client = new LDClient(sdkKey)) {
+      if (client.isInitialized()) {
+        // For onboarding only — events are normally flushed in the background.
+        client.flush();
+        System.out.println("LaunchDarkly client initialized.");
+      } else {
+        System.err.println(
+            "LaunchDarkly client did not initialize within the default wait; defaults apply until connected.");
+        System.exit(1);
+      }
+    }
+  }
+}
+```

--- a/skills/onboarding/references/sdk/snippets/javascript-browser-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/javascript-browser-sdk.md
@@ -1,0 +1,49 @@
+---
+title: JavaScript Browser SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly JavaScript client-side (browser) SDK
+---
+
+# JavaScript (Browser) — SDK detail
+
+- Official docs: [JavaScript SDK reference](https://launchdarkly.com/docs/sdk/client-side/javascript)
+- API reference: [Browser client (`@launchdarkly/js-client-sdk`)](https://launchdarkly.github.io/js-core/packages/sdk/browser/docs/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (JavaScript Browser)
+
+Use **`@launchdarkly/js-client-sdk`**: **`createClient`**, **`start()`**, then **`waitForInitialization({ timeout })`**. Always pass a **timeout** (the docs recommend **1–5 seconds**); without one, connectivity issues can block your app. In v4, `waitForInitialization` **always settles** with a **status** (`complete`, `failed`, or `timeout`)—handle each path ([Use promises to determine when the client is ready](https://launchdarkly.com/docs/sdk/client-side/javascript)).
+
+**Client-side ID and env vars:** Use the **Client-side ID** from **Project settings > Environments** (not a server SDK key). Bundler prefixes: [Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration).
+
+Use this in an ES module context that supports top-level `await`, or wrap in an `async` function.
+
+**Includes:** Copy-paste onboarding sample below. After `status === 'complete'`, replace the flush/log block with your own logic (the docs’ `handleInitializedClient` is only an illustration).
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+const clientSideID = import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID;
+
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+};
+
+const client = createClient(clientSideID, context);
+client.start();
+
+const result = await client.waitForInitialization({ timeout: 5 });
+
+if (result.status === 'complete') {
+  await client.flush();
+  console.log('SDK successfully initialized!');
+} else if (result.status === 'failed') {
+  console.error('LaunchDarkly initialization failed:', result.error);
+} else if (result.status === 'timeout') {
+  console.error(
+    'LaunchDarkly initialization timed out; the client keeps retrying in the background.',
+  );
+}
+```
+
+For Create React App, replace `import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` with `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID`. For Next.js, use `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID`.

--- a/skills/onboarding/references/sdk/snippets/lua-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/lua-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Lua Server SDK
+description: Where to find LaunchDarkly Lua server SDK setup and API documentation
+---
+
+# Lua (Server) — SDK detail
+
+**Primary:** [Lua SDK reference](https://launchdarkly.com/docs/sdk/server-side/lua) — LuaRocks, runtime integration (e.g. OpenResty, NGINX), initialization, and API.
+
+**Also useful:**
+
+- LuaRocks: [launchdarkly modules](https://luarocks.org/modules/launchdarkly)
+- GitHub: [lua-server-sdk](https://github.com/launchdarkly/lua-server-sdk)
+- Samples: [hello-lua-server](https://github.com/launchdarkly/hello-lua-server), [hello-haproxy](https://github.com/launchdarkly/hello-haproxy), [hello-nginx](https://github.com/launchdarkly/hello-nginx)
+- API docs: [Lua SDK modules](https://launchdarkly.github.io/lua-server-sdk/modules/launchdarkly-server-sdk.html)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Lua (Server)
+
+There is no bundled onboarding code sample in this repo for Lua; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/node-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/node-client-sdk.md
@@ -1,0 +1,21 @@
+---
+title: Node.js Client SDK
+description: Where to find LaunchDarkly Node.js client SDK setup (non-Electron Node apps)
+---
+
+# Node.js (Client) — SDK detail
+
+**Primary:** [Node.js SDK reference (client-side)](https://launchdarkly.com/docs/sdk/client-side/node-js) — npm install, initialization, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-node-client-sdk](https://www.npmjs.com/package/launchdarkly-node-client-sdk)
+- GitHub: [node-client-sdk](https://github.com/launchdarkly/node-client-sdk)
+- Sample: [hello-node-client](https://github.com/launchdarkly/hello-node-client)
+- API docs: [Node.js client SDK API](https://launchdarkly.github.io/node-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Node.js (Client)
+
+For **Electron**, use [`electron-client-sdk.md`](electron-client-sdk.md) instead.
+
+There is no bundled onboarding code sample in this repo for Node client; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/node-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/node-server-sdk.md
@@ -1,0 +1,68 @@
+---
+title: Node.js Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Node.js server-side SDK
+---
+
+# Node.js (Server) — SDK detail
+
+- Official docs: [Node.js SDK reference (server-side)](https://launchdarkly.com/docs/sdk/server-side/node-js)
+- API reference: [SDK API docs](https://launchdarkly.github.io/js-core/packages/sdk/server-node/docs/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Node.js Server)
+
+**Includes:** Patterns below follow the **Get started**, **Initialize the client**, **Evaluate a context**, and **Promises and async** sections of the [Node.js server-side SDK reference](https://launchdarkly.com/docs/sdk/server-side/node-js). Use **one** initialization strategy (`waitForInitialization` **or** the `ready` event—not both at once unless you know why). Aligns with [Create First Feature Flag](../../../first-flag/SKILL.md) (evaluation uses **context** + default).
+
+### Singleton client
+
+`LDClient` must be a **singleton** per LaunchDarkly environment—do not create a new client per request. Use your real SDK key from env vars, not a literal in source.
+
+```javascript
+import { init } from '@launchdarkly/node-server-sdk';
+
+const client = init(process.env.LAUNCHDARKLY_SDK_KEY);
+```
+
+### Wait for initialization (startup)
+
+Run this **once** during process startup—for example before your HTTP server accepts connections, inside whatever async bootstrap your framework provides. The public docs use `{ timeout: 10 }` (seconds); adjust as needed.
+
+**Promise style** (from [Promises and async](https://launchdarkly.com/docs/sdk/server-side/node-js)):
+
+```javascript
+client
+  .waitForInitialization({ timeout: 5 })
+  .then(() => {
+    // Initialization complete — safe to evaluate flags and/or start serving traffic.
+  })
+  .catch((err) => {
+    // Timeout or initialization failed
+  });
+```
+
+**Async/await** (same topic—must live inside an `async` function your app already uses for startup):
+
+```javascript
+try {
+  await client.waitForInitialization({ timeout: 5 });
+  // Initialization complete
+} catch (err) {
+  // Timeout or initialization failed
+}
+```
+
+**Alternative:** the docs also document a `ready` event and callback-style `client.variation(..., (err, value) => { ... })` under **Evaluate a context**—use that form if it fits your codebase better.
+
+### Evaluate a flag (when handling work)
+
+The docs state that in production you should invoke `variation` **as needed** (not only once at import). Use `await` inside an `async` route handler, service method, job, etc.
+
+```javascript
+const context = {
+  kind: 'user',
+  key: 'example-user-key',
+  name: 'Example User',
+};
+
+const showFeature = await client.variation('example-flag-key', context, false);
+```
+
+For a boolean flag you may use `boolVariation` if you prefer; the official getting-started examples use `variation` with a boolean default.

--- a/skills/onboarding/references/sdk/snippets/php-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/php-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: PHP Server SDK
+description: Where to find LaunchDarkly PHP server SDK setup and API documentation
+---
+
+# PHP (Server) — SDK detail
+
+**Primary:** [PHP SDK reference](https://launchdarkly.com/docs/sdk/server-side/php) — Composer, initialization, and API.
+
+**Also useful:**
+
+- Packagist: [launchdarkly/server-sdk](https://packagist.org/packages/launchdarkly/server-sdk)
+- GitHub: [php-server-sdk](https://github.com/launchdarkly/php-server-sdk)
+- Sample: [hello-php](https://github.com/launchdarkly/hello-php)
+- API docs: [PHP SDK API](https://launchdarkly.github.io/php-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — PHP (Server)
+
+There is no bundled onboarding code sample in this repo for PHP; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/python-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/python-server-sdk.md
@@ -1,0 +1,67 @@
+---
+title: Python Server SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly Python server-side SDK
+---
+
+# Python (Server) — SDK detail
+
+- Official docs: [Python SDK reference](https://launchdarkly.com/docs/sdk/server-side/python)
+- API reference: [launchdarkly-server-sdk (Read the Docs)](https://launchdarkly-python-sdk.readthedocs.io/)
+- Published package: [launchdarkly-server-sdk (PyPI)](https://pypi.org/project/launchdarkly-server-sdk/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (Python Server)
+
+Use a **current** `launchdarkly-server-sdk` release; see the [SDK releases page](https://github.com/launchdarkly/python-server-sdk/releases) and [version compatibility](https://launchdarkly.com/docs/sdk/server-side/python) (Python **3.9+** from SDK **9.12+**).
+
+**Install** ([Install the SDK](https://launchdarkly.com/docs/sdk/server-side/python#install-the-sdk)):
+
+```bash
+pip install launchdarkly-server-sdk
+```
+
+Optional observability ([Python observability](https://launchdarkly.com/docs/sdk/observability/python)) — requires Python SDK **9.12+**:
+
+```bash
+pip install launchdarkly-observability
+```
+
+**Import** (same topic):
+
+```python
+import ldclient
+from ldclient.config import Config
+
+# Optional — launchdarkly-observability package; requires Python SDK v9.12+
+# from ldobserve import ObservabilityPlugin
+```
+
+**Initialize:** Call **`ldclient.set_config(Config(...))`** once, then **`ldclient.get()`** for the singleton client ([Initialize the client](https://launchdarkly.com/docs/sdk/server-side/python#initialize-the-client)). With observability: `Config(sdk_key, plugins=[ObservabilityPlugin()])`. Worker processes that **fork** may need **`postfork()`** ([Considerations with worker-based servers](https://launchdarkly.com/docs/sdk/server-side/python#considerations-with-worker-based-servers)).
+
+**Includes:** Minimal onboarding script. SDK key: **`LAUNCHDARKLY_SDK_KEY`** ([Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration)).
+
+```python
+import os
+import sys
+
+import ldclient
+from ldclient.config import Config
+
+if __name__ == "__main__":
+    sdk_key = os.environ.get("LAUNCHDARKLY_SDK_KEY")
+    if not sdk_key or not sdk_key.strip():
+        print(
+            "LAUNCHDARKLY_SDK_KEY is not set. Use Project settings > Environments > SDK key.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    ldclient.set_config(Config(sdk_key))
+    client = ldclient.get()
+
+    if not client.is_initialized():
+        print("LaunchDarkly client failed to initialize", file=sys.stderr)
+        raise SystemExit(1)
+
+    # For onboarding only — events are normally flushed in the background.
+    client.flush()
+    print("LaunchDarkly client ready.")
+```

--- a/skills/onboarding/references/sdk/snippets/react-native-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/react-native-sdk.md
@@ -1,0 +1,63 @@
+---
+title: React Native Client SDK — SDK detail
+description: Onboarding sample and links for the LaunchDarkly React Native SDK
+---
+
+# React Native — SDK detail
+
+- Official docs: [React Native SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-native)
+- API reference: [React Native SDK (`@launchdarkly/react-native-client-sdk`)](https://launchdarkly.github.io/js-core/packages/sdk/react-native/docs/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (React Native)
+
+**Current SDK:** **`@launchdarkly/react-native-client-sdk` v10** (TypeScript, [Expo-compatible](https://launchdarkly.com/docs/sdk/client-side/react/react-native); iOS and Android only—not web). Build **`ReactNativeLDClient`** with the **mobile key**, wrap the app in **`LDProvider`**, and call **`identify(context)`** after mount (no context at construction). **`identify`** uses a **5s timeout by default**; do not strip timeouts in custom configuration.
+
+**Install (non-Expo):** Add **`@react-native-async-storage/async-storage`**, then run **`npx pod-install`** for iOS ([Install the SDK](https://launchdarkly.com/docs/sdk/client-side/react/react-native)).
+
+**Mobile key:** Resolve a non-empty string at runtime (below uses Expo’s `EXPO_PUBLIC_` env). Bare React Native typically uses **react-native-config** or native build settings—never hardcode keys in source. Logical name: [Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration).
+
+**Includes:** Copy-paste onboarding sample below.
+
+```tsx
+import { useEffect } from 'react';
+import {
+  AutoEnvAttributes,
+  LDProvider,
+  ReactNativeLDClient,
+} from '@launchdarkly/react-native-client-sdk';
+
+const mobileKey = process.env.EXPO_PUBLIC_LAUNCHDARKLY_MOBILE_KEY?.trim();
+if (!mobileKey) {
+  throw new Error(
+    'LaunchDarkly: missing mobile key. For Expo, set EXPO_PUBLIC_LAUNCHDARKLY_MOBILE_KEY. For bare React Native, inject the key (for example react-native-config) and pass it here.',
+  );
+}
+
+const ldClient = new ReactNativeLDClient(mobileKey, AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY' };
+
+const App = () => {
+  useEffect(() => {
+    ldClient.identify(context).catch((e: unknown) => {
+      console.error('LaunchDarkly identify failed:', e);
+    });
+  }, []);
+
+  return (
+    <LDProvider client={ldClient}>
+      <YourComponent />
+    </LDProvider>
+  );
+};
+
+export default App;
+```
+
+Expo requires the **`EXPO_PUBLIC_`** prefix for `process.env` in app code; other setups should substitute their own resolved string for `mobileKey`.

--- a/skills/onboarding/references/sdk/snippets/react-web-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/react-web-sdk.md
@@ -1,0 +1,63 @@
+---
+title: React Web SDK — SDK detail
+description: Root-level React onboarding sample and links for the LaunchDarkly React Web SDK
+---
+
+# React (Web) — SDK detail
+
+- Official docs: [React SDK reference](https://launchdarkly.com/docs/sdk/client-side/react) · [React Web SDK reference](https://launchdarkly.com/docs/sdk/client-side/react/react-web)
+- API reference: [React Web SDK (`launchdarkly-react-client-sdk`)](https://launchdarkly.github.io/react-client-sdk/)
+- Recipe (detect / install): [SDK Recipes](../recipes.md) (React Web)
+
+**Initialization:** Prefer **`asyncWithLDProvider`** so the tree mounts after the underlying JavaScript client is ready (avoids startup flag flicker). Pass **`timeout`** in **seconds** (docs recommend **1–5**); it is forwarded to `waitForInitialization` on the JS client ([Configuration options](https://launchdarkly.com/docs/sdk/client-side/react/react-web)). **`withLDProvider`** is an alternative if you accept initializing after the first mount.
+
+**Credentials:** **Client-side ID** from **Project settings > Environments** (not a server SDK key). Bundler env prefixes: [Apply: environment configuration](../../../sdk-install/apply/SKILL.md#step-2-add-the-sdk-key-to-environment-configuration).
+
+**Includes:** Copy-paste sample for a Vite-style client entry (e.g. `main.tsx`). Requires **React 16.8+** (`asyncWithLDProvider` uses hooks).
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+
+function App() {
+  return <div>Let your feature flags fly!</div>;
+}
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'user@example.com',
+};
+
+const clientSideID = import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID?.trim();
+if (!clientSideID) {
+  throw new Error(
+    'LaunchDarkly: missing client-side ID. Set VITE_LAUNCHDARKLY_CLIENT_SIDE_ID (Vite), REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID (CRA), or NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID (Next.js client).',
+  );
+}
+
+void (async () => {
+  const LDProvider = await asyncWithLDProvider({
+    clientSideID,
+    context,
+    timeout: 5,
+  });
+
+  const rootEl = document.getElementById('root');
+  if (!rootEl) {
+    throw new Error('LaunchDarkly bootstrap: #root element not found');
+  }
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <LDProvider>
+        <App />
+      </LDProvider>
+    </StrictMode>,
+  );
+})();
+```
+
+For Create React App, read the ID from `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` instead of `import.meta.env.VITE_…`. For Next.js client bundles, use `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` in a client entry (`'use client'` as required).

--- a/skills/onboarding/references/sdk/snippets/roku-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/roku-client-sdk.md
@@ -1,0 +1,17 @@
+---
+title: Roku Client SDK
+description: Where to find LaunchDarkly Roku (BrightScript) SDK setup and releases
+---
+
+# Roku (BrightScript) — SDK detail
+
+**Primary:** [Roku SDK reference](https://launchdarkly.com/docs/sdk/client-side/roku) — component install, initialization, and API.
+
+**Also useful:**
+
+- GitHub: [roku-client-sdk](https://github.com/launchdarkly/roku-client-sdk) (releases)
+- Sample: [hello-roku](https://github.com/launchdarkly/hello-roku)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Roku (BrightScript)
+
+There is no bundled onboarding code sample in this repo for Roku; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/ruby-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/ruby-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Ruby Server SDK
+description: Where to find LaunchDarkly Ruby server SDK setup and API documentation
+---
+
+# Ruby (Server) — SDK detail
+
+**Primary:** [Ruby SDK reference](https://launchdarkly.com/docs/sdk/server-side/ruby) — Gemfile, initialization, and API.
+
+**Also useful:**
+
+- RubyGems: [launchdarkly-server-sdk](https://rubygems.org/gems/launchdarkly-server-sdk)
+- GitHub: [ruby-server-sdk](https://github.com/launchdarkly/ruby-server-sdk)
+- Samples: [hello-ruby](https://github.com/launchdarkly/hello-ruby), [hello-bootstrap-rails](https://github.com/launchdarkly/hello-bootstrap-rails)
+- API docs: [Ruby SDK API](https://launchdarkly.github.io/ruby-server-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Ruby (Server)
+
+There is no bundled onboarding code sample in this repo for Ruby; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/rust-server-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/rust-server-sdk.md
@@ -1,0 +1,19 @@
+---
+title: Rust Server SDK
+description: Where to find LaunchDarkly Rust server SDK setup and API documentation
+---
+
+# Rust (Server) — SDK detail
+
+**Primary:** [Rust SDK reference](https://launchdarkly.com/docs/sdk/server-side/rust) — crates.io, initialization, and API.
+
+**Also useful:**
+
+- crates.io: [launchdarkly-server-sdk](https://crates.io/crates/launchdarkly-server-sdk)
+- GitHub: [rust-server-sdk](https://github.com/launchdarkly/rust-server-sdk)
+- Sample: [hello-rust](https://github.com/launchdarkly/hello-rust)
+- API docs: [docs.rs launchdarkly-server-sdk](https://docs.rs/launchdarkly-server-sdk)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Rust (Server)
+
+There is no bundled onboarding code sample in this repo for Rust; follow the official reference.

--- a/skills/onboarding/references/sdk/snippets/vue-client-sdk.md
+++ b/skills/onboarding/references/sdk/snippets/vue-client-sdk.md
@@ -1,0 +1,18 @@
+---
+title: Vue Client SDK
+description: Where to find LaunchDarkly Vue client SDK setup and API documentation
+---
+
+# Vue — SDK detail
+
+**Primary:** [Vue SDK reference](https://launchdarkly.com/docs/sdk/client-side/vue) — npm install, plugin setup, and API.
+
+**Also useful:**
+
+- npm: [launchdarkly-vue-client-sdk](https://www.npmjs.com/package/launchdarkly-vue-client-sdk)
+- GitHub: [vue-client-sdk](https://github.com/launchdarkly/vue-client-sdk)
+- API docs: [Vue SDK API](https://launchdarkly.github.io/vue-client-sdk/)
+
+**Recipe (detect / install summary):** [SDK Recipes](../recipes.md) — Vue
+
+There is no bundled onboarding code sample in this repo for Vue; follow the official reference.

--- a/skills/onboarding/sdk-install/SKILL.md
+++ b/skills/onboarding/sdk-install/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: launchdarkly-onboarding-sdk-install
+description: "Install and initialize the correct LaunchDarkly SDK during onboarding by running nested skills in order: detect, plan, apply. Parent onboarding Step 6 is first flag."
+license: Apache-2.0
+compatibility: Requires a supported language/framework in the project. SDK credentials are required by [Apply](apply/SKILL.md), not for [Detect](detect/SKILL.md) / [Plan](plan/SKILL.md) alone (see parent onboarding **Prerequisites**).
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly SDK Install (onboarding)
+
+Installs and initializes the right LaunchDarkly SDK for the user’s project by following **three nested skills in order**. **Do not** skip ahead to feature flags here—the parent [LaunchDarkly onboarding](../SKILL.md) continues with **Step 6: First feature flag** using [Create first feature flag](../first-flag/SKILL.md).
+
+## Prerequisites
+
+- Project context from parent **Step 1: Explore the Project** (reuse it; only re-run deep detection if something is unclear)
+- **SDK key / client-side ID / mobile key:** Needed when you reach [Apply code changes](apply/SKILL.md) (env wiring). **Do not** ask the user for these during detect or plan solely because you opened this skill—follow parent onboarding: account is confirmed early; key material is collected at apply (see parent [Prerequisites](../SKILL.md#prerequisites)).
+
+## Key types (summary)
+
+| SDK Type    | Variable (logical)        | Source in LaunchDarkly        |
+|-------------|---------------------------|-------------------------------|
+| Server-side | `LAUNCHDARKLY_SDK_KEY`    | Environments → SDK key        |
+| Client-side | Client-side ID (bundler-prefixed env names) | Environments → Client-side ID |
+| Mobile      | `LAUNCHDARKLY_MOBILE_KEY` | Environments → Mobile key     |
+
+**Never hardcode keys.** Full env rules, consent, and bundler tables: [Apply code changes](apply/SKILL.md) Step 2.
+
+## Workflow — run these nested skills in order
+
+Execute **all three** unless the [detect decision tree](detect/SKILL.md#decision-tree) short-circuits (e.g. skip to apply only). Each nested skill contains **blocking decision points** (marked `D<N> -- BLOCKING`) where you must call your structured question tool and wait for the user's response before continuing. Do NOT batch tool calls across these boundaries.
+
+| Order | Nested skill | Role |
+|-------|----------------|------|
+| 1 | [Detect repository stack](detect/SKILL.md) | Language, package manager, monorepo target, entrypoint, existing LD usage |
+| 2 | [Generate integration plan](plan/SKILL.md) | SDK choice, files to change, env plan -- confirm with user before edits |
+| 3 | [Apply code changes](apply/SKILL.md) | Install package(s), `.env` / secrets with consent, init code, compile check (**both** tracks when [dual-SDK plan](plan/SKILL.md#dual-sdk-integrations)) |
+
+Shared references for all steps: [SDK recipes](../references/sdk/recipes.md), [SDK snippets](../references/sdk/snippets/).
+
+### After Step 3 completes
+
+Continue with the parent skill:
+
+- **Step 6:** [Create first feature flag](../first-flag/SKILL.md)
+
+Do not add standalone “sample flag” evaluation in this skill unless the user explicitly needs a throwaway check; the parent flow creates the first flag in order.
+
+## Guidelines
+
+- Match existing codebase conventions for imports, config, and style.
+- Prefer TypeScript in TypeScript projects.
+- If the project uses a shared config layer, initialize LaunchDarkly there.
+- Add `.env.example` entries when the project uses dotenv.
+- **Dependency scope:** Add only LaunchDarkly SDK package(s) from the recipe unless the user **explicitly approves** upgrading or adding other packages ([Apply — Permission before changing other dependencies](apply/SKILL.md#permission-before-changing-other-dependencies)).
+
+## Edge cases
+
+- **Multiple environments (e.g. Next.js server + client) or user asked for frontend + backend:** Use a **dual-SDK** [plan](plan/SKILL.md#dual-sdk-integrations) and [apply](apply/SKILL.md) **both** packages and **both** inits—never summarize the second SDK as done without lockfile + entrypoint evidence.
+- **Monorepo:** Integrate the package the user chose in parent onboarding; stay within that subtree.
+- **SDK already installed and initialized:** Parent may skip this handoff—see parent **Edge Cases** and [detect decision tree](detect/SKILL.md#decision-tree).
+- **Unsupported or uncommon stack:** Use [SDK recipes](../references/sdk/recipes.md) and the [full SDK catalog](https://launchdarkly.com/docs/sdk).
+
+## References
+
+- [Detect repository stack](detect/SKILL.md)
+- [Generate integration plan](plan/SKILL.md)
+- [Apply code changes](apply/SKILL.md)
+- [SDK recipes](../references/sdk/recipes.md)
+- [SDK snippets](../references/sdk/snippets/)
+- [LaunchDarkly onboarding (parent)](../SKILL.md)

--- a/skills/onboarding/sdk-install/SKILL.md
+++ b/skills/onboarding/sdk-install/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-sdk-install
+name: sdk-install
 description: "Install and initialize the correct LaunchDarkly SDK during onboarding by running nested skills in order: detect, plan, apply. Parent onboarding Step 6 is first flag."
 license: Apache-2.0
 compatibility: Requires a supported language/framework in the project. SDK credentials are required by [Apply](apply/SKILL.md), not for [Detect](detect/SKILL.md) / [Plan](plan/SKILL.md) alone (see parent onboarding **Prerequisites**).

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: launchdarkly-onboarding-sdk-apply
+description: "Apply LaunchDarkly SDK onboarding: install dependency (or dual-SDK pair), configure env and secrets with consent, add init at entrypoint(s), verify compile. Nested under sdk-install; next is run."
+license: Apache-2.0
+compatibility: Requires integration plan and LaunchDarkly credentials (see parent onboarding)
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# Apply code changes (SDK install)
+
+Execute the integration plan. Install the SDK(s) and add the minimal code needed to initialize **each** tracked surface.
+
+This skill is nested under [LaunchDarkly SDK Install (onboarding)](../SKILL.md); the parent **Step 3** is **apply**. **Prior:** [Generate integration plan](../plan/SKILL.md). **Next:** [Start the application](../run/SKILL.md).
+
+**Dual SDK:** If the approved plan is **dual SDK** ([plan: Dual SDK integrations](../plan/SKILL.md#dual-sdk-integrations)), you must complete Steps 1-3 **for both tracks** -- **two** packages in the manifest, **two** install commands run (or equivalent), **two** credential lines where needed, **two** inits in **different** entrypoints per recipe. **Do not** claim the second SDK is set up without performing its real install and init. If the plan only listed one track but the user asked for both, **stop** and return to [plan](../plan/SKILL.md) -- do not invent the second half from memory.
+
+**Credential timing:** This is the first nested step where you ask the user for **SDK key / client-side ID / mobile key** (or consent to fetch/write them). Earlier onboarding should have confirmed only **account** access, not key material ([parent Prerequisites](../../SKILL.md#prerequisites)).
+
+## Step 1: Install the SDK dependency
+
+Use the **exact** package or module name and install command from the SDK row you already matched in [SDK recipes](../../references/sdk/recipes.md), with the project's package manager. Do not copy a generic install line from elsewhere -- each recipe names the right artifact.
+
+**Dual SDK:** Run the **install command for Track A**, then the **install command for Track B** (from the plan). Confirm **both** package names appear in `package.json` / `requirements.txt` / lockfile (or the correct package manifest for each language). Skipping the second install is **not** optional when the plan says dual.
+
+After installation, verify the dependency appears in the lock file or dependency manifest (**all** LaunchDarkly packages from the plan).
+
+### Permission before changing other dependencies
+
+**Allowed without asking for extra permission (beyond normal repo-edit consent):** Installing **only** the LaunchDarkly SDK package(s) named in the recipe(s) for this integration (e.g. one server SDK, **or** the **exact server + client pair** listed in a dual-SDK plan -- **both** packages count as in-scope LD installs). Use the **minimum** install each recipe specifies (exact package names).
+
+**Requires explicit user approval *before* you run any command or edit manifests:** Any change beyond that scope, including but not limited to:
+
+- Upgrading, downgrading, pinning, or adding **non-LaunchDarkly** packages (peer-dependency "fixes," `npm install X@latest`, `yarn upgrade`, `pnpm update`, bumping React/Node types, transitive lockfile churn, etc.)
+- Running **`npm audit fix`**, **bulk updates**, or **replacing** the project's package manager resolution strategy to satisfy the SDK
+- Changing **engine** / **packageManager** fields, **resolutions** / **overrides**, or **workspaces** entries for reasons other than adding the LD artifact line
+
+If the package manager reports peer conflicts or install failures:
+
+**D8 -- BLOCKING:** Call your structured question tool now.
+- question: "The install reported [specific error]. To fix this, I would need to [specific changes to non-LD packages]. Should I proceed with those additional changes?"
+- options:
+  - "Yes, make those changes"
+  - "No, keep only the LaunchDarkly package -- I'll resolve conflicts myself"
+  - "Show me the exact commands first"
+- STOP. Do not write the question as text. Do not upgrade an older repo "to match the newest SDK's dependencies" silently. Do not continue until the user selects an option.
+
+If the user **declines** broader changes: keep only the LD package addition if possible, document the conflict, and proceed with placeholders or manual steps.
+
+## Step 2: Add the SDK key to environment configuration
+
+**Never hardcode SDK keys, client-side IDs, or mobile keys in application source files** (only reference them via environment variables).
+
+### Permission before secrets
+
+**D7 -- BLOCKING:** Call your structured question tool now.
+- question: "The SDK needs an SDK key (or client-side ID / mobile key) for your environment. How would you like to set up the secret?"
+- options:
+  - "I'll tell you where to put it"
+  - "I'll set up the secret myself -- just tell me what variable name to use"
+  - "Write it to a `.env` file for me"
+- STOP. Do not write the question as text. Do not fetch keys from LaunchDarkly or write real values into the repo without the user selecting an option first.
+
+**If the user chooses option 1 ("Tell me where to put it"):**
+1. Ask where they want the secret written (file path, secrets manager, etc.)
+2. Ask how they want to provide the key: paste it, or have the agent fetch it via MCP/API
+3. Write the key **only** to the location the user specified
+4. Do not create a `.env` or modify any other file
+
+**If the user chooses option 2 ("I'll set it up myself"):**
+1. Tell them the variable name(s) they need to set (see the table below)
+2. Link them to the right dashboard page. When the project key and environment key are known: **`https://app.launchdarkly.com/projects/{projectKey}/settings/environments/{envKey}/keys`**. When only the project key is known: **`https://app.launchdarkly.com/projects/{projectKey}/settings/environments`** and tell them to select the environment. When neither is known: **`https://app.launchdarkly.com/projects`** and tell them to navigate to **Settings > Environments** to find the key.
+3. Wait for the user to confirm the secret is in place before proceeding to Step 3
+4. Do not fetch, write, or handle the key value at all
+
+**If the user chooses option 3 ("Write it to a `.env` file for me"):**
+1. Ask how they want to provide the key: paste it, or have the agent fetch it via MCP/API
+2. Follow the [Write to `.env`](#write-to-env-when-the-user-consents) section below
+3. Ensure `.env` is in `.gitignore` before writing any real values
+
+### Fetching keys via MCP
+
+When the user asks the agent to fetch the key (via option 1 or 3 above), use the **`get-environments`** MCP tool (if configured). Call it with the project key — the response includes each environment's **SDK key**, **client-side ID**, and **mobile key**. Do **not** make separate API requests for individual keys when `get-environments` already returns them.
+
+```
+get-environments({ request: { projectKey: "PROJECT_KEY" } })
+```
+
+**Security: Treat MCP responses containing keys as sensitive.** Write keys only to the location the user chose without echoing full key values in chat responses. Keys in agent conversation history or logs may persist beyond the session.
+
+Pick the correct key type from the matching environment in the response (see table below). If MCP is not configured, fall back to `ldcli` or the REST API (`GET /api/v2/projects/{PROJECT_KEY}/environments`).
+
+### Variable names and where values come from
+
+| SDK Type | Variable name (typical) | Source in LaunchDarkly |
+|----------|-------------------------|-------------------------|
+| Server-side | `LAUNCHDARKLY_SDK_KEY` | `get-environments` response → environment → SDK key |
+| Client-side | Logical / bundler-prefixed name (see below) | `get-environments` response → environment → Client-side ID |
+| Mobile | `LAUNCHDARKLY_MOBILE_KEY` | `get-environments` response → environment → Mobile key |
+
+**Client-side (browser) projects:** The LaunchDarkly value is still the Client-side ID. In `.env`, use a name the bundler exposes to client code:
+
+| Stack | `.env` key | Read in code |
+|-------|------------|--------------|
+| Create React App | `REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` | `process.env.REACT_APP_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+| Vite | `VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` | `import.meta.env.VITE_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+| Next.js | `NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` | `process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID` |
+
+Other stacks may use different prefixes or plain `LAUNCHDARKLY_CLIENT_SIDE_ID` -- match what the project already uses for public env vars.
+
+### Write to `.env` (when the user consents)
+
+Use the **integration root** for the file path (repo root or the target package in a monorepo -- see [Detect repository stack](../detect/SKILL.md)).
+
+1. **Create or update `.env`:** If `.env` does not exist, create it. If it exists, **append or update** only the LaunchDarkly lines -- do not remove unrelated variables.
+2. **Add what the integration needs:**
+   - Server-only: `LAUNCHDARKLY_SDK_KEY=...`
+   - Client/browser: the **client-side ID** under the correct bundler-prefixed key (e.g. `VITE_LAUNCHDARKLY_CLIENT_SIDE_ID=...`).
+   - **Full-stack or hybrid (e.g. Next.js, SSR + client):** add **both** the server SDK key and the client-side ID lines when both SDKs are in use.
+   - Mobile: `LAUNCHDARKLY_MOBILE_KEY=...` when applicable.
+3. **`.gitignore`:** Ensure `.env` is listed in `.gitignore` at the same root where you created `.env` (or the nearest relevant ignore file in a monorepo). If the entry is missing, add it -- only after the user has agreed to repo changes (same permission scope as writing `.env`). Do not commit files that contain real secrets.
+4. **`.env.example` / `.env.sample`:** If the project uses one, add **placeholder** entries only (no real keys), so teammates know which variables to set.
+
+If the project does not use dotenv and relies on a config module or hosted secrets, follow existing patterns there instead -- the same D7 consent above still applies before writing real values into any file.
+
+## Step 3: Add SDK initialization code
+
+Initialization shape **depends on which SDK was chosen** during detection and planning. This skill does not include copy-paste samples per SDK -- using the wrong snippet (e.g. React Web when the recipe is Node server) will mislead you.
+
+**Source of truth (use in order, repeat per track when dual-SDK):**
+
+1. **[SDK recipes](../../references/sdk/recipes.md)** -- the row for **this** track's SDK: install is Step 1 above; for init, follow the **SDK detail** / doc links listed there.
+2. **SDK detail files** under [`snippets/`](../../references/sdk/snippets/) (when linked from the recipe) -- curated links and, for many SDKs, a full onboarding sample aligned with that SDK.
+3. **LaunchDarkly's official docs** for that SDK (URLs from the recipe or detail file) -- use their entrypoint and async patterns (e.g. React Web: [React Web SDK](https://launchdarkly.com/docs/sdk/client-side/react/react-web)).
+
+Wire credentials using Step 2: server SDKs use `LAUNCHDARKLY_SDK_KEY`; client/browser SDKs use the client-side ID with the **bundler-prefixed** env names from Step 2 where applicable.
+
+Add imports and init to the **application entrypoint** for **that** track (or the target package's entrypoint in a monorepo -- see [Detect repository stack](../detect/SKILL.md)). **Dual SDK:** server init goes in the **server** entrypoint from the plan; client/provider init goes in the **client** entrypoint -- **never** a single shared block that pretends to cover both unless the official docs for that stack explicitly prescribe one pattern for both.
+
+### Key principles
+
+1. **Import at the top** of the file with other imports
+2. **Initialize early** in the application lifecycle **for that runtime** (Node server vs browser)
+3. **Wait for initialization** before evaluating flags when the SDK supports it
+4. **Handle errors** -- log failures but don't crash the application
+5. **Match existing code style** -- same patterns (async/await, callbacks, modules CommonJS vs ESM) as the rest of the codebase
+6. **Use the right pattern per surface** -- server-side init from the **server** recipe in server code; client/provider init from the **client** recipe in client code. **Do not** reuse one snippet for both tracks or skip the second track's init when the plan is dual-SDK.
+
+## Step 4: Verify the code compiles
+
+After making changes:
+
+1. Run the project's build or compile step
+2. Run the linter if one is configured
+3. Fix any import errors or type issues **without** upgrading unrelated dependencies unless the user approved that scope ([Permission before changing other dependencies](#permission-before-changing-other-dependencies))
+
+Do not proceed to the next step if the code doesn't compile.
+
+---
+
+**Upon completion:** [Start the application](../run/SKILL.md)

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-sdk-apply
+name: apply
 description: "Apply LaunchDarkly SDK onboarding: install dependency (or dual-SDK pair), configure env and secrets with consent, add init at entrypoint(s), verify compile. Nested under sdk-install; next is run."
 license: Apache-2.0
 compatibility: Requires integration plan and LaunchDarkly credentials (see parent onboarding)

--- a/skills/onboarding/sdk-install/detect/SKILL.md
+++ b/skills/onboarding/sdk-install/detect/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-sdk-detect
+name: detect
 description: "Detect repository stack for LaunchDarkly SDK onboarding: languages, frameworks, package managers, monorepo targets, entrypoints, existing LD usage. Nested under sdk-install; next is plan."
 license: Apache-2.0
 compatibility: Requires access to the project repository

--- a/skills/onboarding/sdk-install/detect/SKILL.md
+++ b/skills/onboarding/sdk-install/detect/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: launchdarkly-onboarding-sdk-detect
+description: "Detect repository stack for LaunchDarkly SDK onboarding: languages, frameworks, package managers, monorepo targets, entrypoints, existing LD usage. Nested under sdk-install; next is plan."
+license: Apache-2.0
+compatibility: Requires access to the project repository
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# Detect repository stack (SDK install)
+
+Before installing anything, you must understand the project. Identify what the project is built with and whether LaunchDarkly is already present.
+
+This skill is nested under [LaunchDarkly SDK Install (onboarding)](../SKILL.md); the parent **Step 1** is **detect**. **Next:** [Generate integration plan](../plan/SKILL.md) unless the decision tree sends you elsewhere.
+
+### 1. Language and framework
+
+Look for the indicator files below (and related root layout), then read the relevant manifests to infer language and framework.
+
+Look for these files to identify the stack:
+
+| File | Language/Framework |
+|------|--------------------|
+| `package.json` | JavaScript/TypeScript (check for React, Next.js, Vue, Angular, Express, React Native, Electron, etc.) |
+| `requirements.txt`, `pyproject.toml`, `Pipfile`, `setup.py` | Python (check for Django, Flask, FastAPI) |
+| `go.mod` | Go (check for Gin, Echo, Fiber, Chi) |
+| `pom.xml`, `build.gradle`, `build.gradle.kts` | Java/Kotlin (check for Spring, Quarkus, Android) |
+| `Gemfile` | Ruby (check for Rails, Sinatra) |
+| `*.csproj`, `*.sln`, `*.fsproj` | .NET/C# (check for ASP.NET, MAUI, Xamarin, WPF, UWP) |
+| `composer.json` | PHP (check for Laravel, Symfony) |
+| `Cargo.toml` | Rust (check for Actix, Axum, Rocket) |
+| `pubspec.yaml` | Flutter/Dart |
+| `Package.swift`, `Podfile`, `*.xcodeproj` | Swift/iOS |
+| `AndroidManifest.xml` | Android (also check `build.gradle` for `com.android`) |
+| `rebar.config`, `mix.exs` | Erlang/Elixir |
+| `CMakeLists.txt`, `Makefile` (with C/C++ patterns) | C/C++ (check for `#include` patterns) |
+| `*.cabal`, `stack.yaml` | Haskell |
+| `*.lua`, `rockspec` | Lua |
+| `manifest`, `*.brs` | Roku (BrightScript) |
+| `wrangler.toml` | Cloudflare Workers (edge SDK) |
+| `vercel.json` with edge functions | Vercel Edge (edge SDK) |
+
+Read the dependency file to identify the specific framework. For `package.json`, check both `dependencies` and `devDependencies`.
+
+If you cannot identify the language or framework:
+
+**D5 -- BLOCKING:** Call your structured question tool now.
+- question: "I couldn't detect the project's language or framework. Which SDK would you like to use?"
+- options: Present the available SDKs from [SDK recipes](../../references/sdk/recipes.md) as selectable options.
+- STOP. Do not write the question as text. Do not continue until the user selects an option.
+
+### 2. Package manager
+
+Identify how the project installs dependencies:
+
+| Indicator | Package Manager |
+|-----------|----------------|
+| `package-lock.json` | npm |
+| `yarn.lock` | yarn |
+| `pnpm-lock.yaml` | pnpm |
+| `bun.lockb` | bun |
+| `Pipfile.lock` | pipenv |
+| `poetry.lock` | poetry |
+| `go.sum` | go modules |
+| `Gemfile.lock` | bundler |
+
+Use the detected package manager for all install commands. If multiple lock files exist, prefer the one that was most recently modified.
+
+### 3. Monorepo layout
+
+Some repositories host multiple packages or services. Look for these indicators:
+
+| File / pattern | Tool or layout |
+|----------------|----------------|
+| `pnpm-workspace.yaml` | pnpm workspaces |
+| `lerna.json` | Lerna |
+| `nx.json` | Nx |
+| `turbo.json` | Turborepo |
+| `rush.json` | Rush |
+| `packages/` directory with multiple `package.json` files | Generic monorepo |
+
+When any of these apply, **do not assume the repo root is the integration target**:
+
+**D5 -- BLOCKING:** Call your structured question tool now.
+- question: "This is a monorepo. Which package, app, or service should I integrate LaunchDarkly into?"
+- options: List the discovered packages/apps as selectable options.
+- STOP. Do not write the question as text. Do not continue until the user selects an option.
+
+Then run the rest of this detect step -- language, package manager, entrypoint, and SDK search -- **in that target directory** (and its subtree), not only at the root.
+
+### 4. Application entrypoint
+
+Find the main file where the application starts. In a monorepo, apply the patterns below within the chosen package after [section 3 Monorepo layout](#3-monorepo-layout). Common patterns:
+
+- **Node.js (server)**: Check `package.json` `"main"` field, or look for `index.js`, `server.js`, `app.js`, `src/index.ts`
+- **NestJS**: Look for `src/main.ts` or `src/main.js`
+- **Python**: Look for `app.py`, `main.py`, `manage.py`, `wsgi.py`, or the `[tool.poetry.scripts]` section
+- **Go**: Look for `main.go` or `cmd/*/main.go`
+- **Java**: Search for `public static void main` or `@SpringBootApplication`
+- **Ruby**: Look for `config.ru`, `config/application.rb`
+- **React/Vue/Angular**: Look for `src/index.tsx`, `src/main.tsx`, `src/App.tsx`, `src/main.ts`
+- **Next.js**: App Router -- `app/layout.tsx` or `app/layout.js` (root layout). Pages Router -- `pages/_app.tsx` or `pages/_app.js`
+- **React Native**: Look for `App.tsx`, `App.js`, `index.js` (with `AppRegistry.registerComponent`)
+- **Electron**: Check `package.json` `"main"`; common paths include `main.js` or `src/main.ts`
+- **JavaScript (browser)**: Look for `index.html`, `src/index.js`, or bundler entry in `webpack.config.js` / `vite.config.ts`
+- **Flutter**: Look for `lib/main.dart`
+- **Swift/iOS**: Look for `AppDelegate.swift`, `SceneDelegate.swift`, or `@main` struct
+- **Android**: Look for `MainActivity.java` or `MainActivity.kt`
+
+### 5a. Classify workspace confidence
+
+After sections 1-4, classify the workspace into **one of three states** before continuing. This classification determines how the rest of the flow proceeds.
+
+| State | Meaning | Criteria |
+|-------|---------|----------|
+| **Clear app** | A runnable application was found | Language/framework detected, a real entrypoint exists, dependency manifest is present with application dependencies |
+| **Unclear / weak evidence** | Something is present but it does not clearly represent a runnable app | Stray or minimal `package.json` (e.g. only devDependencies, no scripts), isolated config/manifest files, theme or config-only folders, token/fixture JSON, lockfiles without corresponding source, or multiple conflicting indicators with no dominant app structure |
+| **No app found** | No recognizable application structure was detected | No dependency manifests, no entrypoints, no source files matching known patterns, or the workspace is empty / contains only documentation |
+
+**Weak evidence must not be treated as confirmation.** Examples of weak evidence:
+
+- A `package.json` with no `scripts` section and no application source files
+- A lone `requirements.txt` in a directory of data files or notebooks
+- Config, theme, or fixture directories with manifests that do not represent a runnable service
+- Monorepo roots where the real apps live in subdirectories but none was selected
+
+**Branching by state:**
+
+- **Clear app** → continue to [section 6 (Existing LaunchDarkly SDK)](#6-existing-launchdarkly-sdk) and then SDK confirmation.
+
+- **Unclear / weak evidence:**
+
+**D5-UNCLEAR -- BLOCKING:** Call your structured question tool now.
+- question: "I found some project files, but I'm not confident I've identified the right application to integrate. Can you point me to the correct app folder?"
+- context: Briefly describe what you found and why it's ambiguous (e.g., "There's a `package.json` at the root, but it has no start script and no application source files").
+- options:
+  - Present any candidate folders you detected as selectable options
+  - "It's somewhere else -- I'll tell you the path"
+  - "There is no app yet -- help me create a demo"
+- STOP. Do not make code changes, install packages, or generate an integration plan until the user confirms the target. Do not continue until the user selects an option.
+
+After the user points to the correct folder, re-run detection (sections 1-4) scoped to that folder.
+
+- **No app found:**
+
+Tell the user clearly: "I didn't find a runnable application in this workspace." Then offer two paths:
+
+**D5-NOAPP -- BLOCKING:** Call your structured question tool now.
+- question: "I didn't find a runnable application in this workspace. How would you like to proceed?"
+- options:
+  - "Point me to the right folder -- the app is somewhere else"
+  - "Create a minimal demo app so I can try LaunchDarkly"
+- STOP. Do not continue until the user selects an option.
+
+If the user chooses "point me to the right folder," re-run detection scoped to the path they provide. If they choose "create a demo app," create a minimal runnable app in a **new subfolder** (e.g. `launchdarkly-demo/`) using the simplest stack you can scaffold (Node.js + Express or a static HTML page are good defaults), then continue detection from that subfolder.
+
+**Do not** declare onboarding complete unless the app target has been confirmed and the app can actually run.
+
+### 6. Existing LaunchDarkly SDK
+
+Search the codebase for existing LaunchDarkly usage:
+
+```
+Search for: launchdarkly, ldclient, ld-client, LDClient, @launchdarkly, launchdarkly-
+```
+
+Check:
+
+- Is the SDK already in the dependency file?
+- Is there initialization code?
+- Is it properly configured or partially set up?
+- Are there already feature flag evaluations?
+
+## SDK confirmation
+
+After detecting the stack, confirm the SDK choice with the user:
+
+- **If one SDK is clearly the right fit**: Present your recommendation and get confirmation:
+
+**D5 -- BLOCKING:** Call your structured question tool now.
+- question: "Based on what I found, I recommend the [SDK name] SDK. Does that look right?"
+- options:
+  - "Yes, proceed with that SDK" -> continue to plan
+  - "No, I want a different one" -> let user specify
+- STOP. Do not write the question as text. Do not continue until the user selects an option.
+
+- **If multiple SDKs could apply** (e.g., a Next.js project with both server and client components):
+  - **If the user already asked for both** (e.g. "frontend and backend," "server + browser," "API and SPA"): Treat that as a **dual-SDK** scope. Proceed to [Generate integration plan](../plan/SKILL.md) with **both** SDKs in scope -- do **not** plan or implement only one and assume the other is "covered."
+  - **If scope is unclear**:
+
+**D5 -- BLOCKING:** Call your structured question tool now.
+- question: "This project has both server-side and client-side surfaces. Which do you want to integrate?"
+- options:
+  - "Server-side only"
+  - "Client-side only"
+  - "Both server-side and client-side"
+- STOP. Do not write the question as text. Do not continue until the user selects an option.
+
+If they choose **both**, the plan must include **two** concrete integrations (see [plan: Dual SDK integrations](../plan/SKILL.md#dual-sdk-integrations)).
+
+- **If you cannot determine the right SDK**: Present the available options from the [SDK recipes](../../references/sdk/recipes.md) as selectable options in your question tool and use the same blocking pattern above.
+
+## Decision tree
+
+After detection and confirmation:
+
+- **No app found or unclear** --> Already handled by D5-NOAPP / D5-UNCLEAR in [section 5a](#5a-classify-workspace-confidence). Do not proceed to plan until the user confirms a real app target.
+- **SDK already installed and initialized** --> Skip to [Create first feature flag](../../first-flag/SKILL.md) (parent Step 6)
+- **SDK installed but not initialized** --> Skip to [Apply code changes](../apply/SKILL.md) (just add init code)
+- **SDK not present** --> Continue to [Generate integration plan](../plan/SKILL.md)
+- **Multiple targets detected (e.g., frontend + backend)** --> If the user wants **both** SDKs (confirmed via D5 above), continue to [Generate integration plan](../plan/SKILL.md) with **dual-SDK** scope (two packages, two entrypoints). If they want **one** surface only, plan for that single SDK.
+- **Language not detected** --> Already handled by the D5 blocking question in [section 1](#1-language-and-framework).
+
+---
+
+**Upon completion (normal path):** [Generate integration plan](../plan/SKILL.md)

--- a/skills/onboarding/sdk-install/plan/SKILL.md
+++ b/skills/onboarding/sdk-install/plan/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: launchdarkly-onboarding-sdk-plan
+description: "Generate a minimal LaunchDarkly SDK integration plan from detected stack: choose SDK type(s), dual-SDK server+client when required, files to change, env conventions. Nested under sdk-install; follows detect, precedes apply."
+license: Apache-2.0
+compatibility: Requires completed or equivalent detect context (see sibling detect skill)
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# Generate integration plan (SDK install)
+
+Based on what you detected, choose the right SDK and plan the minimal set of changes needed.
+
+This skill is nested under [LaunchDarkly SDK Install (onboarding)](../SKILL.md); the parent **Step 2** is **plan**. **Prior:** [Detect repository stack](../detect/SKILL.md). **Next:** [Apply code changes](../apply/SKILL.md).
+
+## Choose the right SDK
+
+Use the [SDK recipes](../../references/sdk/recipes.md) reference to match the detected stack to an SDK. Start with **Top 10 SDKs (start here)** in that file for common stacks; use the **(other)** sections for less common SDKs.
+
+The key decision:
+
+| Project Type | SDK Type | Key Type |
+|-------------|----------|----------|
+| Backend API, server-rendered app, CLI tool | Server-side SDK | SDK Key |
+| Browser SPA (React, Vue, Angular, vanilla JS) | Client-side SDK | Client-side ID |
+| iOS or Android native app | Mobile SDK | Mobile Key |
+| React Native | Mobile SDK | Mobile Key |
+| Flutter (iOS, Android, or desktop **app** targets) | Client-side SDK (Flutter) | Mobile Key |
+| Flutter **web** | Client-side SDK (Flutter) | Client-side ID |
+| Electron desktop app | Client-side SDK (Node.js) | Client-side ID |
+| Cloudflare Workers, Vercel Edge, AWS Lambda@Edge | Edge SDK | SDK Key |
+| .NET client (MAUI, Xamarin, WPF, UWP) | Mobile SDK (.NET) | Mobile Key |
+| C/C++ client application | Client-side SDK (C/C++) | Mobile Key |
+| C/C++ server application | Server-side SDK (C/C++) | SDK Key |
+| Haskell server | Server-side SDK (Haskell) | SDK Key |
+| Lua server | Server-side SDK (Lua) | SDK Key |
+| Roku (BrightScript) | Client-side SDK (Roku) | Mobile Key |
+
+For every supported SDK, package name, install hint, and official **Docs** link, use [SDK recipes](../../references/sdk/recipes.md) and the linked files under [`snippets/`](../../references/sdk/snippets/).
+
+## Dual SDK integrations
+
+Use this section when the user asked for **both** a server-side and a client-side integration, or when the stack clearly needs **two** LaunchDarkly SDKs (e.g. Next.js with server evaluation **and** browser UI flags, separate backend + SPA repos in one workspace target, etc.).
+
+**Do not** "complete" onboarding with a single SDK while **hand-waving** the second (no second package in `package.json`, no second init path, no second recipe followed). Each SDK is a separate product with its own install command and initialization.
+
+For **each** of the two SDKs, the plan must spell out (with no gaps):
+
+**Server-side track:**
+
+1. Recipe / [SDK recipes](../../references/sdk/recipes.md) row or snippet name
+2. Package name(s) (exact artifact)
+3. Install command (full command from recipe)
+4. Dependency file (where the line is added)
+5. Entrypoint file(s) (e.g. `instrumentation.ts`, API entry, `main.py`)
+6. Env vars (typically `LAUNCHDARKLY_SDK_KEY`)
+7. Init summary (where it runs; which doc/snippet)
+
+**Client-side track:**
+
+1. Recipe / snippet name (**different** row than server)
+2. Package name(s) (e.g. React Web vs Node server -- must be the **client** artifact)
+3. Install command (**second** command -- never implied)
+4. Dependency file
+5. Entrypoint file(s) (e.g. `app/providers.tsx`, root layout, `main.tsx`)
+6. Env vars (bundler-prefixed **client-side ID**, e.g. `NEXT_PUBLIC_...`)
+7. Init summary (provider/wrapper/hook from **client** recipe)
+
+If you cannot name **two** packages and **two** entrypoints, you are not done planning -- go back to [SDK recipes](../../references/sdk/recipes.md) and detection.
+
+**Important distinctions:**
+
+- **Next.js**: Server-side SDK for API routes / server components / RSC contexts that evaluate on the server; React client SDK for client components. If the user requested **both**, the plan lists **both** tracks in full. If they only want one surface to start, state that explicitly in the plan.
+- **Node.js**: If it's a backend service (Express, Fastify, etc.), use the server-side SDK. There is also a [Node.js client SDK](https://launchdarkly.com/docs/sdk/client-side/node-js) for desktop/Electron apps.
+- **React**: If it's a standalone SPA, use `launchdarkly-react-client-sdk`. If it's part of Next.js, see above.
+- **.NET**: Use the **server** SDK (`LaunchDarkly.ServerSdk`) for ASP.NET and backend services. For MAUI, Xamarin, WPF, and UWP, use the **.NET mobile SDK** (`LaunchDarkly.ClientSdk`, **mobile key**) -- [SDK recipes -- .NET (Client)](../../references/sdk/recipes.md#net-client). **Blazor WebAssembly** (and other browser-hosted .NET client UI) still uses `LaunchDarkly.ClientSdk` but with a **client-side ID**, not a mobile key -- see the same recipe.
+- **Flutter**: Use the Flutter client SDK (`launchdarkly_flutter_client_sdk` -- [SDK recipes -- Flutter](../../references/sdk/recipes.md#flutter)). Use a **mobile key** for typical iOS/Android/desktop **app** builds; use the **client-side ID** (and the project's pattern for public env vars) for **Flutter web**. If the user ships multiple targets, confirm which to wire first or plan separate env/config per target.
+
+## Plan the changes
+
+Your integration plan should identify exactly:
+
+### 1. Files to modify
+
+Use the information gathered during [Detect repository stack](../detect/SKILL.md) -- specifically the detected package manager, dependency file, and application entrypoint:
+
+- **Dependency file**: The file identified during detection (e.g., `package.json`, `requirements.txt`, `go.mod`) -- use the detected package manager to add the SDK
+- **Entrypoint file**: The application entrypoint identified during detection -- where SDK initialization code will go. Dual-SDK plans list **two** entrypoints (see [Dual SDK integrations](#dual-sdk-integrations)).
+- **Environment/config file**: Prefer `.env` at the integration root for real secrets (create it if it does not exist); ensure `.env` is listed in `.gitignore` there. Use `.env.example` / `.env.sample` for placeholders only. If the project does not use dotenv, follow its existing config pattern -- see [Apply code changes](../apply/SKILL.md) Step 2 for consent, writing keys, and hybrid server+client cases.
+
+### 2. Code changes
+
+For **each SDK** in scope (one or two tracks), describe the specific changes:
+
+1. **Add SDK dependency** -- the install command from the SDK recipe (repeat for each package when dual-SDK)
+2. **Add SDK import** -- the import statement at the top of that track's entrypoint
+3. **Add SDK initialization** -- the init code for that SDK from that recipe/snippet, placed early in the right lifecycle (server vs client)
+4. **Configure credentials** -- via environment variable, never hardcoded (SDK key vs client-side ID per track)
+
+### 3. Environment variable convention
+
+Check how the project handles configuration:
+
+- **`.env`:** If the stack uses dotenv (or you are introducing it for LaunchDarkly), plan to create `.env` at the integration root when it is missing, then add `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID` / bundler-prefixed client ID, or `LAUNCHDARKLY_MOBILE_KEY` as appropriate (see [Apply code changes](../apply/SKILL.md) Step 2 for names, consent before real values, and hybrid server+client cases). Plan to verify `.gitignore` includes `.env` at that root (add the entry if missing, with the same user permission as other repo edits).
+- **`.env.example` / `.env.sample`:** If present, plan **placeholder** entries only (no real secrets).
+- **Config module or `process.env`:** If the project does not use `.env`, plan to follow the existing pattern for secrets.
+
+## Present the plan
+
+Before making any changes, summarize the plan to the user.
+
+**Single SDK:**
+
+1. Install `[package name]` using `[install command]`
+2. Add SDK dependency to `[dependency file]`
+3. Add import and initialization to `[entrypoint file]`
+4. Add `[env var]` to `.env` (create if missing; real value after user consent)
+5. Ensure `.env` is in `.gitignore`
+6. Add placeholder to `.env.example` if the project uses one
+
+Only LaunchDarkly SDK packages will be added unless the user explicitly approves other dependency changes.
+
+**Dual SDK:** Present the same numbered format **separately for each track** (e.g. "Server-side:" steps 1-7, then "Client-side:" steps 1-7), following [Dual SDK integrations](#dual-sdk-integrations). Do not omit the second track.
+
+After presenting the plan:
+
+**D6 -- BLOCKING:** Call your structured question tool now.
+- question: "Here's the integration plan. Does this look right?"
+- options:
+  - "Yes, approve and proceed" -> begin applying
+  - "I'd like to change something" -> let user specify changes
+- STOP. Do not write the question as text. Do not begin installing packages, writing files, or modifying code until the user selects an option.
+
+If the entrypoint is ambiguous or multiple SDKs could apply, ask those specific questions as part of the plan presentation (each as its own blocking decision point using the same pattern).
+
+**Do not** ask for SDK keys, client-side IDs, or mobile keys as part of plan confirmation -- the parent flow collects those at [Apply code changes](../apply/SKILL.md). The **Key type** column above is for technical planning only, not a prompt for secrets.
+
+**Do not** promise or imply that you will upgrade unrelated dependencies to satisfy the latest SDK -- [Apply](../apply/SKILL.md) requires **explicit approval** before any non-LaunchDarkly package changes.
+
+---
+
+**Upon completion:** [Apply code changes](../apply/SKILL.md)

--- a/skills/onboarding/sdk-install/plan/SKILL.md
+++ b/skills/onboarding/sdk-install/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launchdarkly-onboarding-sdk-plan
+name: plan
 description: "Generate a minimal LaunchDarkly SDK integration plan from detected stack: choose SDK type(s), dual-SDK server+client when required, files to change, env conventions. Nested under sdk-install; follows detect, precedes apply."
 license: Apache-2.0
 compatibility: Requires completed or equivalent detect context (see sibling detect skill)


### PR DESCRIPTION
## Summary

- Ports over the simplified onboarding agent-skill from the labs repo 

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- 
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12704: Implement Repo Evaluation Skill to Detect Likely Targets (Frontend/Backend)](https://launchdarkly.atlassian.net/browse/REL-12704)
<!-- end-ld-jira-link -->