### PR TITLE
feat: add aiconfig-migrate skill and tighten sibling skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | Skill | Description |
 |-------|-------------|
 | `ai-configs/aiconfig-create` | Create AI Configs with variations for agent or completion mode |
+| `ai-configs/aiconfig-migrate` | Migrate an app with hardcoded LLM prompts to AI Configs in five stages (extract, wrap, tools, tracking, evals) |
 | `ai-configs/aiconfig-update` | Update and delete AI Configs, manage lifecycle |
 | `ai-configs/aiconfig-variations` | Manage AI Config variations for A/B testing |
 | `ai-configs/aiconfig-tools` | Create and attach tools for function calling |

--- a/skills.json
+++ b/skills.json
@@ -9,6 +9,14 @@
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
     },
     {
+      "name": "aiconfig-migrate",
+      "description": "Migrate an application with hardcoded LLM prompts to a full LaunchDarkly AI Configs implementation in five stages: extract prompts, wrap in the AI SDK, add tools, add tracking, add evals/judges. Use when the user wants to externalize model/prompt configuration, move from direct provider calls (OpenAI, Anthropic, Bedrock, Gemini) to a managed AI Config, or stage a full hardcoded-to-LaunchDarkly migration.",
+      "path": "skills/ai-configs/aiconfig-migrate",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
+    },
+    {
       "name": "aiconfig-online-evals",
       "description": "Attach judges to AI Config variations for automatic LLM-as-a-judge evaluation. Create custom judges, configure sampling rates, and monitor quality scores.",
       "path": "skills/ai-configs/aiconfig-online-evals",

--- a/skills.json
+++ b/skills.json
@@ -1,12 +1,28 @@
 {
   "skills": [
     {
+      "name": "aiconfig-ai-metrics",
+      "description": "Instrument an existing codebase with LaunchDarkly AI Config tracking. Walks the four-tier ladder (managed runner \u2192 provider package \u2192 custom extractor + trackMetricsOf \u2192 raw manual) and picks the lowest-ceremony option that still captures duration, tokens, and success/error.",
+      "path": "skills/ai-configs/aiconfig-ai-metrics",
+      "version": "1.0.0-experimental",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the LaunchDarkly server-side AI SDK (`launchdarkly-server-sdk-ai` for Python or `@launchdarkly/server-sdk-ai` for Node) and an existing AI Config."
+    },
+    {
       "name": "aiconfig-create",
       "description": "Create and configure AI Configs in LaunchDarkly. Helps you choose between agent vs completion mode, create the config, add variations with models and prompts, and verify the setup.",
       "path": "skills/ai-configs/aiconfig-create",
       "version": "1.0.0-experimental",
       "license": "Apache-2.0",
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
+    },
+    {
+      "name": "aiconfig-custom-metrics",
+      "description": "Create, track, retrieve, update, and delete custom business metrics for AI Configs. Covers full lifecycle: define metric kinds via API, emit events via SDK, and query results.",
+      "path": "skills/ai-configs/aiconfig-custom-metrics",
+      "version": "1.0.0-experimental",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the LaunchDarkly server SDK and a LaunchDarkly API token with the `writer` role for metric management."
     },
     {
       "name": "aiconfig-migrate",

--- a/skills/ai-configs/aiconfig-ai-metrics/SKILL.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aiconfig-ai-metrics
-description: "Instrument an existing codebase with LaunchDarkly AI Config tracking. Wires the per-request tracker (duration, tokens, success/error, feedback) around provider calls for OpenAI, Anthropic, Bedrock, and streaming responses."
+description: "Instrument an existing codebase with LaunchDarkly AI Config tracking. Walks the four-tier ladder (managed runner → provider package → custom extractor + trackMetricsOf → raw manual) and picks the lowest-ceremony option that still captures duration, tokens, and success/error."
 license: Apache-2.0
 compatibility: Requires the LaunchDarkly server-side AI SDK (`launchdarkly-server-sdk-ai` for Python or `@launchdarkly/server-sdk-ai` for Node) and an existing AI Config.
 metadata:
@@ -10,81 +10,94 @@ metadata:
 
 # AI Metrics Instrumentation
 
-This skill guides you through adding AI metrics tracking to a codebase. Your job is to explore, assess, and implement the right instrumentation strategy for this specific codebase.
+You're using a skill that wires LaunchDarkly AI metrics around an existing provider call. Your job is to audit what's already there, pick the right tier from the ladder below, and implement it with the **least ceremony that still captures the metrics the Monitoring tab needs** (duration, input/output tokens, success/error, plus TTFT when streaming).
+
+The single most important thing to get right: **default to the highest tier that fits the shape of the call**. Going lower ("just write the manual tracker calls") looks flexible but costs you drift, missed metrics, and legacy patterns the SDKs have moved past.
+
+## The four-tier ladder
+
+This is the order the official SDK READMEs (Python core, Node core, and every provider package) recommend. Walk from the top and stop at the first tier that fits:
+
+| Tier | Pattern | Use when | Tracks automatically |
+|------|---------|----------|----------------------|
+| **1 — Managed runner** | Python: `ai_client.create_model(...)` returning a `ManagedModel`, then `await model.invoke(...)`. <br>Node: `aiClient.initChat(...)` / `aiClient.createChat(...)` returning a `TrackedChat`, then `await chat.invoke(...)`. | The call is conversational (chat history, turn-based). This is what the provider READMEs lead with. | Duration, tokens, success/error — **all of it, zero tracker calls**. |
+| **2 — Provider package + `trackMetricsOf`** | `tracker.trackMetricsOf(Provider.getAIMetricsFromResponse, () => providerCall())`. Provider packages today: `@launchdarkly/server-sdk-ai-openai`, `-langchain`, `-vercel` (Node) and `launchdarkly-server-sdk-ai-openai`, `-langchain` (Python). | The shape isn't a chat loop (one-shot completion, structured output, agent step) but the framework or provider has a package. | Duration + success/error from the wrapper; tokens from the package's built-in `getAIMetricsFromResponse` extractor. |
+| **3 — Custom extractor + `trackMetricsOf`** | Same `trackMetricsOf` wrapper, but you write a small function that maps the provider response to `LDAIMetrics` (tokens + success). | No provider package exists (Anthropic direct, Gemini, Cohere, custom HTTP). | Duration + success/error from the wrapper; tokens from your extractor. |
+| **4 — Raw manual** | Separate calls to `trackDuration`, `trackTokens`, `trackSuccess` / `trackError`, plus `trackTimeToFirstToken` for streams. | Streaming with TTFT, unusual response shapes, partial tracking, anything Tier 2–3 can't cleanly wrap. | Only what you explicitly call — it's on you to not miss one. |
+
+A call to `track_openai_metrics` / `trackOpenAIMetrics` / `track_bedrock_converse_metrics` / `trackBedrockConverseMetrics` / `trackVercelAISDKGenerateTextMetrics` is **Tier-2 legacy shorthand**. These helpers still exist in the SDK source but none of the current provider READMEs use them — they've been superseded by `trackMetricsOf` + `Provider.getAIMetricsFromResponse`. Do not recommend them for new code; if you see them in an existing codebase, leave them alone unless the user is already on a cleanup pass.
 
 ## Workflow
 
-### 1. Explore the Codebase
+### 1. Explore the existing call site
 
-Before implementing anything, understand what you're working with:
+Before picking a tier, find the provider call and answer these questions:
 
-- [ ] Find where AI/LLM calls are made (search for `openai`, `anthropic`, `bedrock`, `langchain`, etc.)
-- [ ] Identify which providers are in use
-- [ ] Check if LaunchDarkly SDK is already initialized
-- [ ] Look for existing AI Config usage (`completion_config()`, `agent_config()`)
-- [ ] Note whether calls are streaming or non-streaming
-- [ ] Identify the language/runtime (Python, Node.js, Go, etc.)
+- [ ] **Shape?** Is it a chat loop (history + turn-based), a one-shot completion, an agent step, or something else? → drives Tier 1 vs 2.
+- [ ] **Framework?** Raw provider SDK? LangChain / LangGraph? Vercel AI SDK? CrewAI? → drives which Tier-2 provider package (if any) applies.
+- [ ] **Provider?** OpenAI, Anthropic, Bedrock, Gemini, Azure, custom HTTP? → cross-reference with the package availability matrix below.
+- [ ] **Streaming?** If yes, you'll need TTFT tracking, which means Tier 4 for the TTFT part even if the rest is Tier 2.
+- [ ] **Language?** Python or Node? Provider-package coverage differs between them.
+- [ ] **Already using an AI Config?** If not, route to `aiconfig-create` first — tracking requires a tracker, which comes from `completion_config()` / `completionConfig()` / `initChat()`.
 
-### 2. Assess the Situation
+### 2. Look up your Tier-2 option
 
-Based on exploration, determine:
+Use this matrix to decide whether Tier 2 (provider package) is available for your situation. If it's not, drop to Tier 3 (custom extractor). If the shape is chat-loop, go to Tier 1 first regardless of what's in this matrix.
 
-| Question | Why It Matters |
-|----------|----------------|
-| Which AI provider(s)? | Determines tracking method (automatic vs manual) |
-| Streaming or batch? | Streaming requires TTFT tracking |
-| AI Config already in use? | If not, see `aiconfig-sdk` skill first |
-| Centralized or scattered calls? | Affects instrumentation strategy |
-| Error handling in place? | Need to add `track_error()` calls |
+| Framework / provider | Python provider package | Node provider package | Reference |
+|---|---|---|---|
+| OpenAI (direct SDK) | `launchdarkly-server-sdk-ai-openai` | `@launchdarkly/server-sdk-ai-openai` | [openai-tracking.md](references/openai-tracking.md) |
+| LangChain / LangGraph | `launchdarkly-server-sdk-ai-langchain` | `@launchdarkly/server-sdk-ai-langchain` | (use the LangChain provider docs) |
+| Vercel AI SDK | — | `@launchdarkly/server-sdk-ai-vercel` | (use the Vercel provider docs) |
+| AWS Bedrock (Converse or InvokeModel) | — (use LangChain-aws or custom extractor) | — (use LangChain-aws or custom extractor) | [bedrock-tracking.md](references/bedrock-tracking.md) |
+| Anthropic direct SDK | — | — | [anthropic-tracking.md](references/anthropic-tracking.md) |
+| Gemini / Google GenAI | — | — | Tier 3 custom extractor |
+| Cohere, Mistral, custom HTTP | — | — | Tier 3 custom extractor |
+| **Any provider, streaming + TTFT** | — (Tier 4 only) | `trackStreamMetricsOf` (no TTFT) + manual TTFT | [streaming-tracking.md](references/streaming-tracking.md) |
 
-### 3. Choose Your Implementation Path
+### 3. Implement from the matching reference
 
-Based on your assessment, select the appropriate reference:
+Once you know the tier and the provider, open the reference file and follow the pattern. The references are written so Tier 1 is always the first example, Tier 2/3 next, and Tier 4 last. Stop at the first tier that matches the app's shape.
 
-| Situation | Reference |
-|-----------|-----------|
-| OpenAI calls (non-streaming) | `references/openai-tracking.md` |
-| Anthropic calls | `references/anthropic-tracking.md` |
-| AWS Bedrock | `references/bedrock-tracking.md` |
-| Streaming responses | `references/streaming-tracking.md` |
-| Need to query metrics data | `references/metrics-api.md` |
+Guardrails that apply to every tier:
 
-### 4. Implement
+1. **Always check `config.enabled`** before making the tracked call. A disabled config means the user has flagged the feature off — you should short-circuit to whatever fallback the app uses (cached response, error, degraded path) rather than making the provider call at all.
+2. **Wrap the existing call, don't rewrite it.** Tier 2 and Tier 3 are designed to slot around an unmodified provider call. If you find yourself rewriting the call to fit the tracker, you're at the wrong tier — drop down one.
+3. **Errors go through the tracker too.** `trackMetricsOf` handles the success path; errors still need an explicit `tracker.trackError()` in the catch block (or a try/except around the whole thing). Tier 1 handles both paths automatically.
+4. **Flush in short-lived processes.** In serverless, cron jobs, CLI scripts — anything that exits quickly — call `ldClient.flush()` (sync or await) before the process terminates, or the tracker events never leave the machine.
 
-Follow the chosen reference to implement tracking. Key principles:
+### 4. Verify
 
-1. **Always check `config.enabled`** before making tracked calls
-2. **Wrap existing calls** rather than rewriting them when possible
-3. **Track errors** in exception handlers
-4. **Flush in serverless** environments before function terminates
+Confirm the Monitoring tab fills in:
 
-### 5. Verify
+- [ ] Run one real request through the instrumented path.
+- [ ] Open the AI Config in LaunchDarkly → **Monitoring** tab. Duration, token counts, and generation counts should appear within 1–2 minutes.
+- [ ] Force an error (bad API key, zero `max_tokens`, whatever) and confirm the error count increments.
+- [ ] If streaming: verify TTFT appears. If it doesn't, you probably wrapped the stream creation with `trackMetricsOf` but didn't add the manual `trackTimeToFirstToken` call — see [streaming-tracking.md](references/streaming-tracking.md).
 
-Confirm your instrumentation is working:
+## Quick reference: tracker methods
 
-- [ ] Make a test call through the instrumented code path
-- [ ] Check LaunchDarkly dashboard for metrics appearing
-- [ ] Verify token counts look reasonable
-- [ ] Confirm duration is being tracked
-- [ ] Test error tracking by forcing a failure
+The tracker object (`config.tracker` / `aiConfig.tracker`) provides these methods. This is the raw API surface — most of the time you should not call the individual methods, you should use `trackMetricsOf` or a Tier-1 managed runner. The list is here so you can recognize the methods in existing code and reach for the right one when you genuinely need Tier 4.
 
-## Quick Reference: Tracker Methods
+| Method (Python ↔ Node) | Tier | What it does |
+|---|---|---|
+| `track_metrics_of(extractor, fn)` / `trackMetricsOf(extractor, fn)` | **2 / 3** | Wraps a provider call, captures duration + success/error, calls your extractor for tokens. **This is the default generic tracker.** |
+| `track_metrics_of_async(extractor, fn)` (Python) | 2 / 3 | Async variant of the above. |
+| `trackStreamMetricsOf(extractor, streamFn)` (Node only) | 2 / 3 | Streaming variant. Captures per-chunk usage when the extractor handles chunks. Does **not** auto-capture TTFT. |
+| `track_duration(ms)` / `trackDuration(ms)` | 4 | Record latency in milliseconds. |
+| `track_duration_of(fn)` / `trackDurationOf(fn)` | 4 | Wraps a callable and records duration automatically. Does not capture tokens or success — pair with explicit calls. |
+| `track_tokens(TokenUsage)` / `trackTokens({input, output, total})` | 4 | Record token usage. |
+| `track_time_to_first_token(ms)` / `trackTimeToFirstToken(ms)` | 4 | Record TTFT for streaming responses. |
+| `track_success()` / `trackSuccess()` | 4 | Mark the generation as successful. Required for the Monitoring tab to count it. |
+| `track_error()` / `trackError()` | 4 | Mark the generation as failed. Do not also call `trackSuccess()` in the same request. |
+| `track_feedback({kind})` / `trackFeedback({kind})` | any | Record thumbs-up / thumbs-down from a feedback UI. Independent of the success/error path. |
+| `track_openai_metrics(fn)` / `trackOpenAIMetrics(fn)` | **legacy** | Predates provider packages. Still works; do not use in new code. Replace with `trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, fn)`. |
+| `track_bedrock_converse_metrics(res)` / `trackBedrockConverseMetrics(res)` | **legacy** | Same story. Do not use in new code. |
+| `trackVercelAISDKGenerateTextMetrics(fn)` (Node) | **legacy** | Same story. Use `trackMetricsOf` with the Vercel provider package's extractor. |
 
-The `config.tracker` object provides these methods:
+## Related skills
 
-| Method | Use Case |
-|--------|----------|
-| `track_openai_metrics(fn)` | Automatic tracking for OpenAI |
-| `track_bedrock_converse_metrics(res)` | Automatic tracking for Bedrock |
-| `track_duration_of(fn)` | Wrap any callable to track duration |
-| `track_tokens(TokenUsage)` | Manual token tracking |
-| `track_duration(int)` | Manual duration (ms) |
-| `track_time_to_first_token(int)` | TTFT for streaming (ms) |
-| `track_success()` | Mark successful |
-| `track_error()` | Mark failed |
-
-## Related Skills
-
-- `aiconfig-sdk` - SDK setup (prerequisite if not already configured)
-- `aiconfig-custom-metrics` - Business metrics beyond AI metrics
-- `aiconfig-online-evals` - Automatic quality evaluation
+- `aiconfig-create` — prerequisite if the app doesn't have an AI Config yet
+- `aiconfig-custom-metrics` — business metrics (conversion, resolution, retention) layered on top of the AI metrics this skill captures
+- `aiconfig-online-evals` — automatic quality scoring (LLM-as-judge) on sampled live requests; complementary to the metrics here
+- `aiconfig-migrate` — Stage 4 of the hardcoded-to-AI-Configs migration delegates to this skill

--- a/skills/ai-configs/aiconfig-ai-metrics/SKILL.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: aiconfig-ai-metrics
+description: "Instrument an existing codebase with LaunchDarkly AI Config tracking. Wires the per-request tracker (duration, tokens, success/error, feedback) around provider calls for OpenAI, Anthropic, Bedrock, and streaming responses."
+license: Apache-2.0
+compatibility: Requires the LaunchDarkly server-side AI SDK (`launchdarkly-server-sdk-ai` for Python or `@launchdarkly/server-sdk-ai` for Node) and an existing AI Config.
+metadata:
+  author: launchdarkly
+  version: "1.0.0-experimental"
+---
+
+# AI Metrics Instrumentation
+
+This skill guides you through adding AI metrics tracking to a codebase. Your job is to explore, assess, and implement the right instrumentation strategy for this specific codebase.
+
+## Workflow
+
+### 1. Explore the Codebase
+
+Before implementing anything, understand what you're working with:
+
+- [ ] Find where AI/LLM calls are made (search for `openai`, `anthropic`, `bedrock`, `langchain`, etc.)
+- [ ] Identify which providers are in use
+- [ ] Check if LaunchDarkly SDK is already initialized
+- [ ] Look for existing AI Config usage (`completion_config()`, `agent_config()`)
+- [ ] Note whether calls are streaming or non-streaming
+- [ ] Identify the language/runtime (Python, Node.js, Go, etc.)
+
+### 2. Assess the Situation
+
+Based on exploration, determine:
+
+| Question | Why It Matters |
+|----------|----------------|
+| Which AI provider(s)? | Determines tracking method (automatic vs manual) |
+| Streaming or batch? | Streaming requires TTFT tracking |
+| AI Config already in use? | If not, see `aiconfig-sdk` skill first |
+| Centralized or scattered calls? | Affects instrumentation strategy |
+| Error handling in place? | Need to add `track_error()` calls |
+
+### 3. Choose Your Implementation Path
+
+Based on your assessment, select the appropriate reference:
+
+| Situation | Reference |
+|-----------|-----------|
+| OpenAI calls (non-streaming) | `references/openai-tracking.md` |
+| Anthropic calls | `references/anthropic-tracking.md` |
+| AWS Bedrock | `references/bedrock-tracking.md` |
+| Streaming responses | `references/streaming-tracking.md` |
+| Need to query metrics data | `references/metrics-api.md` |
+
+### 4. Implement
+
+Follow the chosen reference to implement tracking. Key principles:
+
+1. **Always check `config.enabled`** before making tracked calls
+2. **Wrap existing calls** rather than rewriting them when possible
+3. **Track errors** in exception handlers
+4. **Flush in serverless** environments before function terminates
+
+### 5. Verify
+
+Confirm your instrumentation is working:
+
+- [ ] Make a test call through the instrumented code path
+- [ ] Check LaunchDarkly dashboard for metrics appearing
+- [ ] Verify token counts look reasonable
+- [ ] Confirm duration is being tracked
+- [ ] Test error tracking by forcing a failure
+
+## Quick Reference: Tracker Methods
+
+The `config.tracker` object provides these methods:
+
+| Method | Use Case |
+|--------|----------|
+| `track_openai_metrics(fn)` | Automatic tracking for OpenAI |
+| `track_bedrock_converse_metrics(res)` | Automatic tracking for Bedrock |
+| `track_duration_of(fn)` | Wrap any callable to track duration |
+| `track_tokens(TokenUsage)` | Manual token tracking |
+| `track_duration(int)` | Manual duration (ms) |
+| `track_time_to_first_token(int)` | TTFT for streaming (ms) |
+| `track_success()` | Mark successful |
+| `track_error()` | Mark failed |
+
+## Related Skills
+
+- `aiconfig-sdk` - SDK setup (prerequisite if not already configured)
+- `aiconfig-custom-metrics` - Business metrics beyond AI metrics
+- `aiconfig-online-evals` - Automatic quality evaluation

--- a/skills/ai-configs/aiconfig-ai-metrics/references/anthropic-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/anthropic-tracking.md
@@ -1,0 +1,118 @@
+# Anthropic Metrics Tracking
+
+Manual metrics tracking for Anthropic API calls using `TokenUsage` and tracker methods.
+
+## What Gets Tracked
+
+- Input/output/total tokens (manual)
+- Duration (automatic with `track_duration_of`)
+- Success/failure status
+
+## Implementation
+```python
+import anthropic
+from ldai.tracker import TokenUsage
+
+client = anthropic.Anthropic()
+
+def call_with_tracking(config, user_prompt: str):
+    """Anthropic call with manual metrics tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+
+    # Track duration of the call
+    response = tracker.track_duration_of(
+        lambda: client.messages.create(
+            model=config.model.name,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": user_prompt}]
+        )
+    )
+
+    # Manually track tokens using TokenUsage object
+    if hasattr(response, 'usage'):
+        tokens = TokenUsage(
+            total=response.usage.input_tokens + response.usage.output_tokens,
+            input=response.usage.input_tokens,
+            output=response.usage.output_tokens
+        )
+        tracker.track_tokens(tokens)
+
+    tracker.track_success()
+    return response.content[0].text
+```
+
+## With System Prompt from Config
+```python
+def call_with_system_prompt(config, user_prompt: str):
+    """Anthropic call using system prompt from AI Config."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+    system_content = config.messages[0].content if config.messages else ""
+
+    response = tracker.track_duration_of(
+        lambda: client.messages.create(
+            model=config.model.name,
+            max_tokens=1024,
+            system=system_content,
+            messages=[{"role": "user", "content": user_prompt}]
+        )
+    )
+
+    if hasattr(response, 'usage'):
+        tokens = TokenUsage(
+            total=response.usage.input_tokens + response.usage.output_tokens,
+            input=response.usage.input_tokens,
+            output=response.usage.output_tokens
+        )
+        tracker.track_tokens(tokens)
+
+    tracker.track_success()
+    return response.content[0].text
+```
+
+## With Error Handling
+```python
+def call_with_tracking_safe(config, user_prompt: str):
+    """Anthropic call with metrics and error tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+
+    try:
+        response = tracker.track_duration_of(
+            lambda: client.messages.create(
+                model=config.model.name,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": user_prompt}]
+            )
+        )
+
+        if hasattr(response, 'usage'):
+            tokens = TokenUsage(
+                total=response.usage.input_tokens + response.usage.output_tokens,
+                input=response.usage.input_tokens,
+                output=response.usage.output_tokens
+            )
+            tracker.track_tokens(tokens)
+
+        tracker.track_success()
+        return response.content[0].text
+
+    except Exception as e:
+        tracker.track_error()
+        raise
+```
+
+## Notes
+
+- Anthropic doesn't have automatic tracking like OpenAI
+- Use `track_duration_of()` to wrap the call for timing
+- Extract tokens from `response.usage` and create a `TokenUsage` object
+- Call `track_success()` explicitly after successful completion
+- For streaming, see `streaming-tracking.md` instead

--- a/skills/ai-configs/aiconfig-ai-metrics/references/anthropic-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/anthropic-tracking.md
@@ -1,118 +1,130 @@
 # Anthropic Metrics Tracking
 
-Manual metrics tracking for Anthropic API calls using `TokenUsage` and tracker methods.
+**There is no LaunchDarkly provider package for Anthropic direct API today.** The canonical path is the generic `trackMetricsOf` wrapper (Tier 3) with a small custom extractor that reads `response.usage.input_tokens` and `response.usage.output_tokens`. The instinct to "default to generic" is correct here — there is no Tier-2 shortcut to take.
 
-## What Gets Tracked
+Three viable paths, in order of preference:
 
-- Input/output/total tokens (manual)
-- Duration (automatic with `track_duration_of`)
-- Success/failure status
+1. **Route Anthropic through LangChain.** If the app already uses LangChain (or can adopt it cheaply), install the LangChain provider package and use it as Tier 2. LangChain's `ChatAnthropic` wrapper exposes the standardized `usage_metadata` that `LangChainProvider.getAIMetricsFromResponse` reads.
+2. **Route Anthropic through Bedrock Converse.** If the app can switch to Bedrock Converse (Claude is available on Bedrock), you inherit Bedrock's Converse response shape and a custom-extractor pattern that's slightly cleaner. See [bedrock-tracking.md](bedrock-tracking.md).
+3. **Custom extractor on the direct SDK** (this file's primary pattern).
 
-## Implementation
+## Tier 1 is not available
+
+`ManagedModel` / `TrackedChat` do not currently ship an Anthropic provider. If you need Tier 1 for a chat app, use option 1 or 2 above — the LangChain provider package lets `ManagedModel` wrap a `ChatAnthropic` under the hood, which restores the zero-tracker-call experience.
+
+## Tier 3 — Custom extractor + `trackMetricsOf` (primary)
+
+**Python** — direct Anthropic SDK:
+
 ```python
 import anthropic
-from ldai.tracker import TokenUsage
+from ldai.providers.types import LDAIMetrics, TokenUsage
 
 client = anthropic.Anthropic()
 
-def call_with_tracking(config, user_prompt: str):
-    """Anthropic call with manual metrics tracking."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
-
-    # Track duration of the call
-    response = tracker.track_duration_of(
-        lambda: client.messages.create(
-            model=config.model.name,
-            max_tokens=1024,
-            messages=[{"role": "user", "content": user_prompt}]
-        )
-    )
-
-    # Manually track tokens using TokenUsage object
-    if hasattr(response, 'usage'):
-        tokens = TokenUsage(
+def anthropic_extractor(response) -> LDAIMetrics:
+    return LDAIMetrics(
+        success=True,
+        usage=TokenUsage(
             total=response.usage.input_tokens + response.usage.output_tokens,
             input=response.usage.input_tokens,
-            output=response.usage.output_tokens
-        )
-        tracker.track_tokens(tokens)
+            output=response.usage.output_tokens,
+        ),
+    )
 
-    tracker.track_success()
-    return response.content[0].text
-```
-
-## With System Prompt from Config
-```python
-def call_with_system_prompt(config, user_prompt: str):
-    """Anthropic call using system prompt from AI Config."""
-    if not config.enabled:
+def call_with_tracking(ai_config, user_prompt: str) -> str | None:
+    if not ai_config.enabled:
         return None
 
-    tracker = config.tracker
-    system_content = config.messages[0].content if config.messages else ""
+    system_content = ai_config.messages[0].content if ai_config.messages else ""
 
-    response = tracker.track_duration_of(
-        lambda: client.messages.create(
-            model=config.model.name,
+    def call_anthropic():
+        return client.messages.create(
+            model=ai_config.model.name,
             max_tokens=1024,
             system=system_content,
-            messages=[{"role": "user", "content": user_prompt}]
+            messages=[{"role": "user", "content": user_prompt}],
         )
-    )
-
-    if hasattr(response, 'usage'):
-        tokens = TokenUsage(
-            total=response.usage.input_tokens + response.usage.output_tokens,
-            input=response.usage.input_tokens,
-            output=response.usage.output_tokens
-        )
-        tracker.track_tokens(tokens)
-
-    tracker.track_success()
-    return response.content[0].text
-```
-
-## With Error Handling
-```python
-def call_with_tracking_safe(config, user_prompt: str):
-    """Anthropic call with metrics and error tracking."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
 
     try:
-        response = tracker.track_duration_of(
-            lambda: client.messages.create(
-                model=config.model.name,
-                max_tokens=1024,
-                messages=[{"role": "user", "content": user_prompt}]
-            )
-        )
-
-        if hasattr(response, 'usage'):
-            tokens = TokenUsage(
-                total=response.usage.input_tokens + response.usage.output_tokens,
-                input=response.usage.input_tokens,
-                output=response.usage.output_tokens
-            )
-            tracker.track_tokens(tokens)
-
-        tracker.track_success()
+        response = ai_config.tracker.track_metrics_of(call_anthropic, anthropic_extractor)
         return response.content[0].text
-
-    except Exception as e:
-        tracker.track_error()
+    except Exception:
+        ai_config.tracker.track_error()
         raise
 ```
 
-## Notes
+**Node** — direct Anthropic SDK:
 
-- Anthropic doesn't have automatic tracking like OpenAI
-- Use `track_duration_of()` to wrap the call for timing
-- Extract tokens from `response.usage` and create a `TokenUsage` object
-- Call `track_success()` explicitly after successful completion
-- For streaming, see `streaming-tracking.md` instead
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import type { LDAIMetrics } from '@launchdarkly/server-sdk-ai';
+
+const client = new Anthropic();
+
+const anthropicExtractor = (response: Anthropic.Message): LDAIMetrics => ({
+  success: true,
+  usage: {
+    total: response.usage.input_tokens + response.usage.output_tokens,
+    input: response.usage.input_tokens,
+    output: response.usage.output_tokens,
+  },
+});
+
+async function callWithTracking(
+  aiConfig: LDAICompletionConfig,
+  userPrompt: string,
+): Promise<string | null> {
+  if (!aiConfig.enabled) return null;
+
+  const systemContent = aiConfig.messages?.[0]?.content ?? '';
+
+  try {
+    const response = await aiConfig.tracker.trackMetricsOf(
+      anthropicExtractor,
+      () => client.messages.create({
+        model: aiConfig.model!.name,
+        max_tokens: 1024,
+        system: systemContent,
+        messages: [{ role: 'user', content: userPrompt }],
+      }),
+    );
+    return response.content[0].type === 'text' ? response.content[0].text : null;
+  } catch (err) {
+    aiConfig.tracker.trackError();
+    throw err;
+  }
+}
+```
+
+Notes on the extractor shape:
+
+- Anthropic returns `input_tokens` / `output_tokens` on `response.usage`. Compute `total` yourself; Anthropic does not provide it.
+- `LDAIMetrics` is a typed surface — Python has it at `ldai.providers.types`, Node exports it from `@launchdarkly/server-sdk-ai`. Keep the extractor pure: no side effects, no network calls.
+- `success: true` in the extractor is not a lie — `trackMetricsOf` only calls the extractor on the success path. Errors go through the catch block and `trackError()`.
+
+## Tier 2 option — route via LangChain
+
+If the app can adopt LangChain, the LangChain provider package handles Anthropic (via `@langchain/anthropic`) through the same `trackMetricsOf(LangChainProvider.getAIMetricsFromResponse, ...)` pattern used for any other LangChain model. This is often the cleanest answer if the app already uses or is open to LangChain, because the extractor is built in and shared with every other LangChain-wrapped model.
+
+```python
+from ldai_langchain import LangChainProvider
+
+ai_config = ai_client.completion_config("my-config-key", context, default_config)
+llm = await LangChainProvider.create_langchain_model(ai_config)  # ChatAnthropic under the hood
+
+response = ai_config.tracker.track_metrics_of(
+    lambda: llm.invoke(messages),
+    LangChainProvider.get_ai_metrics_from_response,
+)
+```
+
+## Tier 4 — Manual (streaming only)
+
+Streaming Anthropic needs manual TTFT tracking; the pattern is identical to OpenAI streaming. See [streaming-tracking.md](streaming-tracking.md).
+
+## What NOT to do
+
+- **Do not hand-wire `track_duration_of` + `track_tokens` + `track_success` as three separate calls** unless you're on the streaming path. That's Tier 4, and `trackMetricsOf` gives you the same three metrics in one call with half the drift surface.
+- **Do not look for a `track_anthropic_metrics` helper** — it doesn't exist, never has, and won't be added. Anthropic direct support lives in the extractor you write above.
+- **Do not invent a provider package** like `@launchdarkly/server-sdk-ai-anthropic`. It doesn't exist as of this writing. Check [js-core ai-providers](https://github.com/launchdarkly/js-core/tree/main/packages/ai-providers) before recommending one.

--- a/skills/ai-configs/aiconfig-ai-metrics/references/bedrock-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/bedrock-tracking.md
@@ -1,0 +1,89 @@
+# AWS Bedrock Metrics Tracking
+
+Automatic metrics tracking for AWS Bedrock Converse API using `track_bedrock_converse_metrics()`.
+
+## What Gets Tracked Automatically
+
+- Input/output/total tokens
+- Success status
+
+## Implementation
+```python
+import boto3
+
+bedrock = boto3.client("bedrock-runtime")
+
+def call_with_tracking(config, user_prompt: str):
+    """Bedrock Converse call with automatic metrics tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+
+    # Make the Bedrock call
+    response = tracker.track_duration_of(
+        lambda: bedrock.converse(
+            modelId=config.model.name,
+            messages=[{"role": "user", "content": [{"text": user_prompt}]}]
+        )
+    )
+
+    # Track Bedrock-specific metrics from response
+    tracker.track_bedrock_converse_metrics(response)
+
+    return response["output"]["message"]["content"][0]["text"]
+```
+
+## With System Prompt from Config
+```python
+def call_with_system_prompt(config, user_prompt: str):
+    """Bedrock call using system prompt from AI Config."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+    system_content = config.messages[0].content if config.messages else ""
+
+    response = tracker.track_duration_of(
+        lambda: bedrock.converse(
+            modelId=config.model.name,
+            system=[{"text": system_content}],
+            messages=[{"role": "user", "content": [{"text": user_prompt}]}]
+        )
+    )
+
+    tracker.track_bedrock_converse_metrics(response)
+
+    return response["output"]["message"]["content"][0]["text"]
+```
+
+## With Error Handling
+```python
+def call_with_tracking_safe(config, user_prompt: str):
+    """Bedrock call with metrics and error tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+
+    try:
+        response = tracker.track_duration_of(
+            lambda: bedrock.converse(
+                modelId=config.model.name,
+                messages=[{"role": "user", "content": [{"text": user_prompt}]}]
+            )
+        )
+
+        tracker.track_bedrock_converse_metrics(response)
+        return response["output"]["message"]["content"][0]["text"]
+
+    except Exception as e:
+        tracker.track_error()
+        raise
+```
+
+## Notes
+
+- `track_bedrock_converse_metrics()` extracts tokens from Bedrock's response format
+- Wrap with `track_duration_of()` to capture timing
+- This works with the Converse API; for legacy InvokeModel, use manual tracking

--- a/skills/ai-configs/aiconfig-ai-metrics/references/bedrock-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/bedrock-tracking.md
@@ -1,89 +1,153 @@
 # AWS Bedrock Metrics Tracking
 
-Automatic metrics tracking for AWS Bedrock Converse API using `track_bedrock_converse_metrics()`.
+**There is no LaunchDarkly provider package for Bedrock today** (neither Python nor Node). Two practical paths:
 
-## What Gets Tracked Automatically
+1. **Route Bedrock through LangChain** (`ChatBedrockConverse` / `langchain-aws`). If you're open to LangChain, this is the closest thing to Tier 2 — you use the LangChain provider package's `getAIMetricsFromResponse` and inherit the whole `trackMetricsOf` pattern for free.
+2. **Custom extractor on `boto3`** (this file's primary pattern). Bedrock Converse returns a stable response shape with `usage.inputTokens` / `usage.outputTokens` / `usage.totalTokens`, so the extractor is three lines.
 
-- Input/output/total tokens
-- Success status
+## Tier 1 is not available
 
-## Implementation
+Neither `ManagedModel` (Python) nor `TrackedChat` / `initChat` (Node) ship a Bedrock provider today. If you want Tier 1 for a Bedrock chat app, route via LangChain — `ManagedModel` can wrap a `ChatBedrockConverse` through the LangChain provider package.
+
+## Tier 3 — Custom extractor + `trackMetricsOf` (primary)
+
+### Converse API (recommended)
+
+**Python:**
+
 ```python
 import boto3
+from ldai.providers.types import LDAIMetrics, TokenUsage
 
 bedrock = boto3.client("bedrock-runtime")
 
-def call_with_tracking(config, user_prompt: str):
-    """Bedrock Converse call with automatic metrics tracking."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
-
-    # Make the Bedrock call
-    response = tracker.track_duration_of(
-        lambda: bedrock.converse(
-            modelId=config.model.name,
-            messages=[{"role": "user", "content": [{"text": user_prompt}]}]
-        )
+def bedrock_converse_extractor(response) -> LDAIMetrics:
+    usage = response.get("usage", {})
+    return LDAIMetrics(
+        success=True,
+        usage=TokenUsage(
+            total=usage.get("totalTokens", 0),
+            input=usage.get("inputTokens", 0),
+            output=usage.get("outputTokens", 0),
+        ),
     )
 
-    # Track Bedrock-specific metrics from response
-    tracker.track_bedrock_converse_metrics(response)
-
-    return response["output"]["message"]["content"][0]["text"]
-```
-
-## With System Prompt from Config
-```python
-def call_with_system_prompt(config, user_prompt: str):
-    """Bedrock call using system prompt from AI Config."""
-    if not config.enabled:
+def call_with_tracking(ai_config, user_prompt: str) -> str | None:
+    if not ai_config.enabled:
         return None
 
-    tracker = config.tracker
-    system_content = config.messages[0].content if config.messages else ""
+    system_content = ai_config.messages[0].content if ai_config.messages else ""
 
-    response = tracker.track_duration_of(
-        lambda: bedrock.converse(
-            modelId=config.model.name,
-            system=[{"text": system_content}],
-            messages=[{"role": "user", "content": [{"text": user_prompt}]}]
-        )
-    )
-
-    tracker.track_bedrock_converse_metrics(response)
-
-    return response["output"]["message"]["content"][0]["text"]
-```
-
-## With Error Handling
-```python
-def call_with_tracking_safe(config, user_prompt: str):
-    """Bedrock call with metrics and error tracking."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
+    def call_bedrock():
+        kwargs = {
+            "modelId": ai_config.model.name,
+            "messages": [{"role": "user", "content": [{"text": user_prompt}]}],
+        }
+        if system_content:
+            kwargs["system"] = [{"text": system_content}]
+        return bedrock.converse(**kwargs)
 
     try:
-        response = tracker.track_duration_of(
-            lambda: bedrock.converse(
-                modelId=config.model.name,
-                messages=[{"role": "user", "content": [{"text": user_prompt}]}]
-            )
-        )
-
-        tracker.track_bedrock_converse_metrics(response)
+        response = ai_config.tracker.track_metrics_of(call_bedrock, bedrock_converse_extractor)
         return response["output"]["message"]["content"][0]["text"]
-
-    except Exception as e:
-        tracker.track_error()
+    except Exception:
+        ai_config.tracker.track_error()
         raise
 ```
 
-## Notes
+**Node:**
 
-- `track_bedrock_converse_metrics()` extracts tokens from Bedrock's response format
-- Wrap with `track_duration_of()` to capture timing
-- This works with the Converse API; for legacy InvokeModel, use manual tracking
+```typescript
+import { BedrockRuntimeClient, ConverseCommand, type ConverseCommandOutput } from '@aws-sdk/client-bedrock-runtime';
+import type { LDAIMetrics } from '@launchdarkly/server-sdk-ai';
+
+const bedrock = new BedrockRuntimeClient({});
+
+const bedrockConverseExtractor = (response: ConverseCommandOutput): LDAIMetrics => ({
+  success: true,
+  usage: {
+    total: response.usage?.totalTokens ?? 0,
+    input: response.usage?.inputTokens ?? 0,
+    output: response.usage?.outputTokens ?? 0,
+  },
+});
+
+async function callWithTracking(
+  aiConfig: LDAICompletionConfig,
+  userPrompt: string,
+): Promise<string | null> {
+  if (!aiConfig.enabled) return null;
+
+  const systemContent = aiConfig.messages?.[0]?.content;
+
+  try {
+    const response = await aiConfig.tracker.trackMetricsOf(
+      bedrockConverseExtractor,
+      () => bedrock.send(new ConverseCommand({
+        modelId: aiConfig.model!.name,
+        messages: [{ role: 'user', content: [{ text: userPrompt }] }],
+        ...(systemContent ? { system: [{ text: systemContent }] } : {}),
+      })),
+    );
+    return response.output?.message?.content?.[0]?.text ?? null;
+  } catch (err) {
+    aiConfig.tracker.trackError();
+    throw err;
+  }
+}
+```
+
+### Legacy InvokeModel API
+
+`InvokeModel` returns per-model shapes (Anthropic on Bedrock returns Anthropic's shape, Llama on Bedrock returns Meta's shape, etc.), so the extractor has to branch. **Prefer Converse** unless you're locked into InvokeModel by an older model that Converse doesn't support. If you must use InvokeModel, switch the extractor based on the model family:
+
+```python
+def invoke_model_extractor(response) -> LDAIMetrics:
+    body = json.loads(response["body"].read())
+    # Claude on InvokeModel
+    if "usage" in body:
+        return LDAIMetrics(
+            success=True,
+            usage=TokenUsage(
+                total=body["usage"]["input_tokens"] + body["usage"]["output_tokens"],
+                input=body["usage"]["input_tokens"],
+                output=body["usage"]["output_tokens"],
+            ),
+        )
+    # Llama / Titan — use the fields on the specific body shape
+    # ...
+    return LDAIMetrics(success=True, usage=TokenUsage(total=0, input=0, output=0))
+```
+
+This is a good reason to migrate to Converse if you can.
+
+## Tier 2 option — route via LangChain
+
+If the app uses LangChain, the LangChain provider package's `ChatBedrockConverse` support gives you the Tier-2 experience:
+
+```python
+from ldai_langchain import LangChainProvider
+
+ai_config = ai_client.completion_config("my-config-key", context, default_config)
+llm = await LangChainProvider.create_langchain_model(ai_config)  # ChatBedrockConverse when provider=bedrock
+
+response = ai_config.tracker.track_metrics_of(
+    lambda: llm.invoke(messages),
+    LangChainProvider.get_ai_metrics_from_response,
+)
+```
+
+LangChain normalizes the Converse response shape into `AIMessage.usage_metadata`, which `LangChainProvider.get_ai_metrics_from_response` reads — so you don't need a Bedrock-specific extractor.
+
+## Tier 4 — Manual (streaming only)
+
+Bedrock Converse streaming (`ConverseStream`) needs manual TTFT tracking. The pattern is identical to OpenAI streaming. See [streaming-tracking.md](streaming-tracking.md).
+
+## Legacy: `track_bedrock_converse_metrics` / `trackBedrockConverseMetrics`
+
+Existing code may call `tracker.track_bedrock_converse_metrics(response)` directly. This helper still works and reads the same fields the custom extractor above reads. The current recommendation is to prefer `trackMetricsOf` with a custom extractor because:
+
+- It keeps the tracking call in one place (the wrapper) rather than requiring a separate post-call step, which is easy to forget.
+- It captures duration automatically; the legacy helper does not, so existing code typically pairs it with `track_duration_of`, which drifts.
+
+**Do not introduce `track_bedrock_converse_metrics` in new code.** Leave it alone in existing code unless the user asks for a cleanup.

--- a/skills/ai-configs/aiconfig-ai-metrics/references/metrics-api.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/metrics-api.md
@@ -1,0 +1,101 @@
+# Metrics API
+
+Retrieve AI Config metrics via the LaunchDarkly REST API.
+
+## Endpoint
+
+```
+GET /api/v2/projects/{projectKey}/ai-configs/{configKey}/metrics
+```
+
+## Authentication
+
+Requires an API token with `ai-configs:read` permission.
+
+```python
+headers = {
+    "Authorization": "your-api-token",
+    "LD-API-Version": "beta"
+}
+```
+
+## Implementation
+```python
+import requests
+import time
+import os
+
+def get_ai_config_metrics(project_key: str, config_key: str, env: str = "production", hours: int = 24):
+    """Get AI Config metrics for the last N hours."""
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    now = int(time.time())
+    start = now - (hours * 3600)
+
+    url = f"https://app.launchdarkly.com/api/v2/projects/{project_key}/ai-configs/{config_key}/metrics"
+
+    params = {
+        "from": start,
+        "to": now,
+        "env": env
+    }
+
+    headers = {
+        "Authorization": API_TOKEN,
+        "LD-API-Version": "beta"
+    }
+
+    response = requests.get(url, headers=headers, params=params)
+
+    if response.status_code == 200:
+        metrics = response.json()
+        print(f"[OK] Metrics for {config_key} (last {hours} hours, {env}):")
+        print(f"     Generations: {metrics.get('generationCount', 0):,}")
+        print(f"     Success: {metrics.get('generationSuccessCount', 0):,}")
+        print(f"     Errors: {metrics.get('generationErrorCount', 0):,}")
+        print(f"     Input Tokens: {metrics.get('inputTokens', 0):,}")
+        print(f"     Output Tokens: {metrics.get('outputTokens', 0):,}")
+        print(f"     Total Tokens: {metrics.get('totalTokens', 0):,}")
+        print(f"     Input Cost: ${metrics.get('inputCost', 0):.4f}")
+        print(f"     Output Cost: ${metrics.get('outputCost', 0):.4f}")
+        print(f"     Duration (ms): {metrics.get('durationMs', 0):,}")
+        print(f"     TTFT (ms): {metrics.get('timeToFirstTokenMs', 0):,}")
+        print(f"     Thumbs Up: {metrics.get('thumbsUp', 0)}")
+        print(f"     Thumbs Down: {metrics.get('thumbsDown', 0)}")
+        return metrics
+    else:
+        print(f"[ERROR] Failed to get metrics: {response.status_code}")
+        return None
+```
+
+## Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `generationCount` | Total number of generations |
+| `generationSuccessCount` | Successful generations |
+| `generationErrorCount` | Failed generations |
+| `inputTokens` | Total input tokens used |
+| `outputTokens` | Total output tokens generated |
+| `totalTokens` | Sum of input + output tokens |
+| `inputCost` | Cost for input tokens |
+| `outputCost` | Cost for output tokens |
+| `durationMs` | Total duration in milliseconds |
+| `timeToFirstTokenMs` | Time to first token (streaming) |
+| `thumbsUp` | Positive feedback count |
+| `thumbsDown` | Negative feedback count |
+
+## Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | int | Unix timestamp for start of range |
+| `to` | int | Unix timestamp for end of range |
+| `env` | string | Environment key (default: "production") |
+
+## Notes
+
+- Time range is specified in Unix timestamps (seconds)
+- Costs are calculated based on model pricing and token usage
+- Feedback counts require user feedback tracking implementation
+- Rate limits apply; see API documentation for details

--- a/skills/ai-configs/aiconfig-ai-metrics/references/openai-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/openai-tracking.md
@@ -1,0 +1,84 @@
+# OpenAI Metrics Tracking
+
+Automatic metrics tracking for OpenAI API calls using `track_openai_metrics()`.
+
+## What Gets Tracked Automatically
+
+- Input/output/total tokens
+- Duration
+- Success/failure status
+
+## Implementation
+```python
+import openai
+
+def call_with_tracking(config, user_prompt: str):
+    """OpenAI call with automatic metrics tracking."""
+    if not config.enabled:
+        return None
+
+    response = config.tracker.track_openai_metrics(
+        lambda: openai.chat.completions.create(
+            model=config.model.name,
+            messages=[
+                {"role": "system", "content": config.messages[0].content},
+                {"role": "user", "content": user_prompt}
+            ]
+        )
+    )
+
+    return response.choices[0].message.content
+```
+
+## With Error Handling
+```python
+def call_with_tracking_safe(config, user_prompt: str):
+    """OpenAI call with metrics and error tracking."""
+    if not config.enabled:
+        return None
+
+    try:
+        response = config.tracker.track_openai_metrics(
+            lambda: openai.chat.completions.create(
+                model=config.model.name,
+                messages=[
+                    {"role": "system", "content": config.messages[0].content},
+                    {"role": "user", "content": user_prompt}
+                ]
+            )
+        )
+        return response.choices[0].message.content
+
+    except Exception as e:
+        config.tracker.track_error()
+        raise
+```
+
+## Adapting Existing Code
+
+If you have existing OpenAI calls like this:
+```python
+# Before
+response = openai.chat.completions.create(
+    model="gpt-4",
+    messages=messages
+)
+```
+
+Wrap them like this:
+```python
+# After
+response = config.tracker.track_openai_metrics(
+    lambda: openai.chat.completions.create(
+        model=config.model.name,
+        messages=messages
+    )
+)
+```
+
+## Notes
+
+- The wrapper returns the original OpenAI response object unchanged
+- Token counts are extracted from the response automatically
+- Duration is measured from call start to completion
+- For streaming, see `streaming-tracking.md` instead

--- a/skills/ai-configs/aiconfig-ai-metrics/references/openai-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/openai-tracking.md
@@ -1,84 +1,175 @@
 # OpenAI Metrics Tracking
 
-Automatic metrics tracking for OpenAI API calls using `track_openai_metrics()`.
+OpenAI is covered by a first-class LaunchDarkly provider package in both Python and Node. Walk the tiers from top to bottom and stop at the first one that fits the call shape.
 
-## What Gets Tracked Automatically
+## Tier 1 — Managed runner (chat apps)
 
-- Input/output/total tokens
-- Duration
-- Success/failure status
+The simplest path for conversational OpenAI calls. Zero tracker calls — duration, tokens, and success/error are all captured by `invoke()`.
 
-## Implementation
+**Python** — `ManagedModel` via `ai_client.create_model()`:
+
+```python
+from ldclient import Context
+from ldai import LDAIClient, AICompletionConfigDefault, ModelConfig, LDMessage, ProviderConfig
+
+default_config = AICompletionConfigDefault(
+    enabled=True,
+    model=ModelConfig(name="gpt-4o"),
+    provider=ProviderConfig(name="openai"),
+    messages=[LDMessage(role="system", content="You are a helpful assistant.")],
+)
+
+async def handle_turn(ai_client: LDAIClient, context: Context, user_input: str) -> str:
+    model = await ai_client.create_model(
+        "customer-support-chat",
+        context,
+        default_config,
+    )
+    if not model:
+        return "Feature is currently unavailable."
+    response = await model.invoke(user_input)
+    return response.message.content
+```
+
+**Node** — `TrackedChat` via `aiClient.initChat()`:
+
+```typescript
+import { init } from '@launchdarkly/node-server-sdk';
+import { initAi } from '@launchdarkly/server-sdk-ai';
+
+const ldClient = init(process.env.LD_SDK_KEY!);
+const aiClient = initAi(ldClient);
+
+async function handleTurn(context: LDContext, userInput: string): Promise<string> {
+  const chat = await aiClient.initChat(
+    'customer-support-chat',
+    context,
+    {
+      enabled: true,
+      model: { name: 'gpt-4o' },
+      provider: { name: 'openai' },
+      messages: [{ role: 'system', content: 'You are a helpful assistant.' }],
+    },
+  );
+  if (!chat) return 'Feature is currently unavailable.';
+  const response = await chat.invoke(userInput);
+  return response.message.content;
+}
+```
+
+Tracking is handled inside `invoke()`. You do not need `trackMetricsOf`, `trackSuccess`, or `trackTokens` at this tier.
+
+## Tier 2 — Provider package + `trackMetricsOf` (non-chat shapes)
+
+Use this when the call isn't a chat loop (one-shot completion, structured output, batch job, agent step). The provider package exposes a static `getAIMetricsFromResponse` that knows how to pull tokens out of an OpenAI response; you compose it with the generic `trackMetricsOf` wrapper.
+
+**Python** — `launchdarkly-server-sdk-ai-openai`:
+
+```python
+from ldai_openai import OpenAIProvider
+
+ai_config = ai_client.completion_config("my-config-key", context, default_config)
+if not ai_config.enabled:
+    return None
+
+provider = await OpenAIProvider.create(ai_config)
+response = await provider.invoke_model(ai_config.messages)
+return response.message.content
+```
+
+`OpenAIProvider.invoke_model()` also tracks automatically. If you need finer-grained control (e.g., you want to supply your own OpenAI client with custom retries), use the raw SDK + `track_metrics_of`:
+
 ```python
 import openai
+from ldai_openai import OpenAIProvider
 
-def call_with_tracking(config, user_prompt: str):
-    """OpenAI call with automatic metrics tracking."""
-    if not config.enabled:
-        return None
+client = openai.OpenAI()
 
-    response = config.tracker.track_openai_metrics(
-        lambda: openai.chat.completions.create(
-            model=config.model.name,
-            messages=[
-                {"role": "system", "content": config.messages[0].content},
-                {"role": "user", "content": user_prompt}
-            ]
-        )
+ai_config = ai_client.completion_config("my-config-key", context, default_config)
+if not ai_config.enabled:
+    return None
+
+def call_openai():
+    return client.chat.completions.create(
+        model=ai_config.model.name,
+        messages=[
+            {"role": "system", "content": ai_config.messages[0].content},
+            {"role": "user", "content": user_prompt},
+        ],
     )
 
-    return response.choices[0].message.content
-```
-
-## With Error Handling
-```python
-def call_with_tracking_safe(config, user_prompt: str):
-    """OpenAI call with metrics and error tracking."""
-    if not config.enabled:
-        return None
-
-    try:
-        response = config.tracker.track_openai_metrics(
-            lambda: openai.chat.completions.create(
-                model=config.model.name,
-                messages=[
-                    {"role": "system", "content": config.messages[0].content},
-                    {"role": "user", "content": user_prompt}
-                ]
-            )
-        )
-        return response.choices[0].message.content
-
-    except Exception as e:
-        config.tracker.track_error()
-        raise
-```
-
-## Adapting Existing Code
-
-If you have existing OpenAI calls like this:
-```python
-# Before
-response = openai.chat.completions.create(
-    model="gpt-4",
-    messages=messages
+response = ai_config.tracker.track_metrics_of(
+    call_openai,
+    OpenAIProvider.get_ai_metrics_from_response,
 )
+return response.choices[0].message.content
 ```
 
-Wrap them like this:
+**Node** — `@launchdarkly/server-sdk-ai-openai`:
+
+```typescript
+import { OpenAI } from 'openai';
+import { OpenAIProvider } from '@launchdarkly/server-sdk-ai-openai';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const aiConfig = await aiClient.completionConfig('my-config-key', context, defaultConfig);
+if (!aiConfig.enabled) return null;
+
+const response = await aiConfig.tracker.trackMetricsOf(
+  OpenAIProvider.getAIMetricsFromResponse,
+  () => client.chat.completions.create({
+    model: aiConfig.model!.name,
+    messages: [
+      ...aiConfig.messages,
+      { role: 'user', content: userPrompt },
+    ],
+  }),
+);
+return response.choices[0].message.content;
+```
+
+**Error handling.** `trackMetricsOf` records `success: true` on return and lets exceptions propagate. Wrap with try/catch to capture errors:
+
+```typescript
+try {
+  const response = await aiConfig.tracker.trackMetricsOf(
+    OpenAIProvider.getAIMetricsFromResponse,
+    () => client.chat.completions.create({ /* ... */ }),
+  );
+  return response.choices[0].message.content;
+} catch (err) {
+  aiConfig.tracker.trackError();
+  throw err;
+}
+```
+
+Python follows the same shape with `try` / `except` and `config.tracker.track_error()`.
+
+## Tier 3 — Custom extractor (fallback)
+
+You should not need Tier 3 for OpenAI — the provider package covers it. If you're using a fork, a drop-in replacement (LiteLLM, Azure OpenAI via raw HTTP), or something the provider package doesn't recognize, write a small extractor:
+
 ```python
-# After
-response = config.tracker.track_openai_metrics(
-    lambda: openai.chat.completions.create(
-        model=config.model.name,
-        messages=messages
+from ldai.providers.types import LDAIMetrics, TokenUsage
+
+def my_openai_extractor(response) -> LDAIMetrics:
+    return LDAIMetrics(
+        success=True,
+        usage=TokenUsage(
+            total=response.usage.total_tokens,
+            input=response.usage.prompt_tokens,
+            output=response.usage.completion_tokens,
+        ),
     )
-)
+
+response = ai_config.tracker.track_metrics_of(call_openai, my_openai_extractor)
 ```
 
-## Notes
+## Tier 4 — Manual (streaming only)
 
-- The wrapper returns the original OpenAI response object unchanged
-- Token counts are extracted from the response automatically
-- Duration is measured from call start to completion
-- For streaming, see `streaming-tracking.md` instead
+For OpenAI streaming calls you need manual tracking because the current provider packages don't capture TTFT. See [streaming-tracking.md](streaming-tracking.md) for the full pattern. The short version: the helper that looks like it should work (`trackStreamMetricsOf` in Node) captures tokens from stream chunks but does not record TTFT, so you still need a manual `trackTimeToFirstToken` call on the first content chunk.
+
+## Legacy: `track_openai_metrics` / `trackOpenAIMetrics`
+
+You may see existing code that calls `config.tracker.track_openai_metrics(lambda: openai.chat.completions.create(...))` or the Node equivalent. These helpers still work but are no longer the recommended pattern — they predate the provider packages and the generic `trackMetricsOf` + `getAIMetricsFromResponse` composition. **Do not introduce them in new code.** If you're migrating an existing codebase, leave them in place unless the user has specifically asked for a cleanup pass — the migration from the legacy helper to the new pattern is mechanical but not free.

--- a/skills/ai-configs/aiconfig-ai-metrics/references/streaming-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/streaming-tracking.md
@@ -1,0 +1,162 @@
+# Streaming Metrics Tracking
+
+Manual metrics tracking for streaming AI responses, including time-to-first-token (TTFT).
+
+## What Gets Tracked
+
+- Time to first token (TTFT)
+- Total duration
+- Token counts (estimated or from final chunk)
+- Success/failure status
+
+## Implementation
+```python
+import time
+import openai
+from ldai.tracker import TokenUsage
+
+def call_streaming_with_tracking(config, user_prompt: str):
+    """Streaming call with TTFT and duration tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+    start_time = time.time()
+    first_token_time = None
+
+    stream = openai.chat.completions.create(
+        model=config.model.name,
+        messages=[{"role": "user", "content": user_prompt}],
+        stream=True
+    )
+
+    response_text = ""
+    for chunk in stream:
+        if first_token_time is None and chunk.choices[0].delta.content:
+            first_token_time = time.time()
+            ttft_ms = int((first_token_time - start_time) * 1000)
+            tracker.track_time_to_first_token(ttft_ms)
+
+        if chunk.choices[0].delta.content:
+            response_text += chunk.choices[0].delta.content
+
+    # Track final metrics (milliseconds)
+    duration_ms = int((time.time() - start_time) * 1000)
+    tracker.track_duration(duration_ms)
+    tracker.track_success()
+
+    # Estimate tokens (or use tiktoken for accuracy)
+    estimated_input = len(user_prompt.split()) * 2
+    estimated_output = len(response_text.split()) * 2
+    tokens = TokenUsage(
+        total=estimated_input + estimated_output,
+        input=estimated_input,
+        output=estimated_output
+    )
+    tracker.track_tokens(tokens)
+
+    return response_text
+```
+
+## With Accurate Token Counting (tiktoken)
+```python
+import time
+import openai
+import tiktoken
+from ldai.tracker import TokenUsage
+
+def call_streaming_accurate_tokens(config, user_prompt: str):
+    """Streaming with accurate token counting using tiktoken."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+    start_time = time.time()
+    first_token_time = None
+
+    # Get encoder for the model
+    try:
+        enc = tiktoken.encoding_for_model(config.model.name)
+    except KeyError:
+        enc = tiktoken.get_encoding("cl100k_base")
+
+    stream = openai.chat.completions.create(
+        model=config.model.name,
+        messages=[{"role": "user", "content": user_prompt}],
+        stream=True
+    )
+
+    response_text = ""
+    for chunk in stream:
+        if first_token_time is None and chunk.choices[0].delta.content:
+            first_token_time = time.time()
+            ttft_ms = int((first_token_time - start_time) * 1000)
+            tracker.track_time_to_first_token(ttft_ms)
+
+        if chunk.choices[0].delta.content:
+            response_text += chunk.choices[0].delta.content
+
+    # Track final metrics
+    duration_ms = int((time.time() - start_time) * 1000)
+    tracker.track_duration(duration_ms)
+    tracker.track_success()
+
+    # Accurate token counts
+    input_tokens = len(enc.encode(user_prompt))
+    output_tokens = len(enc.encode(response_text))
+    tokens = TokenUsage(
+        total=input_tokens + output_tokens,
+        input=input_tokens,
+        output=output_tokens
+    )
+    tracker.track_tokens(tokens)
+
+    return response_text
+```
+
+## With Error Handling
+```python
+def call_streaming_safe(config, user_prompt: str):
+    """Streaming call with error tracking."""
+    if not config.enabled:
+        return None
+
+    tracker = config.tracker
+    start_time = time.time()
+    first_token_time = None
+
+    try:
+        stream = openai.chat.completions.create(
+            model=config.model.name,
+            messages=[{"role": "user", "content": user_prompt}],
+            stream=True
+        )
+
+        response_text = ""
+        for chunk in stream:
+            if first_token_time is None and chunk.choices[0].delta.content:
+                first_token_time = time.time()
+                ttft_ms = int((first_token_time - start_time) * 1000)
+                tracker.track_time_to_first_token(ttft_ms)
+
+            if chunk.choices[0].delta.content:
+                response_text += chunk.choices[0].delta.content
+
+        duration_ms = int((time.time() - start_time) * 1000)
+        tracker.track_duration(duration_ms)
+        tracker.track_success()
+
+        return response_text
+
+    except Exception as e:
+        tracker.track_error()
+        raise
+```
+
+## Notes
+
+- TTFT is tracked when the first content chunk arrives
+- Duration is tracked from stream start to completion
+- Token counts must be estimated or calculated with tiktoken
+- Works with any streaming provider (OpenAI, Anthropic, etc.)
+- Error tracking should wrap the entire stream consumption

--- a/skills/ai-configs/aiconfig-ai-metrics/references/streaming-tracking.md
+++ b/skills/ai-configs/aiconfig-ai-metrics/references/streaming-tracking.md
@@ -1,162 +1,188 @@
 # Streaming Metrics Tracking
 
-Manual metrics tracking for streaming AI responses, including time-to-first-token (TTFT).
+**This is Tier 4 — the manual fallback.** Streaming is the one case where no current helper captures everything you need. The Node SDK ships `trackStreamMetricsOf`, which can pull tokens from stream chunks, but it does **not** capture time-to-first-token (TTFT). Python doesn't have a streaming helper at all. So if you want TTFT in the Monitoring tab, you have to wire it manually — and since TTFT is the whole point of streaming observability, this is almost always what you want.
 
-## What Gets Tracked
+If the app doesn't need TTFT (you just want total duration + tokens + success), you can use Tier 2 / Tier 3 patterns in Node via `trackStreamMetricsOf`, and Tier 3 in Python by consuming the whole stream into a response object and then calling `trackMetricsOf` on the assembled result. TTFT is the tiebreaker that forces Tier 4.
 
-- Time to first token (TTFT)
-- Total duration
-- Token counts (estimated or from final chunk)
-- Success/failure status
+## What you track
 
-## Implementation
+- **Time to first token (TTFT)** — measured from "stream request sent" to "first content chunk received."
+- **Total duration** — measured from "stream request sent" to "stream fully consumed."
+- **Tokens** — read from the final stream event (if the provider includes usage) or from `tiktoken` / provider-native counters if not.
+- **Success / error** — explicit calls in the consumer loop.
+
+## Python — OpenAI streaming
+
 ```python
 import time
 import openai
 from ldai.tracker import TokenUsage
 
-def call_streaming_with_tracking(config, user_prompt: str):
-    """Streaming call with TTFT and duration tracking."""
-    if not config.enabled:
+def call_streaming_with_tracking(ai_config, user_prompt: str) -> str | None:
+    if not ai_config.enabled:
         return None
 
-    tracker = config.tracker
-    start_time = time.time()
-    first_token_time = None
-
-    stream = openai.chat.completions.create(
-        model=config.model.name,
-        messages=[{"role": "user", "content": user_prompt}],
-        stream=True
-    )
-
-    response_text = ""
-    for chunk in stream:
-        if first_token_time is None and chunk.choices[0].delta.content:
-            first_token_time = time.time()
-            ttft_ms = int((first_token_time - start_time) * 1000)
-            tracker.track_time_to_first_token(ttft_ms)
-
-        if chunk.choices[0].delta.content:
-            response_text += chunk.choices[0].delta.content
-
-    # Track final metrics (milliseconds)
-    duration_ms = int((time.time() - start_time) * 1000)
-    tracker.track_duration(duration_ms)
-    tracker.track_success()
-
-    # Estimate tokens (or use tiktoken for accuracy)
-    estimated_input = len(user_prompt.split()) * 2
-    estimated_output = len(response_text.split()) * 2
-    tokens = TokenUsage(
-        total=estimated_input + estimated_output,
-        input=estimated_input,
-        output=estimated_output
-    )
-    tracker.track_tokens(tokens)
-
-    return response_text
-```
-
-## With Accurate Token Counting (tiktoken)
-```python
-import time
-import openai
-import tiktoken
-from ldai.tracker import TokenUsage
-
-def call_streaming_accurate_tokens(config, user_prompt: str):
-    """Streaming with accurate token counting using tiktoken."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
-    start_time = time.time()
-    first_token_time = None
-
-    # Get encoder for the model
-    try:
-        enc = tiktoken.encoding_for_model(config.model.name)
-    except KeyError:
-        enc = tiktoken.get_encoding("cl100k_base")
-
-    stream = openai.chat.completions.create(
-        model=config.model.name,
-        messages=[{"role": "user", "content": user_prompt}],
-        stream=True
-    )
-
-    response_text = ""
-    for chunk in stream:
-        if first_token_time is None and chunk.choices[0].delta.content:
-            first_token_time = time.time()
-            ttft_ms = int((first_token_time - start_time) * 1000)
-            tracker.track_time_to_first_token(ttft_ms)
-
-        if chunk.choices[0].delta.content:
-            response_text += chunk.choices[0].delta.content
-
-    # Track final metrics
-    duration_ms = int((time.time() - start_time) * 1000)
-    tracker.track_duration(duration_ms)
-    tracker.track_success()
-
-    # Accurate token counts
-    input_tokens = len(enc.encode(user_prompt))
-    output_tokens = len(enc.encode(response_text))
-    tokens = TokenUsage(
-        total=input_tokens + output_tokens,
-        input=input_tokens,
-        output=output_tokens
-    )
-    tracker.track_tokens(tokens)
-
-    return response_text
-```
-
-## With Error Handling
-```python
-def call_streaming_safe(config, user_prompt: str):
-    """Streaming call with error tracking."""
-    if not config.enabled:
-        return None
-
-    tracker = config.tracker
+    tracker = ai_config.tracker
     start_time = time.time()
     first_token_time = None
 
     try:
         stream = openai.chat.completions.create(
-            model=config.model.name,
-            messages=[{"role": "user", "content": user_prompt}],
-            stream=True
+            model=ai_config.model.name,
+            messages=[
+                {"role": "system", "content": ai_config.messages[0].content},
+                {"role": "user", "content": user_prompt},
+            ],
+            stream=True,
+            stream_options={"include_usage": True},  # Required to get usage in final chunk
         )
 
         response_text = ""
+        final_usage = None
         for chunk in stream:
-            if first_token_time is None and chunk.choices[0].delta.content:
-                first_token_time = time.time()
-                ttft_ms = int((first_token_time - start_time) * 1000)
-                tracker.track_time_to_first_token(ttft_ms)
-
-            if chunk.choices[0].delta.content:
+            if chunk.choices and chunk.choices[0].delta.content:
+                if first_token_time is None:
+                    first_token_time = time.time()
+                    tracker.track_time_to_first_token(
+                        int((first_token_time - start_time) * 1000)
+                    )
                 response_text += chunk.choices[0].delta.content
+            if getattr(chunk, "usage", None):
+                final_usage = chunk.usage
 
-        duration_ms = int((time.time() - start_time) * 1000)
-        tracker.track_duration(duration_ms)
+        tracker.track_duration(int((time.time() - start_time) * 1000))
         tracker.track_success()
+
+        if final_usage:
+            tracker.track_tokens(TokenUsage(
+                total=final_usage.total_tokens,
+                input=final_usage.prompt_tokens,
+                output=final_usage.completion_tokens,
+            ))
 
         return response_text
 
-    except Exception as e:
+    except Exception:
         tracker.track_error()
         raise
 ```
 
-## Notes
+The `stream_options={"include_usage": True}` flag is required — without it, OpenAI streaming does not include usage data and you fall back to `tiktoken` estimation.
 
-- TTFT is tracked when the first content chunk arrives
-- Duration is tracked from stream start to completion
-- Token counts must be estimated or calculated with tiktoken
-- Works with any streaming provider (OpenAI, Anthropic, etc.)
-- Error tracking should wrap the entire stream consumption
+## Python — tiktoken fallback
+
+If you can't set `include_usage` (older SDK, Azure OpenAI on an endpoint that doesn't support it), count tokens locally with `tiktoken`:
+
+```python
+import tiktoken
+from ldai.tracker import TokenUsage
+
+def estimate_tokens(model_name: str, prompt: str, response: str) -> TokenUsage:
+    try:
+        enc = tiktoken.encoding_for_model(model_name)
+    except KeyError:
+        enc = tiktoken.get_encoding("cl100k_base")
+    input_tokens = len(enc.encode(prompt))
+    output_tokens = len(enc.encode(response))
+    return TokenUsage(
+        total=input_tokens + output_tokens,
+        input=input_tokens,
+        output=output_tokens,
+    )
+```
+
+Drop it into the streaming consumer where `final_usage` would have been.
+
+## Node — OpenAI streaming with manual TTFT
+
+```typescript
+import { OpenAI } from 'openai';
+
+const client = new OpenAI();
+
+async function callStreamingWithTracking(
+  aiConfig: LDAICompletionConfig,
+  userPrompt: string,
+): Promise<string | null> {
+  if (!aiConfig.enabled) return null;
+
+  const { tracker } = aiConfig;
+  const startTime = Date.now();
+  let firstTokenTime: number | null = null;
+
+  try {
+    const stream = await client.chat.completions.create({
+      model: aiConfig.model!.name,
+      messages: [
+        ...aiConfig.messages,
+        { role: 'user', content: userPrompt },
+      ],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+
+    let responseText = '';
+    let finalUsage: OpenAI.CompletionUsage | undefined;
+
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta?.content;
+      if (delta) {
+        if (firstTokenTime === null) {
+          firstTokenTime = Date.now();
+          tracker.trackTimeToFirstToken(firstTokenTime - startTime);
+        }
+        responseText += delta;
+      }
+      if (chunk.usage) {
+        finalUsage = chunk.usage;
+      }
+    }
+
+    tracker.trackDuration(Date.now() - startTime);
+    tracker.trackSuccess();
+
+    if (finalUsage) {
+      tracker.trackTokens({
+        total: finalUsage.total_tokens,
+        input: finalUsage.prompt_tokens,
+        output: finalUsage.completion_tokens,
+      });
+    }
+
+    return responseText;
+  } catch (err) {
+    tracker.trackError();
+    throw err;
+  }
+}
+```
+
+## Node — `trackStreamMetricsOf` (no TTFT)
+
+If the app doesn't need TTFT, the Node SDK has a built-in streaming wrapper that handles tokens + success/error + duration:
+
+```typescript
+const response = await aiConfig.tracker.trackStreamMetricsOf(
+  (chunks) => {
+    // Extract usage from the final chunk
+    const final = chunks[chunks.length - 1];
+    return {
+      success: true,
+      usage: {
+        total: final.usage?.total_tokens ?? 0,
+        input: final.usage?.prompt_tokens ?? 0,
+        output: final.usage?.completion_tokens ?? 0,
+      },
+    };
+  },
+  () => client.chat.completions.create({ /* ... */, stream: true, stream_options: { include_usage: true } }),
+);
+```
+
+This is cleaner when TTFT doesn't matter (batch processing, log summarization, tasks where latency-to-first-byte isn't user-facing). If the user is going to look at the Monitoring tab's TTFT chart, though, you need the manual pattern above.
+
+## What to avoid
+
+- **Do not wrap `openai.chat.completions.create(stream=True)` with `trackMetricsOf`.** It'll record duration as the time to get the stream *object*, not the time to consume it — and tokens won't be captured at all because the extractor sees a stream object, not a response with `usage`.
+- **Do not forget `track_success()` / `trackSuccess()`.** Unlike `trackMetricsOf`, the manual pattern doesn't call it for you. If you skip it, the Monitoring tab won't count the generation.
+- **Do not set `first_token_time` on the first *chunk*.** Set it on the first chunk with non-empty `delta.content`. Many providers emit a role/metadata chunk before the first content chunk.

--- a/skills/ai-configs/aiconfig-create/SKILL.md
+++ b/skills/ai-configs/aiconfig-create/SKILL.md
@@ -70,7 +70,7 @@ Use `setup-ai-config` to create the config and its first variation in one call. 
 **Variation fields:**
 - `variationKey`, `variationName` -- identifiers for the first variation
 - `modelConfigKey` -- must be `Provider.model-id` format (e.g., `OpenAI.gpt-4o`, `Anthropic.claude-sonnet-4-5`)
-- `modelName` -- the model identifier (e.g., `gpt-4o`)
+- `modelName` -- the model identifier (e.g., `gpt-4o`). **Always pass this in the initial call** — leaving it off produces a variation that displays "NO MODEL" and forces a second PATCH to set it. The field is `modelName`; it is **not** `name` or `model.name` on this endpoint.
 
 **For agent mode**, provide:
 - `instructions` -- a string with the agent's system instructions
@@ -125,11 +125,19 @@ If you used `setup-ai-config`, verification is automatic: the response includes 
 3. Instructions or messages are present
 4. Parameters are set
 
+**Use `get-ai-config` for the verification call — do not drop to raw `curl` + `jq`.** The MCP tool returns a typed object you can inspect directly. Hand-rolled `jq` filters against the REST response routinely break: the AI Configs detail endpoint returns the variation list under different keys depending on `expand`, and a filter like `.variations.items[]` will fail with `Cannot index array with string "items"` when the response shape is a bare array. If you must call the REST API, use `jq -e .` first to inspect the actual shape before drilling in.
+
 **Report results:**
 - Config created with correct structure
 - Variation has model assigned
 - Flag any missing model or parameters
 - Provide config URL: `https://app.launchdarkly.com/projects/{projectKey}/ai-configs/{configKey}`
+
+### Step 5: Make the variation servable
+
+`setup-ai-config` and `create-ai-config-variation` create the variation but **do not promote it to fallthrough**. The new config will return `enabled=False` to every consumer until targeting is updated. This is the single most common "I created a config but my SDK still gets the fallback" failure.
+
+**Always end this skill by telling the user to run `aiconfig-targeting`** to set the new variation as the fallthrough (or as a targeted rule) in the environment they intend to ship to. Do not consider the workflow complete until that step is acknowledged.
 
 ## modelConfigKey Format
 
@@ -156,6 +164,9 @@ The `create-ai-config-variation` tool validates this format and rejects invalid 
 - Don't skip the two-step process (config then variation)
 - Don't try to attach tools during initial creation -- update the variation afterward
 - Don't forget modelConfigKey (models won't show in the UI)
+- Don't omit `modelName` from the initial variation call. It is required at create time; setting it via a follow-up PATCH is a workaround for a bug, not the intended flow. The PATCH field is also `modelName`, not `name`.
+- Don't drop to raw `curl` + `jq` for verification. Use `get-ai-config` (MCP) — it returns a typed object and avoids brittle `jq` filters that break on response-shape variation.
+- Don't consider the workflow complete until the user has been told to run `aiconfig-targeting`. A created variation that isn't promoted to fallthrough returns `enabled=False` to every consumer.
 
 ## Related Skills
 

--- a/skills/ai-configs/aiconfig-custom-metrics/SKILL.md
+++ b/skills/ai-configs/aiconfig-custom-metrics/SKILL.md
@@ -1,0 +1,503 @@
+---
+name: aiconfig-custom-metrics
+description: "Create, track, retrieve, update, and delete custom business metrics for AI Configs. Covers full lifecycle: define metric kinds via API, emit events via SDK, and query results."
+license: Apache-2.0
+compatibility: Requires the LaunchDarkly server SDK and a LaunchDarkly API token with the `writer` role for metric management.
+metadata:
+  author: launchdarkly
+  version: "1.0.0-experimental"
+---
+
+# Custom Metrics for AI Configs
+
+Full lifecycle management of custom business metrics: create metric definitions via API, track events via SDK, retrieve metric data, and manage metrics programmatically.
+
+## Prerequisites
+
+- LaunchDarkly SDK initialized (see `aiconfig-sdk`)
+- LaunchDarkly API token with `writer` role for metric management
+- Understanding of built-in AI metrics (see `aiconfig-ai-metrics`)
+
+## API Key Detection
+
+Before prompting the user for an API key, try to detect it automatically:
+
+1. **Check Claude MCP config** - Read `~/.claude/config.json` and look for `mcpServers.launchdarkly.env.LAUNCHDARKLY_API_KEY`
+2. **Check environment variables** - Look for `LAUNCHDARKLY_API_KEY`, `LAUNCHDARKLY_API_TOKEN`, or `LD_API_KEY`
+3. **Prompt user** - Only if detection fails, ask the user for their API key
+
+```python
+import os
+import json
+from pathlib import Path
+
+def get_launchdarkly_api_key():
+    """Auto-detect LaunchDarkly API key from Claude config or environment."""
+    # 1. Check Claude MCP config
+    claude_config = Path.home() / ".claude" / "config.json"
+    if claude_config.exists():
+        try:
+            config = json.load(open(claude_config))
+            api_key = config.get("mcpServers", {}).get("launchdarkly", {}).get("env", {}).get("LAUNCHDARKLY_API_KEY")
+            if api_key:
+                return api_key
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    # 2. Check environment variables
+    for var in ["LAUNCHDARKLY_API_KEY", "LAUNCHDARKLY_API_TOKEN", "LD_API_KEY"]:
+        if os.environ.get(var):
+            return os.environ[var]
+
+    return None
+```
+
+## Metrics Lifecycle Overview
+
+| Step | Method | Purpose |
+|------|--------|---------|
+| 1. Create | API | Define metric in LaunchDarkly |
+| 2. Track | SDK | Send events to the metric |
+| 3. Get | API | Retrieve metric definition/data |
+| 4. Update | API | Modify metric properties |
+| 5. Delete | API | Remove metric |
+
+## 1. Create Metric (API)
+
+**Required fields for numeric custom metrics:**
+- `successCriteria` - Must be one of: `"HigherThanBaseline"`, `"LowerThanBaseline"`
+- `unit` - e.g., `"count"`, `"percent"`, `"milliseconds"`
+
+The API will return `400 Bad Request` if these are missing for numeric metrics.
+
+```python
+import requests
+import os
+
+def create_metric(
+    project_key: str,
+    metric_key: str,
+    name: str,
+    kind: str = "custom",
+    is_numeric: bool = True,
+    unit: str = "count",
+    success_criteria: str = "HigherThanBaseline",
+    event_key: str = None,
+    description: str = None
+):
+    """Create a new metric definition in LaunchDarkly."""
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    url = f"https://app.launchdarkly.com/api/v2/metrics/{project_key}"
+
+    payload = {
+        "key": metric_key,
+        "name": name,
+        "kind": kind,
+        "isNumeric": is_numeric,
+        "eventKey": event_key or metric_key
+    }
+
+    # Unit and successCriteria are required for numeric custom metrics
+    if is_numeric and kind == "custom":
+        payload["unit"] = unit
+        payload["successCriteria"] = success_criteria
+
+    if description:
+        payload["description"] = description
+
+    headers = {
+        "Authorization": API_TOKEN,
+        "Content-Type": "application/json"
+    }
+
+    response = requests.post(url, json=payload, headers=headers)
+
+    if response.status_code == 201:
+        print(f"[OK] Created metric: {metric_key}")
+        return response.json()
+    elif response.status_code == 409:
+        print(f"[INFO] Metric already exists: {metric_key}")
+        return None
+    else:
+        print(f"[ERROR] Failed to create metric: {response.status_code}")
+        print(f"        {response.text}")
+        return None
+```
+
+**Metric Kinds:**
+- `custom` - Track any event (most common for AI metrics)
+- `pageview` - Track page views
+- `click` - Track click events
+
+**Success Criteria** (for numeric metrics):
+- `HigherThanBaseline` - Higher values are better (e.g., revenue, satisfaction)
+- `LowerThanBaseline` - Lower values are better (e.g., errors, latency)
+
+**Common Units:**
+- `count` - Generic count
+- `milliseconds` - Time duration
+- `percent` - Percentage values
+- `dollars` - Currency
+
+## 2. Track Events (SDK)
+
+Once the metric is created, track events using the SDK:
+
+```python
+from ldclient import Context
+from ldclient.config import Config
+import ldclient
+
+# Initialize (see aiconfig-sdk for details)
+ldclient.set_config(Config("your-sdk-key"))
+ld_client = ldclient.get()
+
+def track_metric(ld_client, user_id: str, metric_key: str, value: float, data: dict = None):
+    """Track an event to a metric."""
+    context = Context.builder(user_id).build()
+
+    ld_client.track(
+        metric_key,
+        context,
+        data=data,
+        metric_value=value
+    )
+```
+
+### Common Tracking Patterns
+
+```python
+def track_conversion(ld_client, user_id: str, amount: float, config_key: str):
+    """Track a conversion event with revenue."""
+    context = Context.builder(user_id).build()
+
+    ld_client.track(
+        "business.conversion",
+        context,
+        data={"configKey": config_key, "category": "electronics"},
+        metric_value=amount
+    )
+
+def track_task_success(ld_client, user_id: str, task_type: str, success: bool):
+    """Track task completion success/failure."""
+    context = Context.builder(user_id).build()
+
+    ld_client.track(
+        "task.success_rate",
+        context,
+        data={"taskType": task_type},
+        metric_value=1.0 if success else 0.0
+    )
+
+def track_satisfaction(ld_client, user_id: str, score: float, feedback_type: str):
+    """Track user satisfaction (0-100 scale)."""
+    context = Context.builder(user_id).build()
+
+    ld_client.track(
+        "user.satisfaction",
+        context,
+        data={"feedbackType": feedback_type},
+        metric_value=score
+    )
+
+    # Track negative feedback separately for alerts
+    if score < 50:
+        ld_client.track(
+            "user.negative_feedback",
+            context,
+            metric_value=1.0
+        )
+
+def track_revenue(ld_client, user_id: str, revenue: float, source: str):
+    """Track revenue generated after AI interaction."""
+    context = Context.builder(user_id).set("tier", "premium").build()
+
+    if revenue > 0:
+        ld_client.track(
+            "revenue.impact",
+            context,
+            data={"source": source},
+            metric_value=revenue
+        )
+```
+
+## 3. Get Metrics (API)
+
+### Get Single Metric
+
+```python
+def get_metric(project_key: str, metric_key: str):
+    """Get a single metric definition."""
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    url = f"https://app.launchdarkly.com/api/v2/metrics/{project_key}/{metric_key}"
+
+    headers = {"Authorization": API_TOKEN}
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        metric = response.json()
+        print(f"[OK] Metric: {metric['key']}")
+        print(f"     Name: {metric.get('name', 'N/A')}")
+        print(f"     Kind: {metric.get('kind', 'N/A')}")
+        print(f"     Numeric: {metric.get('isNumeric', False)}")
+        print(f"     Event Key: {metric.get('eventKey', 'N/A')}")
+        return metric
+    elif response.status_code == 404:
+        print(f"[INFO] Metric not found: {metric_key}")
+        return None
+    else:
+        print(f"[ERROR] Failed to get metric: {response.status_code}")
+        return None
+```
+
+### List All Metrics
+
+```python
+def list_metrics(project_key: str, limit: int = 20):
+    """List all metrics in a project."""
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    url = f"https://app.launchdarkly.com/api/v2/metrics/{project_key}"
+
+    headers = {"Authorization": API_TOKEN}
+    params = {"limit": limit}
+
+    response = requests.get(url, headers=headers, params=params)
+
+    if response.status_code == 200:
+        data = response.json()
+        metrics = data.get("items", [])
+        print(f"[OK] Found {len(metrics)} metrics:")
+        for metric in metrics:
+            numeric = "numeric" if metric.get("isNumeric") else "non-numeric"
+            print(f"     - {metric['key']} ({metric.get('kind', 'custom')}, {numeric})")
+        return metrics
+    else:
+        print(f"[ERROR] Failed to list metrics: {response.status_code}")
+        return None
+```
+
+## 4. Update Metric (API)
+
+```python
+def update_metric(project_key: str, metric_key: str, updates: list):
+    """
+    Update a metric using JSON Patch operations.
+
+    Args:
+        updates: List of patch operations, e.g.:
+            [{"op": "replace", "path": "/name", "value": "New Name"}]
+    """
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    url = f"https://app.launchdarkly.com/api/v2/metrics/{project_key}/{metric_key}"
+
+    headers = {
+        "Authorization": API_TOKEN,
+        "Content-Type": "application/json"
+    }
+
+    response = requests.patch(url, json=updates, headers=headers)
+
+    if response.status_code == 200:
+        print(f"[OK] Updated metric: {metric_key}")
+        return response.json()
+    elif response.status_code == 404:
+        print(f"[ERROR] Metric not found: {metric_key}")
+        return None
+    else:
+        print(f"[ERROR] Failed to update metric: {response.status_code}")
+        print(f"        {response.text}")
+        return None
+
+# Example: Update metric name and description
+def rename_metric(project_key: str, metric_key: str, new_name: str, new_description: str = None):
+    """Rename a metric and optionally update description."""
+    updates = [
+        {"op": "replace", "path": "/name", "value": new_name}
+    ]
+    if new_description:
+        updates.append({"op": "replace", "path": "/description", "value": new_description})
+
+    return update_metric(project_key, metric_key, updates)
+```
+
+## 5. Delete Metric (API)
+
+```python
+def delete_metric(project_key: str, metric_key: str):
+    """Delete a metric from the project."""
+    API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+
+    url = f"https://app.launchdarkly.com/api/v2/metrics/{project_key}/{metric_key}"
+
+    headers = {"Authorization": API_TOKEN}
+
+    response = requests.delete(url, headers=headers)
+
+    if response.status_code == 204:
+        print(f"[OK] Deleted metric: {metric_key}")
+        return True
+    elif response.status_code == 404:
+        print(f"[INFO] Metric not found: {metric_key}")
+        return False
+    else:
+        print(f"[ERROR] Failed to delete metric: {response.status_code}")
+        return False
+```
+
+## Complete Workflow Example
+
+```python
+import os
+import requests
+from ldclient import Context
+from ldclient.config import Config
+import ldclient
+
+# Setup
+API_TOKEN = os.environ.get("LAUNCHDARKLY_API_TOKEN")
+SDK_KEY = os.environ.get("LAUNCHDARKLY_SDK_KEY")
+PROJECT_KEY = "support-ai"
+
+ldclient.set_config(Config(SDK_KEY))
+ld_client = ldclient.get()
+
+# 1. Create metric
+create_metric(
+    PROJECT_KEY,
+    "ai.task.completion",
+    name="AI Task Completion Rate",
+    kind="custom",
+    is_numeric=True,
+    description="Tracks successful AI task completions"
+)
+
+# 2. Track events
+context = Context.builder("user-123").build()
+ld_client.track("ai.task.completion", context, metric_value=1.0)
+ld_client.track("ai.task.completion", context, metric_value=1.0)
+ld_client.track("ai.task.completion", context, metric_value=0.0)  # failure
+ld_client.flush()
+
+# 3. Get metric definition
+metric = get_metric(PROJECT_KEY, "ai.task.completion")
+
+# 4. Update metric name
+rename_metric(PROJECT_KEY, "ai.task.completion", "AI Task Success Rate")
+
+# 5. List all metrics
+list_metrics(PROJECT_KEY)
+
+# 6. Delete metric (when no longer needed)
+# delete_metric(PROJECT_KEY, "ai.task.completion")
+```
+
+## Session Metrics Tracker
+
+```python
+import time
+from ldclient import Context
+
+class SessionMetricsTracker:
+    """Track metrics across an entire user session."""
+
+    def __init__(self, ld_client):
+        self.ld_client = ld_client
+        self.session_data = {}
+
+    def start_session(self, user_id: str, session_id: str):
+        """Initialize session tracking."""
+        self.session_data[session_id] = {
+            "user_id": user_id,
+            "start_time": time.time(),
+            "interactions": 0,
+            "successful_tasks": 0
+        }
+
+    def track_interaction(self, session_id: str, success: bool):
+        """Track individual interaction within session."""
+        if session_id not in self.session_data:
+            return
+        session = self.session_data[session_id]
+        session["interactions"] += 1
+        if success:
+            session["successful_tasks"] += 1
+
+    def end_session(self, session_id: str):
+        """Finalize and track session metrics."""
+        if session_id not in self.session_data:
+            return None
+
+        session = self.session_data[session_id]
+        duration = time.time() - session["start_time"]
+
+        context = Context.builder(session["user_id"]).build()
+
+        # Track session duration
+        self.ld_client.track(
+            "session.duration",
+            context,
+            data={"interactions": session["interactions"]},
+            metric_value=duration
+        )
+
+        # Track session success rate
+        if session["interactions"] > 0:
+            success_rate = session["successful_tasks"] / session["interactions"]
+            self.ld_client.track(
+                "session.success_rate",
+                context,
+                metric_value=success_rate * 100
+            )
+
+        result = dict(session)
+        result["duration"] = duration
+        del self.session_data[session_id]
+        return result
+```
+
+## Naming Conventions
+
+```python
+# Use dot notation for hierarchy
+"quality.accuracy"
+"quality.relevance"
+"user.satisfaction"
+"user.engagement"
+"revenue.conversion"
+"task.success_rate"
+"session.duration"
+"ai.task.completion"
+"ai.recommendation.conversion"
+```
+
+## Best Practices
+
+1. **Create Before Track** - Metric must exist before tracking events
+2. **Use Numeric Metrics** - Set `isNumeric=True` for aggregation
+3. **Consistent Keys** - Use same key in `create_metric()` and `ld_client.track()`
+4. **Flush in Serverless** - Call `ld_client.flush()` before Lambda terminates
+5. **Rate Limit** - Don't track on every keystroke
+
+## Viewing Metrics
+
+Custom metrics appear in:
+- **Metrics** page in LaunchDarkly UI
+- **Monitoring tab** of your AI Config
+- Via API using `get_metric()` or `list_metrics()`
+
+## Related Skills
+
+- `aiconfig-sdk` - SDK setup
+- `aiconfig-ai-metrics` - Built-in AI metrics (tokens, duration, cost)
+- `aiconfig-online-evals` - Quality metrics via judges
+
+## References
+
+- [Metrics API Documentation](https://apidocs.launchdarkly.com/tag/Metrics)
+- [Custom Events Documentation](https://docs.launchdarkly.com/sdk/features/events)
+- [Python SDK track() Reference](https://launchdarkly-python-sdk.readthedocs.io/)

--- a/skills/ai-configs/aiconfig-migrate/README.md
+++ b/skills/ai-configs/aiconfig-migrate/README.md
@@ -1,0 +1,67 @@
+# LaunchDarkly AI Config Migrate Skill
+
+An Agent Skill for migrating an application with hardcoded LLM prompts to a full LaunchDarkly AI Configs implementation in five stages: extract, wrap, tools, tracking, evals.
+
+## Overview
+
+This skill orchestrates the full migration journey from hardcoded `openai.chat.completions.create(model="gpt-4o", ...)` (or equivalent in any provider SDK) to a managed AI Config with tools, tracking, and judges. It delegates each stage to a focused skill and covers the tracker wiring inline — since no existing skill owns `tracker.track_*` calls.
+
+The five stages:
+
+1. **Extract** hardcoded model names, prompts, and parameters (read-only)
+2. **Wrap** the call site in `completion_config` / `completionConfig` with a safe fallback — delegates the config creation to `aiconfig-create`
+3. **Tools** — move function-calling schemas into LaunchDarkly — delegates to `aiconfig-tools`
+4. **Tracking** — wire `track_duration`, `track_tokens`, `track_success`/`track_error`, optional `track_feedback` — inline, with a reference doc covering every SDK method in Python and Node side by side
+5. **Evals** — attach judges for LLM-as-a-judge scoring — delegates to `aiconfig-online-evals`
+
+## Installation (Local)
+
+Copy `skills/ai-configs/aiconfig-migrate/` into your agent client's skills path.
+
+## Prerequisites
+
+- Remotely hosted LaunchDarkly MCP server
+- `LD_SDK_KEY` environment variable (server-side SDK key, starts with `sdk-`)
+- An application with hardcoded LLM calls (OpenAI, Anthropic, Bedrock, Gemini, LangChain, LangGraph, or CrewAI)
+
+## Usage
+
+```
+Migrate our chat service from hardcoded OpenAI prompts to LaunchDarkly AI Configs
+```
+
+```
+Our LangGraph agent has its model and instructions baked in — walk me through wrapping it in an AI Config
+```
+
+```
+Wire up the AI tracker and attach accuracy + relevance judges to our existing config
+```
+
+## Structure
+
+```
+aiconfig-migrate/
+├── SKILL.md
+├── README.md
+└── references/
+    ├── phase-1-analysis-checklist.md
+    ├── before-after-examples.md
+    ├── sdk-ai-tracker-patterns.md
+    ├── agent-mode-frameworks.md
+    ├── fallback-defaults-pattern.md
+    └── agent-graph-reference.md
+```
+
+## Related
+
+- [AI Config Create](../aiconfig-create/): Delegated to by Stage 2 (wrap)
+- [AI Config Tools](../aiconfig-tools/): Delegated to by Stage 3 (tools)
+- [AI Config Online Evals](../aiconfig-online-evals/): Delegated to by Stage 5 (evals)
+- [AI Config Variations](../aiconfig-variations/): Next step after migration for A/B testing
+- [AI Config Targeting](../aiconfig-targeting/): Next step after migration for rollout control
+- [LaunchDarkly AI Configs Docs](https://docs.launchdarkly.com/home/ai-configs)
+
+## License
+
+Apache-2.0

--- a/skills/ai-configs/aiconfig-migrate/SKILL.md
+++ b/skills/ai-configs/aiconfig-migrate/SKILL.md
@@ -228,91 +228,64 @@ Delegate: **`aiconfig-ai-metrics`** wires the per-request `tracker.track_*` call
 
 Hand off: print the AI Config key, variation key, provider, and whether the call is streaming, then tell the user: *"Run `/aiconfig-ai-metrics` with these inputs, then come back here."* Do not auto-invoke. Return here for sub-step 5 (verify) once they're done.
 
-1. **Locate the tracker.** It's attached to the config object returned in Stage 2: `config.tracker` (Python) or `aiConfig.tracker` (Node).
+1. **Locate the tracker.** It's attached to the config object returned in Stage 2: `config.tracker` (Python) or `aiConfig.tracker` (Node). Tier 1 (managed runner) tracks automatically and does not need an explicit tracker call at all — if the app is a chat loop, use `ai_client.create_model(...)` / `aiClient.initChat(...)` and skip to sub-step 4.
 
-2. **Wrap the provider call** with duration, success, error, and token tracking.
+2. **Pick a tier from the four-tier ladder.** The delegate skill's [SKILL.md](../aiconfig-ai-metrics/SKILL.md) has the full walk-through; the condensed version for migration-context decisions:
 
-   **Python — manual tracking:**
+   | Tier | When to use | Pattern |
+   |---|---|---|
+   | **1 — Managed runner** | The call site is a chat loop (turn-based, maintains history). | `ManagedModel` / `TrackedChat` — automatic tracking, no tracker calls. |
+   | **2 — Provider package + `trackMetricsOf`** | Non-chat shape where a provider package exists: OpenAI, LangChain/LangGraph, Vercel AI SDK. | `tracker.trackMetricsOf(Provider.getAIMetricsFromResponse, fn)` |
+   | **3 — Custom extractor + `trackMetricsOf`** | Anthropic direct, Gemini, Bedrock, Cohere, custom HTTP. | `tracker.trackMetricsOf(myExtractor, fn)` — one small function mapping response → `LDAIMetrics`. |
+   | **4 — Raw manual** | Streaming with TTFT, partial tracking, unusual shapes. | Explicit `trackDuration` + `trackTokens` + `trackSuccess` / `trackError`. |
+
+   **Do not introduce `track_openai_metrics` / `track_bedrock_converse_metrics` / `trackVercelAISDKGenerateTextMetrics` in new code.** They still exist in the SDK but have been replaced by `trackMetricsOf` composed with a provider-package extractor. Current Python and Node SDK READMEs document the new pattern exclusively.
+
+3. **Wire the chosen tier.** The delegate skill has full Python + Node examples for each tier plus per-provider files. A condensed Tier 2/3 example for reference — OpenAI via the provider package:
+
+   **Python:**
    ```python
-   import time
-   from ldai.tracker import TokenUsage
+   from ldai_openai import OpenAIProvider
+   import openai
 
-   start = time.time()
+   client = openai.OpenAI()
+
+   def call_openai():
+       return client.chat.completions.create(
+           model=config.model.name,
+           messages=[{"role": "system", "content": config.messages[0].content},
+                     {"role": "user", "content": user_prompt}],
+       )
+
    try:
-       response = openai_client.chat.completions.create(...)
-       config.tracker.track_duration(int((time.time() - start) * 1000))
-       config.tracker.track_success()
-       config.tracker.track_tokens(TokenUsage(
-           input=response.usage.prompt_tokens,
-           output=response.usage.completion_tokens,
-           total=response.usage.total_tokens,
-       ))
+       response = config.tracker.track_metrics_of(
+           call_openai,
+           OpenAIProvider.get_ai_metrics_from_response,
+       )
    except Exception:
        config.tracker.track_error()
        raise
    ```
 
-   **Node — manual tracking:**
+   **Node:**
    ```typescript
-   const start = Date.now();
+   import { OpenAIProvider } from '@launchdarkly/server-sdk-ai-openai';
+
    try {
-     const response = await openai.chat.completions.create(/* ... */);
-     aiConfig.tracker.trackDuration(Date.now() - start);
-     aiConfig.tracker.trackSuccess();
-     aiConfig.tracker.trackTokens({
-       input: response.usage?.prompt_tokens ?? 0,
-       output: response.usage?.completion_tokens ?? 0,
-       total: response.usage?.total_tokens ?? 0,
-     });
-   } catch (error) {
+     const response = await aiConfig.tracker.trackMetricsOf(
+       OpenAIProvider.getAIMetricsFromResponse,
+       () => openaiClient.chat.completions.create({
+         model: aiConfig.model!.name,
+         messages: [...aiConfig.messages, { role: 'user', content: userPrompt }],
+       }),
+     );
+   } catch (err) {
      aiConfig.tracker.trackError();
-     throw error;
+     throw err;
    }
    ```
 
-3. **Prefer auto-tracking helpers where available.** They capture duration, tokens, and success/error in one call and avoid drift between manual blocks.
-
-   | Provider | Python method | Node method |
-   |----------|--------------|-------------|
-   | OpenAI (any chat completion) | `tracker.track_openai_metrics(lambda: ...)` | `tracker.trackOpenAIMetrics(() => ...)` |
-   | Bedrock (Converse API) | `tracker.track_bedrock_converse_metrics(response)` | `tracker.trackBedrockConverseMetrics(response)` |
-   | Vercel AI SDK (`generateText`) | — | `tracker.trackVercelAISDKGenerateTextMetrics(() => ...)` |
-   | LangChain (single-node model call) | **Manual** — wrap `ainvoke` in try/except and call `tracker.track_duration` + `track_success` + `track_tokens` using `response.usage_metadata` (see snippet below) | **Manual** (same pattern; LangChain.js usage metadata is standardized) |
-   | LangGraph multi-node (EXPERIMENTAL) | `ldai_langchain.LDMetricsCallbackHandler` — requires `node_keys: Set[str]` and `fn_name_to_config_key: Dict[str, str]` constructor args. Marked not production-ready. Not suitable for single-node react-agent shapes. | — |
-   | Custom / any other | `tracker.track_metrics_of(func, extractor)` | `tracker.trackMetricsOf(extractor, () => ...)` |
-
-   **Do not hallucinate a `LaunchDarklyCallbackHandler` or `ldai.langchain` module.** Neither exists. The real Python package is `ldai_langchain` (underscore, top-level), it exposes `LangChainModelRunner`, `LangChainAgentRunner`, `LangChainRunnerFactory`, `LangGraphAgentGraphRunner`, and helper functions — none of which is a single-node plug-and-play callback. For the common single-node LangChain case, manual tracking via `response.usage_metadata` is the recommended path.
-
-   **LangChain single-node manual tracking pattern** (Python):
-
-   ```python
-   import time
-   from ldai.tracker import TokenUsage
-
-   start = time.time()
-   try:
-       response = await model.ainvoke([
-           {"role": "system", "content": config.instructions},
-           *state.messages,
-       ])
-       config.tracker.track_duration(int((time.time() - start) * 1000))
-       config.tracker.track_success()
-       # LangChain standardizes token usage across providers on AIMessage.usage_metadata
-       if hasattr(response, "usage_metadata") and response.usage_metadata:
-           um = response.usage_metadata
-           config.tracker.track_tokens(TokenUsage(
-               input=um.get("input_tokens", 0),
-               output=um.get("output_tokens", 0),
-               total=um.get("total_tokens", 0),
-           ))
-   except Exception:
-       config.tracker.track_error()
-       raise
-   ```
-
-   `AIMessage.usage_metadata` is LangChain's standardized token usage field — it works across providers (OpenAI, Anthropic, Bedrock, Gemini) because LangChain normalizes the provider-specific shapes behind the scenes.
-
-   There is no built-in Anthropic direct-API helper in either SDK. For Anthropic direct calls (not via LangChain), use the manual pattern from the "Node — manual tracking" block above, or switch the call through Bedrock Converse.
+   For Anthropic direct, Bedrock (no provider package), Gemini, and custom HTTP, write a small extractor returning `LDAIMetrics` — see the delegate skill's [anthropic-tracking.md](../aiconfig-ai-metrics/references/anthropic-tracking.md) and [bedrock-tracking.md](../aiconfig-ai-metrics/references/bedrock-tracking.md). LangChain single-node and LangGraph go through the `launchdarkly-server-sdk-ai-langchain` / `@launchdarkly/server-sdk-ai-langchain` provider package with `LangChainProvider.get_ai_metrics_from_response`.
 
 4. **Wire feedback tracking if the app has thumbs-up/down UI.** Both SDKs expose `trackFeedback` with a `{kind}` argument.
 
@@ -420,9 +393,9 @@ Delegate: **`aiconfig-online-evals`** (sub-step 3, optional — only for UI-atta
 - Don't claim you "delegated to `aiconfig-create`" or any other sibling skill. This skill does not auto-invoke. At each handoff, print the inputs and tell the user to run the sibling slash-command, then wait. Anything else misleads the user about what just happened.
 - Don't skip the `/aiconfig-targeting` step between Stage 2 and Stage 4. A freshly created variation returns `enabled=False` until targeting promotes it to fallthrough — Stage 2 verification will silently take the fallback path on every request.
 - Don't attempt a multi-agent graph migration in one pass. Migrate a single agent first; use [agent-graph-reference.md](references/agent-graph-reference.md) as the next-step read.
-- Don't use `track_request()` in Python — it does not exist in `launchdarkly-server-sdk-ai`. Use `track_duration()` + `track_success()`/`track_error()` explicitly, or prefer `track_openai_metrics` / `track_metrics_of` auto-helpers.
+- Don't use `track_request()` in Python — it does not exist in `launchdarkly-server-sdk-ai`. Use `track_metrics_of` with a provider-package or custom extractor, or drop to explicit `track_duration` + `track_tokens` + `track_success` / `track_error` if you're on the streaming path.
 - Don't tuple-unpack the return of `completion_config` / `agent_config` / `completionConfig` / `agentConfig`. They return a **single** config object (e.g. `AIAgentConfig`, `AICompletionConfig`), not `(config, tracker)`. The tracker is at `config.tracker`. LLMs hallucinate the tuple shape because pre-v0.x SDKs used to return one — the current API does not.
-- Don't import `LaunchDarklyCallbackHandler` from `ldai.langchain` — neither the class nor the dotted module path exists. The real Python LangChain helper package is `ldai_langchain` (top-level module, underscore), and it does not expose a single-node callback handler. For single-node LangChain calls, use manual tracker wiring with `response.usage_metadata` (see `references/sdk-ai-tracker-patterns.md`).
+- Don't import `LaunchDarklyCallbackHandler` from `ldai.langchain` — neither the class nor the dotted module path exists. The real Python LangChain helper package is `ldai_langchain` (top-level module, underscore). For single-node LangChain calls, use `track_metrics_of(fn, LangChainProvider.get_ai_metrics_from_response)` — the provider package normalizes `AIMessage.usage_metadata` for you across OpenAI / Anthropic / Bedrock / Gemini. See [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) for the full matrix.
 
 ## Related Skills
 

--- a/skills/ai-configs/aiconfig-migrate/SKILL.md
+++ b/skills/ai-configs/aiconfig-migrate/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: aiconfig-migrate
+description: "Migrate an application with hardcoded LLM prompts to a full LaunchDarkly AI Configs implementation in five stages: extract prompts, wrap in the AI SDK, add tools, add tracking, add evals/judges. Use when the user wants to externalize model/prompt configuration, move from direct provider calls (OpenAI, Anthropic, Bedrock, Gemini) to a managed AI Config, or stage a full hardcoded-to-LaunchDarkly migration."
+license: Apache-2.0
+compatibility: Requires the remotely hosted LaunchDarkly MCP server
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# Migrate to AI Configs
+
+You're using a skill that will guide you through migrating an application from hardcoded LLM prompts to a full LaunchDarkly AI Configs implementation. Your job is to audit the existing code, extract the hardcoded model and prompt, wrap the call site in the AI SDK with a safe fallback, move tools into the config, instrument the tracker, and attach evaluations — in that order, stopping at each stage for the user to confirm.
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment, and an application that already calls an LLM provider with hardcoded model, prompt, and parameter values.
+
+**Required environment:**
+- `LD_SDK_KEY` — server-side SDK key (starts with `sdk-`) from the target LaunchDarkly project
+
+**MCP tools used directly by this skill:** none — every LaunchDarkly write happens in a focused sibling skill.
+
+**Hand-off model.** This skill does **not** auto-invoke other skills. At each stage that needs a LaunchDarkly write, this skill prepares the inputs (config key, mode, model, prompt, tool schemas, judge keys) and then **tells the user to run the next slash-command themselves**. After the user finishes that sibling skill, return to the next step here. Treat the "Delegate" lines below as next-step instructions, not auto-handoffs.
+
+**Sibling skills the user runs at each stage:**
+- `aiconfig-projects` — pre-Stage 2, only if no project exists yet
+- `aiconfig-create` — Stage 2 (creates the AI Config and first variation)
+- `aiconfig-tools` — Stage 3 (creates tool definitions and attaches them)
+- `aiconfig-targeting` — between Stage 2 and Stage 4 (promotes the new variation to fallthrough so the SDK actually serves it)
+- `aiconfig-online-evals` — Stage 5 (attaches judges, creates custom judges)
+
+## Core Principles
+
+1. **Inspect before you mutate.** Every stage begins with a read-only audit. Do not touch code until Step 1 is confirmed by the user.
+2. **Replace config, not business logic.** The SDK call is a drop-in for the place where the model, parameters, and prompt are *defined* — not for the provider call itself. OpenAI/Anthropic/Bedrock calls stay where they are.
+3. **Fallback mirrors current behavior.** The fallback passed to `completion_config` / `agent_config` must preserve the hardcoded values you removed, so the app is unchanged if LaunchDarkly is unreachable.
+4. **Stages are ordered.** Wrap before you add tools. Add tools before you track. Track before you add evals. Skipping ahead produces configs without traffic, metrics without context, and judges with nothing to score.
+5. **Hand off to focused skills, manually.** Each stage that needs a LaunchDarkly write tells the user to run a sibling slash-command (`/aiconfig-create`, `/aiconfig-tools`, `/aiconfig-targeting`, `/aiconfig-online-evals`) and waits for them to come back. This skill does **not** auto-invoke other skills.
+
+## Workflow
+
+### Step 1: Audit the codebase (read-only)
+
+Run the phase-1 checklist and produce a structured summary. **This step writes no code and creates no LaunchDarkly resources.**
+
+Use [phase-1-analysis-checklist.md](references/phase-1-analysis-checklist.md) to scan:
+
+1. **Language and package manager** — Python (pip/poetry/uv), TypeScript/JavaScript (npm/pnpm/yarn), Go, Ruby, .NET
+2. **LLM provider** — OpenAI, Anthropic, Bedrock, Gemini, LangChain, LangGraph, CrewAI
+3. **Existing LaunchDarkly usage** — any pre-existing `LDClient` or `ldclient` initialization to reuse
+4. **Hardcoded model configs** — model name string literals, temperature / maxTokens / topP, system prompts, instruction strings
+5. **Mode decision** — completion mode (chat messages array) or agent mode (single instructions string). Completion mode is the default and the only mode that supports judges attached in the UI.
+
+**Phase 1 output** (return to user as a structured summary):
+
+```
+Language: Python 3.12
+Package manager: uv
+LLM provider: OpenAI
+Existing LD SDK: none
+Target mode: completion
+Hardcoded targets:
+  - src/chat.py:42   model="gpt-4o"
+  - src/chat.py:43   temperature=0.7, max_tokens=2000
+  - src/chat.py:45   system="You are a helpful assistant..."
+Proposed plan: single AI Config key `chat-assistant`, mirror fallback, Stage 3 (tools) skipped (no function calling), Stage 4 (tracking) inline, Stage 5 (evals) attach built-in accuracy judge.
+```
+
+**STOP.** Present this summary and wait for the user to confirm before proceeding to Stage 1 extract. This is the same stop point as the `AGENT-SETUP-PROMPT.md` Phase 1 pattern.
+
+### Step 2: Extract prompts (Stage 1)
+
+Turn the audit into a concrete migration manifest — still read-only. For each hardcoded target from Step 1, record:
+
+- File path and line range
+- Current value (model name, full prompt text, parameter dict)
+- Target AI Config field (`model.name`, `model.parameters.temperature`, `messages[].content`, `instructions`)
+- Whether the surrounding call uses function calling / tools (drives Stage 3)
+- Whether the surrounding call has retry logic (affects where Stage 4 tracker calls go)
+
+This manifest is the contract for the next four stages. Review it with the user. Do not mutate any files in this step.
+
+### Step 3: Wrap the call in the AI SDK (Stage 2)
+
+This is the first stage that writes code. It has six sub-steps.
+
+1. **Install the AI SDK.** Detect the package manager from Step 1, then install:
+   - Python: `launchdarkly-server-sdk` + `launchdarkly-server-sdk-ai`
+   - Node.js/TypeScript: `@launchdarkly/node-server-sdk` + `@launchdarkly/server-sdk-ai`
+   - Go: `github.com/launchdarkly/go-server-sdk/v7` + `github.com/launchdarkly/go-server-sdk/ldai`
+
+2. **Initialize `LDAIClient` once at startup.** Reuse any existing `LDClient` — do not create a second base client. Place the initialization in the same module that owns existing app config.
+
+   **Python:**
+   ```python
+   import ldclient
+   from ldclient.config import Config
+   from ldai.client import LDAIClient
+
+   ldclient.set_config(Config(os.environ["LD_SDK_KEY"]))
+   ai_client = LDAIClient(ldclient.get())
+   ```
+
+   **Node.js/TypeScript:**
+   ```typescript
+   import { init } from '@launchdarkly/node-server-sdk';
+   import { initAi } from '@launchdarkly/server-sdk-ai';
+
+   const ldClient = init(process.env.LD_SDK_KEY!);
+   await ldClient.waitForInitialization({ timeout: 10 });
+   const aiClient = initAi(ldClient);
+   ```
+
+3. **Hand off to `aiconfig-create`.** Print the extracted model, prompt/instructions, parameters, and mode from Step 2's manifest, then tell the user: *"Run `/aiconfig-create` with these inputs, then come back here."* Supply the config key you want the code to call (e.g. `chat-assistant`). Do not attempt to auto-invoke the sibling skill — wait for the user to finish it before continuing.
+
+   **After `aiconfig-create` finishes, the user must also run `/aiconfig-targeting` to promote the new variation to fallthrough.** A freshly created variation returns `enabled=False` to every consumer until targeting is updated. Skip this and Stage 2 verification (sub-step 7 below) will silently take the fallback path on every request.
+
+4. **Build the fallback.** Mirror the hardcoded values you extracted. Use `AICompletionConfigDefault` / `AIAgentConfigDefault` in Python, plain object literals in Node. See [fallback-defaults-pattern.md](references/fallback-defaults-pattern.md) for inline, file-backed, and bootstrap-generated patterns.
+
+   **Python fallback (completion mode):**
+   ```python
+   from ldai.client import AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
+
+   fallback = AICompletionConfigDefault(
+       enabled=True,
+       model=ModelConfig(name="gpt-4o", parameters={"temperature": 0.7, "maxTokens": 2000}),
+       provider=ProviderConfig(name="openai"),
+       messages=[LDMessage(role="system", content="You are a helpful assistant...")],
+   )
+   ```
+
+5. **Replace the hardcoded call site.** Swap the hardcoded model/prompt/params for a `completion_config` / `completionConfig` (or `agent_config` / `agentConfig`) call, then read the returned fields into the existing provider call. Keep the provider call intact.
+
+   **Python — before:**
+   ```python
+   response = openai_client.chat.completions.create(
+       model="gpt-4o",
+       temperature=0.7,
+       max_tokens=2000,
+       messages=[
+           {"role": "system", "content": "You are a helpful assistant..."},
+           {"role": "user", "content": user_input},
+       ],
+   )
+   ```
+
+   **Python — after:**
+   ```python
+   context = Context.builder(user_id).set("email", user.email).build()
+   config = ai_client.completion_config("chat-assistant", context, fallback)
+
+   if not config.enabled:
+       return disabled_response()
+
+   params = config.model.parameters or {}
+   response = openai_client.chat.completions.create(
+       model=config.model.name,
+       temperature=params.get("temperature"),
+       max_tokens=params.get("maxTokens"),
+       messages=[m.to_dict() for m in (config.messages or [])] + [
+           {"role": "user", "content": user_input},
+       ],
+   )
+   ```
+
+   **Python — after (agent mode)** — for LangGraph, CrewAI, or any framework that takes a goal/instructions string:
+
+   ```python
+   context = Context.builder(user_id).kind("user").build()
+   config = ai_client.agent_config("support-agent", context, FALLBACK)
+
+   if not config.enabled:
+       return disabled_response()
+
+   # config is a single AIAgentConfig object — NOT a (config, tracker) tuple.
+   # The tracker lives at config.tracker.
+   model_name = f"{config.provider.name}/{config.model.name}"
+   instructions = config.instructions
+   params = config.model.parameters or {}
+
+   # Pass model_name + instructions into your framework's agent constructor.
+   # Example: LangGraph create_react_agent
+   # agent = create_react_agent(
+   #     model=load_chat_model(model_name),
+   #     tools=TOOLS,               # Stage 3 will replace this with a config.tools loader
+   #     prompt=instructions,
+   # )
+   ```
+
+   See [before-after-examples.md](references/before-after-examples.md) for full Python OpenAI, Node Anthropic, and LangGraph agent-mode paired snippets.
+
+6. **Check `config.enabled`.** If it returns `False`, handle the disabled path without crashing and without calling the provider. The check is required — not optional.
+
+7. **Verify.** Run the app with a valid `LD_SDK_KEY`; confirm the call succeeds and the response matches pre-migration output. Then temporarily set `LD_SDK_KEY=sdk-invalid` (or unset it) and confirm the fallback path runs without error. Both paths must work before moving to Stage 3.
+
+Delegate: **`aiconfig-create`** (sub-step 3).
+
+### Step 4: Move tools into the config (Stage 3)
+
+Skip this step if the audited app has no function calling / tools. Otherwise:
+
+1. **Enumerate the tools currently registered.** Common shapes to look for:
+
+   - `openai.chat.completions.create(tools=[...])` — OpenAI direct
+   - `anthropic.messages.create(tools=[...])` — Anthropic direct
+   - `create_react_agent(tools=[...])` — LangGraph prebuilt ReAct
+   - `Agent(tools=[...])` — CrewAI
+   - **Custom `StateGraph`** — module-level `TOOLS = [...]` list referenced in **both** `model.bind_tools(TOOLS)` and `ToolNode(TOOLS)`. This is the `langchain-ai/react-agent` template shape; the list is usually in a `tools.py` module. Grep for `bind_tools(` and `ToolNode(` together — they will point at the same list.
+
+   Record each tool's name, description, and JSON schema.
+
+   For LangChain/LangGraph tools defined with `@tool`, extract the schema via `tool.args_schema.model_json_schema()` (or the equivalent Pydantic `model_json_schema()` call). For plain async callables used as tools (common in custom StateGraph shapes), LangChain infers the schema from the function signature at bind time — extract it via `StructuredTool.from_function(fn).args_schema.model_json_schema()`. Do not hand-write the schema.
+
+2. **Hand off to `aiconfig-tools`.** Print the extracted tool names, descriptions, and schemas, then tell the user: *"Run `/aiconfig-tools` with these tools and the variation key, then come back here."* The sibling skill creates tool definitions (`create-ai-tool`) and attaches them to the variation (`update-ai-config-variation`). Wait for the user to finish before proceeding to sub-step 3. Do not auto-invoke.
+
+3. **Replace the hardcoded tools array at the call site** with a read from `config.tools` (or the SDK equivalent for your language). Load the actual implementation functions dynamically from the tool names — see [agent-mode-frameworks.md](references/agent-mode-frameworks.md) for the dynamic-tool-factory pattern from the devrel agents tutorial.
+
+   **For custom `StateGraph` shapes**, you must update **both** call sites: `.bind_tools(TOOLS)` and `ToolNode(TOOLS)` must both read from the same `config.tools`-derived list. Forgetting one leaves the LLM seeing the new tools but the executor still running the old ones, or vice versa.
+
+4. **Verify.** Run the app; confirm the tool flows still execute correctly. `get-ai-config` (via the delegate) confirms the tools are attached server-side.
+
+Delegate: **`aiconfig-tools`** (sub-step 2).
+
+### Step 5: Instrument the tracker (Stage 4)
+
+This stage has **no delegate**. The tracker wiring is inline because no existing skill covers the AI `tracker.track_*` methods — the `launchdarkly-metric-instrument` skill is for `ldClient.track()` feature metrics, which is a different API. See [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) for the full per-method Python + Node matrix.
+
+1. **Locate the tracker.** It's attached to the config object returned in Stage 2: `config.tracker` (Python) or `aiConfig.tracker` (Node).
+
+2. **Wrap the provider call** with duration, success, error, and token tracking.
+
+   **Python — manual tracking:**
+   ```python
+   import time
+   from ldai.tracker import TokenUsage
+
+   start = time.time()
+   try:
+       response = openai_client.chat.completions.create(...)
+       config.tracker.track_duration(int((time.time() - start) * 1000))
+       config.tracker.track_success()
+       config.tracker.track_tokens(TokenUsage(
+           input=response.usage.prompt_tokens,
+           output=response.usage.completion_tokens,
+           total=response.usage.total_tokens,
+       ))
+   except Exception:
+       config.tracker.track_error()
+       raise
+   ```
+
+   **Node — manual tracking:**
+   ```typescript
+   const start = Date.now();
+   try {
+     const response = await openai.chat.completions.create(/* ... */);
+     aiConfig.tracker.trackDuration(Date.now() - start);
+     aiConfig.tracker.trackSuccess();
+     aiConfig.tracker.trackTokens({
+       input: response.usage?.prompt_tokens ?? 0,
+       output: response.usage?.completion_tokens ?? 0,
+       total: response.usage?.total_tokens ?? 0,
+     });
+   } catch (error) {
+     aiConfig.tracker.trackError();
+     throw error;
+   }
+   ```
+
+3. **Prefer auto-tracking helpers where available.** They capture duration, tokens, and success/error in one call and avoid drift between manual blocks.
+
+   | Provider | Python method | Node method |
+   |----------|--------------|-------------|
+   | OpenAI (any chat completion) | `tracker.track_openai_metrics(lambda: ...)` | `tracker.trackOpenAIMetrics(() => ...)` |
+   | Bedrock (Converse API) | `tracker.track_bedrock_converse_metrics(response)` | `tracker.trackBedrockConverseMetrics(response)` |
+   | Vercel AI SDK (`generateText`) | — | `tracker.trackVercelAISDKGenerateTextMetrics(() => ...)` |
+   | LangChain (single-node model call) | **Manual** — wrap `ainvoke` in try/except and call `tracker.track_duration` + `track_success` + `track_tokens` using `response.usage_metadata` (see snippet below) | **Manual** (same pattern; LangChain.js usage metadata is standardized) |
+   | LangGraph multi-node (EXPERIMENTAL) | `ldai_langchain.LDMetricsCallbackHandler` — requires `node_keys: Set[str]` and `fn_name_to_config_key: Dict[str, str]` constructor args. Marked not production-ready. Not suitable for single-node react-agent shapes. | — |
+   | Custom / any other | `tracker.track_metrics_of(func, extractor)` | `tracker.trackMetricsOf(extractor, () => ...)` |
+
+   **Do not hallucinate a `LaunchDarklyCallbackHandler` or `ldai.langchain` module.** Neither exists. The real Python package is `ldai_langchain` (underscore, top-level), it exposes `LangChainModelRunner`, `LangChainAgentRunner`, `LangChainRunnerFactory`, `LangGraphAgentGraphRunner`, and helper functions — none of which is a single-node plug-and-play callback. For the common single-node LangChain case, manual tracking via `response.usage_metadata` is the recommended path.
+
+   **LangChain single-node manual tracking pattern** (Python):
+
+   ```python
+   import time
+   from ldai.tracker import TokenUsage
+
+   start = time.time()
+   try:
+       response = await model.ainvoke([
+           {"role": "system", "content": config.instructions},
+           *state.messages,
+       ])
+       config.tracker.track_duration(int((time.time() - start) * 1000))
+       config.tracker.track_success()
+       # LangChain standardizes token usage across providers on AIMessage.usage_metadata
+       if hasattr(response, "usage_metadata") and response.usage_metadata:
+           um = response.usage_metadata
+           config.tracker.track_tokens(TokenUsage(
+               input=um.get("input_tokens", 0),
+               output=um.get("output_tokens", 0),
+               total=um.get("total_tokens", 0),
+           ))
+   except Exception:
+       config.tracker.track_error()
+       raise
+   ```
+
+   `AIMessage.usage_metadata` is LangChain's standardized token usage field — it works across providers (OpenAI, Anthropic, Bedrock, Gemini) because LangChain normalizes the provider-specific shapes behind the scenes.
+
+   There is no built-in Anthropic direct-API helper in either SDK. For Anthropic direct calls (not via LangChain), use the manual pattern from the "Node — manual tracking" block above, or switch the call through Bedrock Converse.
+
+4. **Wire feedback tracking if the app has thumbs-up/down UI.** Both SDKs expose `trackFeedback` with a `{kind}` argument.
+
+   **Python:**
+   ```python
+   from ldai.tracker import FeedbackKind
+   config.tracker.track_feedback({"kind": FeedbackKind.Positive})
+   ```
+
+   **Node:**
+   ```typescript
+   import { LDFeedbackKind } from '@launchdarkly/server-sdk-ai';
+   aiConfig.tracker.trackFeedback({ kind: LDFeedbackKind.Positive });
+   ```
+
+5. **Verify.** Hit the wrapped endpoint in staging, then open the AI Config in LaunchDarkly → Monitoring tab. Duration, token, and generation counts should appear within 1–2 minutes. If nothing shows up, walk the checklist in [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) under "Troubleshooting."
+
+### Step 6: Attach evaluations (Stage 5)
+
+1. **Decide between three evaluation paths.** This is the most commonly misunderstood stage — there are **three** paths, not two, and the right default for a migration context is often the one people skip.
+
+   | Path | When to use | Supports agent mode? |
+   |------|-------------|---------------------|
+   | **Offline eval** (recommended default for migration) | Pre-ship regression: run a fixed dataset through the new variation in the LD Playground and score against baseline. Best fit for migration because you want to prove the new AI Config behaves at least as well as the hardcoded version before shipping. | Yes — all modes |
+   | **UI-attached auto judges** | Attach one or more judges to a variation in the LD UI; judges run on sampled live requests automatically. Zero code changes. | Completion mode only (the UI widget is completion-only today) |
+   | **Programmatic direct-judge** | Call `ai_client.create_judge(...)` inside the request handler and `judge.evaluate(input, output)` on each call. Adds per-request cost and code complexity. Best for continuous live scoring of workflows where sampled auto-judges aren't enough. | Yes — all modes (the SDK handles both identically) |
+
+   **Most migration users should start with offline eval**, then add programmatic direct-judge only if they need continuous live scoring after the rollout is stable.
+
+2. **For agent-mode migrations, default to offline eval.** UI-attached auto judges are completion-mode only today. The documented path for agent mode is either (a) **offline regression** via the LD Playground + Datasets (works for all modes), or (b) **programmatic direct-judge** wired into the call site. Generate a starter dataset CSV from the audit manifest (one representative input per row) and point the user at `/tutorials/offline-evals` for the Playground walkthrough. Only wire programmatic direct-judge into production code if the user explicitly asks for continuous live scoring.
+
+3. **Hand off to `aiconfig-online-evals`** — only for UI-attached judges (completion mode) or to create custom judge AI Configs that will be referenced by the programmatic path. Tell the user: *"Run `/aiconfig-online-evals` with these inputs, then come back here."* Do not auto-invoke. Pass:
+   - The parent AI Config key and variation key
+   - A list of built-in judges (Accuracy, Relevance, Toxicity) or custom judge keys to create/attach
+   - Target environment
+
+   The delegate handles creating custom judge AI Configs, attaching them via the variation PATCH endpoint, and setting fallthrough on each judge config. Offline eval does **not** go through this delegate — it's a Playground workflow, not an API write.
+
+4. **For programmatic direct-judge: wire `create_judge` + `evaluate` + `track_eval_scores`.** This is the only path at Stage 5 that writes code. The correct shape:
+
+   ```python
+   from ldai.client import AIJudgeConfigDefault
+
+   judge = await ai_client.create_judge(
+       judge_key,                               # judge AI Config key in LD
+       ld_context,
+       AIJudgeConfigDefault(enabled=False),     # fallback: skip eval on SDK miss
+   )
+
+   if judge and judge.enabled:
+       result = await judge.evaluate(
+           input_text,
+           output_text,
+           sampling_rate=0.25,                  # optional; default 1.0 (always eval)
+       )
+       if result:
+           config.tracker.track_eval_scores(result.evals)
+   ```
+
+   Three rules:
+   - **`create_judge` returns `Optional[Judge]`.** Always guard with `if judge and judge.enabled:` — it returns `None` if the judge AI Config is disabled for the context or the provider is missing. A direct `.evaluate()` on a `None` return will raise `AttributeError`.
+   - **Pass `AIJudgeConfigDefault`**, not `AICompletionConfigDefault`. The `create_judge` `default` parameter is typed `Optional[AIJudgeConfigDefault]`; passing the completion type will not type-check and is a doc-level bug in some older examples.
+   - **`sampling_rate` is a parameter on `evaluate()`**, not on `create_judge`. It defaults to `1.0` (evaluate every call). For live paths, pass something lower (0.1–0.25) to control cost.
+
+   **Ask the user which judge AI Config key to use.** LaunchDarkly ships three built-in judges — Accuracy, Relevance, Toxicity — but the actual AI Config **keys** for the built-ins are not canonical SDK constants and aren't documented. Have the user open **AI Configs > Library** in the LD UI and copy the key of the judge they want to reference, or create a custom judge AI Config via `aiconfig-create` first.
+
+5. **Verify.**
+   - **UI-attached auto judges:** trigger a request in staging, open the Monitoring tab → "Evaluator metrics" dropdown. Scores appear within 1–2 minutes at the configured sampling rate.
+   - **Programmatic direct-judge:** hit the wrapped endpoint and confirm `track_eval_scores` lands on the parent config's Monitoring tab.
+   - **Offline eval:** run the dataset through the LD Playground, compare baseline vs new-variation scores side by side. No runtime wiring required.
+
+Delegate: **`aiconfig-online-evals`** (sub-step 3, optional — only for UI-attached judges or custom-judge creation; offline eval doesn't delegate).
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Hardcoded prompt uses f-string / template literal interpolation | Move interpolation into AI Config prompt variables `{{ variable }}`; pass values as the last argument to `completion_config` / `completionConfig` |
+| App already initializes `LDClient` for feature flags | Reuse it — pass the existing client to `LDAIClient()` / `initAi()`, do not create a second client |
+| App uses LangChain `ChatOpenAI(model=...)` | Read `config.model.name` and pass it as `ChatOpenAI(model=config.model.name)`; keep LangChain for the call itself |
+| Retry wrapper around the provider call | Move tracker inside the retry — failures in the same request should share one `track_error`, and success tracking should fire only after the final attempt |
+| App has no tools — Stage 3 skipped | Move directly from Stage 2 verification to Stage 4 (tracking) |
+| Mode mismatch: user said agent, audit shows one-shot chat | Choose completion mode unless the app uses LangGraph `create_react_agent`, CrewAI `Agent`, or a similar goal-driven framework |
+| TypeScript app using Anthropic SDK | No `trackAnthropicMetrics` helper exists — use manual `trackDuration` + `trackTokens` + `trackSuccess`/`trackError` (see the Step 5 manual block) |
+| Fallback would silently crash because `LD_SDK_KEY` is missing | Log a startup warning; proceed with the fallback. Never raise at import time |
+| Multi-agent graph (supervisor + workers) | Stop after migrating a single agent. Agent graphs are currently **Python-only** (`launchdarkly-server-sdk-ai.agent_graph`). Read [agent-graph-reference.md](references/agent-graph-reference.md) for the graph-level migration path — it is deliberately out of this skill's main scope |
+| Single-agent (ReAct, tool loop) + agent mode | Default to offline eval via the LD Playground + Datasets for Stage 5. UI-attached judges are completion-only today, and programmatic direct-judge adds per-call cost that is usually not worth it until after the migration is live and stable. Point at `/tutorials/offline-evals` |
+| Tool with a Pydantic `args_schema` (LangChain `@tool`) | Extract the schema via `tool.args_schema.model_json_schema()`; do not hand-write the JSON schema for the delegate |
+| Custom `StateGraph` with module-level `TOOLS` list bound via `.bind_tools(TOOLS)` and run through `ToolNode(TOOLS)` (e.g. the `langchain-ai/react-agent` template) | Find the `TOOLS` list (usually in a separate `tools.py` module). Extract schemas the same way. Swap **both** call sites — `.bind_tools(...)` and `ToolNode(...)` — to read from the same `config.tools`-derived list |
+| App has already externalized config into a `Context` dataclass with env-var fallback (e.g. `react-agent` template's `context.py`) | Good news — migration is a single-layer change. Replace the `Context` dataclass consumer (`runtime.context.model`, `runtime.context.system_prompt`) with a per-request `ai_client.agent_config(...)` call. Keep the dataclass as the fallback shape (it already mirrors the hardcoded values) |
+
+## What NOT to Do
+
+- Don't skip Step 1 even when the user says "just wrap it." Without the audit, the fallback will drift from the hardcoded behavior.
+- Don't delegate to `aiconfig-create` before extracting the prompt and model — the delegate needs them as inputs.
+- Don't try to attach tools during initial `setup-ai-config`. Tool attachment is a separate step owned by `aiconfig-tools`.
+- Don't use `launchdarkly-metric-instrument` for Step 5. That skill is for `ldClient.track()` feature metrics, not AI `tracker.track_*` calls — they are different APIs.
+- Don't wire evals before the tracker is in place. Judges score traffic; without Stage 4 traffic, there is nothing to judge.
+- Don't frame Stage 5 as "either UI or programmatic." There are **three** paths: offline eval (recommended default for migration), UI-attached auto judges (completion-mode only), and programmatic direct-judge. Offline eval is the one most people skip and usually the right starting point.
+- Don't pass `sampling_rate` to `create_judge` — it's a parameter on `Judge.evaluate()`, not `create_judge()`.
+- Don't hardcode judge AI Config keys (`"accuracy-judge"`, `"relevance-judge"`, etc). The built-in keys are not canonical SDK constants; ask the user to look them up in **AI Configs > Library** in the LD UI.
+- Don't forget the `if judge and judge.enabled:` guard after `create_judge`. It returns `Optional[Judge]` and returns `None` when the judge config is disabled for the context.
+- Don't cache the config object across requests. Call `completion_config` / `completionConfig` on each request so LaunchDarkly can re-evaluate targeting.
+- Don't delete the fallback once LaunchDarkly is wired up. It is required for the `enabled=False` and SDK-unreachable paths.
+- Don't claim you "delegated to `aiconfig-create`" or any other sibling skill. This skill does not auto-invoke. At each handoff, print the inputs and tell the user to run the sibling slash-command, then wait. Anything else misleads the user about what just happened.
+- Don't skip the `/aiconfig-targeting` step between Stage 2 and Stage 4. A freshly created variation returns `enabled=False` until targeting promotes it to fallthrough — Stage 2 verification will silently take the fallback path on every request.
+- Don't attempt a multi-agent graph migration in one pass. Migrate a single agent first; use [agent-graph-reference.md](references/agent-graph-reference.md) as the next-step read.
+- Don't use `track_request()` in Python — it does not exist in `launchdarkly-server-sdk-ai`. Use `track_duration()` + `track_success()`/`track_error()` explicitly, or prefer `track_openai_metrics` / `track_metrics_of` auto-helpers.
+- Don't tuple-unpack the return of `completion_config` / `agent_config` / `completionConfig` / `agentConfig`. They return a **single** config object (e.g. `AIAgentConfig`, `AICompletionConfig`), not `(config, tracker)`. The tracker is at `config.tracker`. LLMs hallucinate the tuple shape because pre-v0.x SDKs used to return one — the current API does not.
+- Don't import `LaunchDarklyCallbackHandler` from `ldai.langchain` — neither the class nor the dotted module path exists. The real Python LangChain helper package is `ldai_langchain` (top-level module, underscore), and it does not expose a single-node callback handler. For single-node LangChain calls, use manual tracker wiring with `response.usage_metadata` (see `references/sdk-ai-tracker-patterns.md`).
+
+## Related Skills
+
+- `aiconfig-create` — called by Stage 2 to create the config
+- `aiconfig-tools` — called by Stage 3 to create and attach tool definitions
+- `aiconfig-online-evals` — called by Stage 5 to attach judges
+- `aiconfig-variations` — add variations for A/B testing after migration is complete
+- `aiconfig-targeting` — roll out new variations to users after migration is complete
+- `aiconfig-update` — modify config properties as your app evolves
+- `launchdarkly-metric-instrument` — for `ldClient.track()` feature metrics (NOT for AI tracker calls)
+
+## References
+
+- [phase-1-analysis-checklist.md](references/phase-1-analysis-checklist.md) — Step 1 audit checklist, grep patterns, SDK routing table, mode decision tree
+- [before-after-examples.md](references/before-after-examples.md) — Paired hardcoded-to-wrapped snippets for Python OpenAI, Node Anthropic, Python LangGraph
+- [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) — Every `tracker.track_*` method in Python and Node side by side, auto-helper matrix, and common gotchas
+- [agent-mode-frameworks.md](references/agent-mode-frameworks.md) — How to wire `agent_config` into LangGraph, CrewAI, and custom react loops; dynamic tool loading pattern
+- [fallback-defaults-pattern.md](references/fallback-defaults-pattern.md) — Three fallback patterns (inline, file-backed, bootstrap-generated) and when to use each
+- [agent-graph-reference.md](references/agent-graph-reference.md) — Out-of-scope pointer doc for multi-agent migrations

--- a/skills/ai-configs/aiconfig-migrate/SKILL.md
+++ b/skills/ai-configs/aiconfig-migrate/SKILL.md
@@ -224,7 +224,9 @@ Delegate: **`aiconfig-tools`** (sub-step 2).
 
 ### Step 5: Instrument the tracker (Stage 4)
 
-This stage has **no delegate**. The tracker wiring is inline because no existing skill covers the AI `tracker.track_*` methods — the `launchdarkly-metric-instrument` skill is for `ldClient.track()` feature metrics, which is a different API. See [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) for the full per-method Python + Node matrix.
+Delegate: **`aiconfig-ai-metrics`** wires the per-request `tracker.track_*` calls (duration, tokens, success/error, feedback) around the provider call. Use **`aiconfig-custom-metrics`** alongside it if the app needs business metrics beyond the built-in AI ones. Note: do not confuse this with `launchdarkly-metric-instrument`, which is for `ldClient.track()` feature metrics — a different API. See [sdk-ai-tracker-patterns.md](references/sdk-ai-tracker-patterns.md) for the full per-method Python + Node matrix that the delegate skill draws on.
+
+Hand off: print the AI Config key, variation key, provider, and whether the call is streaming, then tell the user: *"Run `/aiconfig-ai-metrics` with these inputs, then come back here."* Do not auto-invoke. Return here for sub-step 5 (verify) once they're done.
 
 1. **Locate the tracker.** It's attached to the config object returned in Stage 2: `config.tracker` (Python) or `aiConfig.tracker` (Node).
 

--- a/skills/ai-configs/aiconfig-migrate/references/agent-graph-reference.md
+++ b/skills/ai-configs/aiconfig-migrate/references/agent-graph-reference.md
@@ -1,0 +1,241 @@
+# Agent Graph Reference
+
+> **Out of scope for the main migration workflow.** Read this only after a single-agent migration works end-to-end. The main `SKILL.md` workflow stops at single-agent because multi-agent orchestration is a meaningful jump in complexity and is still evolving in the SDK.
+
+> **Python-only today.** The `@launchdarkly/server-sdk-ai` (Node.js) SDK does **not** expose any graph API. Agent graphs are available only via `launchdarkly-server-sdk-ai` (Python). If your app is Node, migrate single-agent and stop — revisit graphs when the Node SDK catches up.
+
+## What an agent graph is
+
+An **agent graph** is a directed graph where each node is its own AI Config (with its own instructions, model, parameters, and tools) and each edge carries routing metadata for handoffs. A supervisor node routes incoming requests to worker nodes based on the supervisor's output; worker nodes may themselves route to other workers or terminate. The graph lives in LaunchDarkly — both its topology and each node's config are managed as versioned resources and can be changed at runtime without redeploying.
+
+Why use it:
+
+- **Add or remove an agent by editing LaunchDarkly** — no redeploy
+- **A/B test routing strategies** — target different graph topologies to different users
+- **Roll out a new worker node to a percentage of traffic**
+- **Guardrail a specific path** — attach a judge at a terminal node
+
+## SDK surface (Python, from main)
+
+The current Python API (verified against `launchdarkly-server-sdk-ai` main branch) exposes these methods on `LDAIClient`:
+
+```python
+def agent_graph(self, key: str, context: Context) -> AgentGraphDefinition:
+    """Retrieve an AI agent graph by key."""
+
+async def create_agent_graph(
+    self,
+    key: str,
+    context: Context,
+    tools: Optional[ToolRegistry] = None,
+    default_ai_provider: Optional[str] = None,
+) -> Optional[ManagedAgentGraph]:
+    """Experimental — not production-ready. Returns a managed graph that can be invoked directly."""
+```
+
+**Use `agent_graph` for read-only traversal** (you drive the loop). **`create_agent_graph` + `ManagedAgentGraph.run` is experimental** and carries explicit production-not-ready warnings in the SDK source. Stick with `agent_graph` for now.
+
+### `AgentGraphDefinition`
+
+```python
+graph_def: AgentGraphDefinition = ai_client.agent_graph("support-flow", context)
+
+graph_def.is_enabled() -> bool
+graph_def.root() -> Optional[AgentGraphNode]
+graph_def.traverse(fn, execution_context=None)            # callback over nodes from root
+graph_def.reverse_traverse(fn, execution_context=None)    # callback over nodes from terminals
+graph_def.get_node(key: str) -> Optional[AgentGraphNode]
+graph_def.get_child_nodes(node_key: str) -> List[AgentGraphNode]
+graph_def.get_parent_nodes(node_key: str) -> List[AgentGraphNode]
+graph_def.terminal_nodes() -> List[AgentGraphNode]
+graph_def.get_tracker() -> Optional[AIGraphTracker]
+```
+
+### `AgentGraphNode`
+
+```python
+node.get_key() -> str
+node.get_config() -> AIAgentConfig            # the same shape as agent_config() returns
+node.get_edges() -> List[Edge]
+node.is_terminal() -> bool
+```
+
+### `Edge`
+
+```python
+@dataclass
+class Edge:
+    key: str
+    source_config: str
+    target_config: str
+    handoff: Optional[dict]                    # arbitrary dict; typically has a 'route' key
+```
+
+### `AIGraphTracker`
+
+```python
+tracker.track_invocation_success() -> None
+tracker.track_invocation_failure() -> None
+tracker.track_latency(duration: int) -> None           # milliseconds, graph-level total
+tracker.track_total_tokens(tokens: TokenUsage) -> None
+tracker.track_path(path: List[str]) -> None            # e.g. ["supervisor", "security", "support"]
+tracker.track_judge_response(response) -> None
+tracker.track_redirect(source_key: str, redirected_target: str) -> None
+tracker.track_handoff_success(source_key: str, target_key: str) -> None
+tracker.track_handoff_failure(source_key: str, target_key: str) -> None
+```
+
+**Things that are NOT on the graph tracker:**
+
+- `track_node_invocation` — not a public method. Use `track_path(execution_path)` at the end of traversal instead.
+- `track_tool_call(node_key, tool_name)` — graph-level tool-call tracking does not exist. Track per-node tool calls via `config.tracker.track_tool_call(tool_name, graph_key=graph_key)` on each node's `AIAgentConfig.tracker` (see `sdk-ai-tracker-patterns.md`).
+- No `track_request()`, no `track_duration()` per call — use `track_latency(total_ms)` once per traversal.
+
+If you see older devrel-agents-tutorial code that calls `track_node_invocation`, `track_tool_call`, or pokes `graph_tracker._ld_client.track(...)` directly, that code targets an earlier API shape and needs updating. A PR is in flight against `launchdarkly-labs/devrel-agents-tutorial` to align the tutorial with the current SDK.
+
+## Canonical traversal pattern
+
+```python
+from ldai.client import LDAIClient
+from ldai.tracker import TokenUsage
+
+async def execute_graph(ai_client: LDAIClient, graph_key: str, context, user_input: str):
+    graph = ai_client.agent_graph(graph_key, context)
+
+    if not graph.is_enabled():
+        raise ValueError(f"Agent graph '{graph_key}' is not enabled")
+
+    # Build a lookup from node key to AgentGraphNode so we can follow edges.
+    nodes: dict[str, object] = {}
+    graph.reverse_traverse(lambda node, _: nodes.update({node.get_key(): node}), {})
+
+    graph_tracker = graph.get_tracker()
+    start = time.time()
+    execution_path = []
+    shared_ctx = {"user_input": user_input, "final_response": "", "tool_calls": [],
+                  "total_input_tokens": 0, "total_output_tokens": 0}
+
+    current_node = graph.root()
+    if not current_node:
+        raise ValueError("Graph has no root node")
+
+    prev_node_key = None
+    visited = set()
+    MAX_HOPS = 10
+    hop_count = 0
+
+    try:
+        while current_node:
+            node_key = current_node.get_key()
+            if node_key in visited:
+                raise ValueError(f"Cycle detected at {node_key}")
+            visited.add(node_key)
+            hop_count += 1
+            if hop_count > MAX_HOPS:
+                raise ValueError(f"Max hops exceeded: {hop_count}")
+
+            config = current_node.get_config()
+            execution_path.append(node_key)
+
+            # Track handoff into this node
+            if graph_tracker and prev_node_key:
+                graph_tracker.track_handoff_success(prev_node_key, node_key)
+
+            # Compute valid routes from outgoing edges
+            edges = current_node.get_edges()
+            valid_routes = [
+                (edge.handoff or {}).get("route")
+                for edge in edges
+                if (edge.handoff or {}).get("route")
+            ]
+
+            # Execute this node — uses your existing agent-mode wiring
+            result = await run_node(config, shared_ctx, valid_routes=valid_routes)
+
+            # Per-node tool-call tracking lives on the node's config tracker
+            if result.get("tool_calls"):
+                for tool_name in result["tool_calls"]:
+                    config.tracker.track_tool_call(tool_name, graph_key=graph_key)
+
+            # Merge node result into shared context
+            update_shared_ctx(shared_ctx, result)
+
+            # Terminal?
+            if not edges or current_node.is_terminal():
+                break
+
+            # Pick next node by matching the node's routing_decision to an edge handoff
+            next_node = select_next_node(edges, result, nodes, graph_tracker, source_key=node_key)
+            prev_node_key = node_key
+            current_node = next_node
+
+        # Graph-level metrics
+        if graph_tracker:
+            graph_tracker.track_path(execution_path)
+            graph_tracker.track_latency(int((time.time() - start) * 1000))
+            if shared_ctx["total_input_tokens"] or shared_ctx["total_output_tokens"]:
+                graph_tracker.track_total_tokens(TokenUsage(
+                    input=shared_ctx["total_input_tokens"],
+                    output=shared_ctx["total_output_tokens"],
+                    total=shared_ctx["total_input_tokens"] + shared_ctx["total_output_tokens"],
+                ))
+            graph_tracker.track_invocation_success()
+
+    except Exception:
+        if graph_tracker:
+            graph_tracker.track_invocation_failure()
+        raise
+
+    return shared_ctx
+
+
+def select_next_node(edges, result, nodes, graph_tracker, source_key: str):
+    routing = result.get("routing_decision", "").lower().strip() if result.get("routing_decision") else None
+    route_map = {
+        (edge.handoff or {}).get("route", "").lower().strip(): edge.target_config
+        for edge in edges
+        if (edge.handoff or {}).get("route")
+    }
+
+    if routing and routing in route_map:
+        return nodes.get(route_map[routing])
+    if routing:
+        # Unrecognized route — signal failure with source + attempted target
+        if graph_tracker:
+            graph_tracker.track_handoff_failure(source_key, routing)
+    # Fallback: first edge
+    if edges:
+        return nodes.get(edges[0].target_config)
+    return None
+```
+
+## Migrating a multi-agent app to graphs
+
+Do this in phases, not one big bang:
+
+1. **Pick one worker node to migrate first.** Use the single-agent skill workflow on that worker in isolation — extract, wrap, tools, tracking, evals. Leave the rest of the multi-agent app hardcoded.
+2. **Confirm the wrapped worker runs in production** for the traffic it serves today, with metrics flowing in the Monitoring tab.
+3. **Migrate the supervisor** the same way — single-agent workflow — but keep its routing logic hardcoded initially (a big if/elif over the other workers).
+4. **Create the AI Graph in LaunchDarkly** via the UI. Define nodes (one per worker + supervisor) and edges (with `handoff.route` metadata).
+5. **Replace the hardcoded router** with the traversal pattern above. Call `ai_client.agent_graph(...)` instead of assembling the pipeline by hand.
+6. **Verify the Monitoring tab** shows the graph-level metrics (`track_path`, `track_latency`, `track_total_tokens`, handoff success/failure counts) in addition to the per-node metrics.
+7. **Only then** start moving routing decisions into LaunchDarkly edges and using targeting to change the graph topology per user segment.
+
+Each phase is reversible. If something breaks at phase 5, the supervisor can fall back to the hardcoded router while the graph issue is fixed.
+
+## Limitations to know about
+
+- **Python-only.** Repeating because it matters: Node cannot consume agent graphs today.
+- **`create_agent_graph` is experimental.** Do not build production features on `ManagedAgentGraph.run`. Use the traversal pattern above.
+- **Graph tracker is less granular than the config tracker.** If you want per-node duration or per-node token breakdowns, use the node's `config.tracker` — the graph tracker handles totals only.
+- **Cycles must be caught in your code.** The SDK does not stop cycle traversal automatically; track `visited` and `hop_count` yourself.
+- **Fallback shape.** There is no `AIAgentGraphDefault`. Each node's `AIAgentConfig` still takes an `AIAgentConfigDefault`, but the graph itself has no aggregate fallback. If `agent_graph` fails, handle it at the app level — typically by falling back to the hardcoded pre-migration pipeline.
+
+## Resources
+
+- Python SDK source: https://github.com/launchdarkly/python-server-sdk-ai
+  - `packages/sdk/server-ai/src/ldai/agent_graph/__init__.py` — `AgentGraphDefinition` and `AgentGraphNode`
+  - `packages/sdk/server-ai/src/ldai/tracker.py` — `AIGraphTracker` (near the bottom of the file)
+  - `packages/sdk/server-ai/src/ldai/client.py` — `LDAIClient.agent_graph` and `create_agent_graph`
+- Node SDK source (no graph support): https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai
+- Devrel reference implementation (Python, after PR alignment): https://github.com/launchdarkly-labs/devrel-agents-tutorial on the `tutorial/agent-graphs` branch

--- a/skills/ai-configs/aiconfig-migrate/references/agent-mode-frameworks.md
+++ b/skills/ai-configs/aiconfig-migrate/references/agent-mode-frameworks.md
@@ -1,0 +1,385 @@
+# Agent-Mode Frameworks
+
+How to wire an AI Config in **agent mode** into the frameworks that take a goal/instructions string: LangGraph, CrewAI, and custom ReAct loops. Also covers the **dynamic tool loading** pattern from the devrel-agents-tutorial — how to extract tool names from `config.tools` at runtime and instantiate the actual tool implementations without hardcoding.
+
+## When to pick agent mode
+
+Completion mode is the default and covers direct provider calls (OpenAI, Anthropic, Bedrock) where the app assembles a `messages` array. Pick **agent mode** when:
+
+| Signal | Framework | Example |
+|--------|-----------|---------|
+| Takes a `prompt` or `instructions` string as a single argument | LangGraph `create_react_agent` | `create_react_agent(model, tools, prompt="You are...")` |
+| Takes `role`, `goal`, `backstory` | CrewAI `Agent` | `Agent(role="researcher", goal="...", backstory="...")` |
+| Custom ReAct loop with a system instruction separated from messages | hand-rolled | `system = "You can use search..."; while not done: ...` |
+| Multi-step tool use with persistent instructions across turns | LangGraph / LangChain `AgentExecutor` | The system prompt stays stable across a long interaction |
+
+Agent mode returns an `instructions` string. Completion mode returns a `messages` array. Both modes support tools, parameters, and the same tracker — the only difference is the input shape the SDK returns to you.
+
+**Caveat:** judges cannot be attached to agent-mode variations via the LaunchDarkly UI. Agent mode evaluations must go through the programmatic judge API (`create_judge(...).evaluate(input, output)`). See `aiconfig-online-evals` for the programmatic path.
+
+## Wiring `agent_config` into each framework
+
+### LangGraph `create_react_agent`
+
+```python
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+from ldai.client import LDAIClient, AIAgentConfigDefault, ModelConfig, ProviderConfig
+
+FALLBACK = AIAgentConfigDefault(
+    enabled=True,
+    model=ModelConfig(name="gpt-4o", parameters={"temperature": 0.3}),
+    provider=ProviderConfig(name="openai"),
+    instructions="You are a helpful assistant.",
+)
+
+def build_agent(ai_client: LDAIClient, user_id: str, tools: list):
+    context = Context.builder(user_id).kind("user").build()
+    config = ai_client.agent_config("support-agent", context, FALLBACK)
+
+    if not config.enabled:
+        return None, None
+
+    params = config.model.parameters or {}
+    llm = ChatOpenAI(
+        model=config.model.name,
+        temperature=params.get("temperature", 0.3),
+    )
+
+    agent = create_react_agent(
+        model=llm,
+        tools=tools,
+        prompt=config.instructions,
+    )
+    return agent, config.tracker
+```
+
+**Key points:**
+- `prompt=config.instructions` — the instructions string replaces the hardcoded prompt
+- `model=` and `temperature=` come from `config.model`
+- The tracker is returned alongside the agent so the caller can wire Stage 4 tracking around `agent.invoke(...)`
+
+### CrewAI `Agent`
+
+```python
+from crewai import Agent
+from ldai.client import LDAIClient, AIAgentConfigDefault
+
+def build_crew_agent(ai_client, user_id: str):
+    context = Context.builder(user_id).kind("user").build()
+    config = ai_client.agent_config("researcher-agent", context, FALLBACK)
+
+    if not config.enabled:
+        return None
+
+    # CrewAI expects role/goal/backstory — split the instructions or store them
+    # in the AI Config as three variables and pipe them in at runtime.
+    return Agent(
+        role="Research Analyst",
+        goal="Produce a summary of recent AI Config adoption patterns.",
+        backstory=config.instructions,
+        llm=config.model.name,  # CrewAI accepts a string or a LangChain model
+    )
+```
+
+**Pattern note:** CrewAI's `Agent` takes three separate fields. If you want to drive all three from LaunchDarkly, either:
+- Use prompt **variables** on the AI Config (`{{role}}`, `{{goal}}`, `{{backstory}}`) and pass them as the `variables` argument to `agent_config(...)`
+- Or store a structured JSON blob in `instructions` and parse it in the app
+
+Prompt variables are cleaner and keep the AI Config human-readable in the UI.
+
+### Custom `StateGraph` (bind_tools + ToolNode)
+
+The most common LangGraph pattern in the wild is not `create_react_agent` — it's a custom `StateGraph` with a `call_model` node that does `model.bind_tools(TOOLS)`, a separate `"tools"` node that runs `ToolNode(TOOLS)`, and a conditional edge between them. This is the shape of the `langchain-ai/react-agent` template.
+
+Two things make it different from `create_react_agent`:
+
+1. **Tools appear in two places** — `bind_tools(TOOLS)` (so the LLM knows which tools exist) and `ToolNode(TOOLS)` (so the executor knows how to run them). Both must read from the same source.
+2. **The system prompt is injected manually** in the `call_model` node body (usually as the first message in the `ainvoke([{"role": "system", ...}, *state.messages])` call), not passed as a constructor argument.
+
+Before — the typical template shape (`src/react_agent/graph.py`, `src/react_agent/tools.py`, `src/react_agent/context.py`):
+
+```python
+# tools.py
+TOOLS: List[Callable[..., Any]] = [search]
+
+# context.py
+@dataclass(kw_only=True)
+class Context:
+    system_prompt: str = field(default=prompts.SYSTEM_PROMPT)
+    model: str = field(default="anthropic/claude-sonnet-4-5-20250929")
+
+# graph.py
+from .tools import TOOLS
+
+async def call_model(state: State, runtime: Runtime[Context]):
+    model = load_chat_model(runtime.context.model).bind_tools(TOOLS)
+    system_message = runtime.context.system_prompt.format(system_time=now_iso())
+    response = await model.ainvoke(
+        [{"role": "system", "content": system_message}, *state.messages]
+    )
+    return {"messages": [response]}
+
+builder = StateGraph(State, context_schema=Context)
+builder.add_node(call_model)
+builder.add_node("tools", ToolNode(TOOLS))
+builder.add_edge("__start__", "call_model")
+builder.add_conditional_edges("call_model", route_model_output)
+builder.add_edge("tools", "call_model")
+graph = builder.compile()
+```
+
+After — `call_model` reads from an AI Config fetched per invocation. `TOOLS` becomes a function that takes the config:
+
+```python
+# tools.py — unchanged module-level implementations, plus a factory
+TOOL_IMPLEMENTATIONS: Dict[str, Callable[..., Any]] = {"search": search}
+
+def build_tools_from_config(ai_config) -> List[Callable[..., Any]]:
+    """Instantiate tool callables for every tool name on the AI Config."""
+    names = [t.name if hasattr(t, "name") else t.get("name") for t in (ai_config.tools or [])]
+    return [TOOL_IMPLEMENTATIONS[name] for name in names if name in TOOL_IMPLEMENTATIONS]
+
+
+# context.py — kept as the fallback shape, not the primary source
+@dataclass(kw_only=True)
+class Context:
+    system_prompt: str = field(default=prompts.SYSTEM_PROMPT)
+    model: str = field(default="anthropic/claude-sonnet-4-5-20250929")
+    user_key: str = field(default="anonymous")  # for LD targeting context
+
+
+# graph.py
+from ldai.client import LDAIClient, AIAgentConfigDefault, ModelConfig, ProviderConfig
+from ldclient import Context as LDContext
+from .tools import build_tools_from_config, TOOL_IMPLEMENTATIONS
+
+def _build_fallback(ctx: Context) -> AIAgentConfigDefault:
+    """Reuse the existing Context defaults as the fallback."""
+    provider, _, model_name = ctx.model.partition("/")
+    return AIAgentConfigDefault(
+        enabled=True,
+        model=ModelConfig(name=model_name or ctx.model, parameters={}),
+        provider=ProviderConfig(name=provider or "anthropic"),
+        instructions=ctx.system_prompt.format(system_time=now_iso()),
+    )
+
+
+async def call_model(state: State, runtime: Runtime[Context]):
+    ld_context = LDContext.builder(runtime.context.user_key).kind("user").build()
+    ai_config = ai_client.agent_config(
+        "react-agent",
+        ld_context,
+        _build_fallback(runtime.context),
+    )
+
+    if not ai_config.enabled:
+        return {"messages": [AIMessage(content="")]}
+
+    tools = build_tools_from_config(ai_config)
+    model = load_chat_model(ai_config.model.name).bind_tools(tools)
+    instructions = ai_config.instructions
+
+    import time
+    start = time.time()
+    try:
+        response = cast(
+            AIMessage,
+            await model.ainvoke(
+                [{"role": "system", "content": instructions}, *state.messages]
+            ),
+        )
+        ai_config.tracker.track_duration(int((time.time() - start) * 1000))
+        ai_config.tracker.track_success()
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            from ldai.tracker import TokenUsage
+            ai_config.tracker.track_tokens(TokenUsage(
+                input=response.usage_metadata.get("input_tokens", 0),
+                output=response.usage_metadata.get("output_tokens", 0),
+                total=response.usage_metadata.get("total_tokens", 0),
+            ))
+    except Exception:
+        ai_config.tracker.track_error()
+        raise
+
+    # Stash tools on state so the "tools" node picks up the same list
+    return {"messages": [response], "_active_tools": tools}
+
+
+def build_tools_node_factory():
+    """Return a ToolNode factory that reads tools from state."""
+    def dynamic_tools_node(state: State):
+        tools = getattr(state, "_active_tools", None) or list(TOOL_IMPLEMENTATIONS.values())
+        return ToolNode(tools).invoke(state)
+    return dynamic_tools_node
+
+
+builder = StateGraph(State, context_schema=Context)
+builder.add_node(call_model)
+builder.add_node("tools", build_tools_node_factory())
+builder.add_edge("__start__", "call_model")
+builder.add_conditional_edges("call_model", route_model_output)
+builder.add_edge("tools", "call_model")
+graph = builder.compile()
+```
+
+**What changed:**
+
+- `TOOLS` (a static list) → `TOOL_IMPLEMENTATIONS` (a name-to-callable dict) + `build_tools_from_config(ai_config)` (a per-request builder). This is the dynamic tool factory pattern from the devrel-agents-tutorial, adapted to plain callables.
+- `call_model` fetches an `AIAgentConfig` per invocation, builds tools from `ai_config.tools`, binds them, and injects `ai_config.instructions` as the system message (replacing `runtime.context.system_prompt`).
+- The `"tools"` node is replaced with a factory that reads the active tool list from state — so both `bind_tools` and `ToolNode` always run against the same list. If you skip this step and leave `ToolNode(TOOLS)` hardcoded, the LLM and the executor will disagree on what's available and the graph will misbehave.
+- Tracker calls wrap the provider call inside `call_model`. On Node, use `trackDuration` / `trackSuccess` / `trackTokens` or `trackOpenAIMetrics` via the helper package.
+- The existing `Context` dataclass is kept as the fallback shape — its defaults become the `AIAgentConfigDefault` values, so the app still runs exactly as before when LaunchDarkly is unreachable.
+
+**Gotcha:** the `"tools"` node above reads `_active_tools` from state. That means your `State` TypedDict has to include it. If it doesn't, either add the field, or take the simpler route of fetching the AI Config **once at graph-compile time** (at module load) and accepting that tool changes require a restart. The per-invocation pattern above is strictly better but adds one state field.
+
+### Custom ReAct loop
+
+```python
+def build_react_loop(ai_client, user_id: str):
+    context = Context.builder(user_id).kind("user").build()
+    config = ai_client.agent_config("custom-react", context, FALLBACK)
+
+    if not config.enabled:
+        return
+
+    system_prompt = config.instructions
+    model_name = config.model.name
+    tracker = config.tracker
+
+    for turn in range(MAX_TURNS):
+        start = time.time()
+        response = my_provider.complete(
+            model=model_name,
+            system=system_prompt,
+            messages=history,
+            tools=config.tools,  # see dynamic-tool loading below
+        )
+        tracker.track_duration(int((time.time() - start) * 1000))
+        tracker.track_tokens(extract_tokens(response))
+        # ... handle tool calls, append to history, check done ...
+
+    tracker.track_success()
+```
+
+The call site stays in your control; the AI Config just delivers `instructions`, `model.name`, `model.parameters`, and `tools`. Everything else (the loop, the history, the tool dispatch) is unchanged.
+
+## Dynamic tool loading — the "tools factory" pattern
+
+The devrel-agents-tutorial uses a **dynamic tool factory** that reads tool names from `config.tools` and instantiates the actual tool implementations at runtime. This decouples the AI Config (which holds tool metadata) from the application (which holds the executable code).
+
+### The pattern
+
+```python
+# tools_impl/dynamic_tool_factory.py — adapted from devrel-agents-tutorial
+
+def extract_tool_names(config) -> list[str]:
+    """Read the list of tool names from the AI Config."""
+    if not hasattr(config, "tools") or not config.tools:
+        return []
+    return [tool.name if hasattr(tool, "name") else tool.get("name") for tool in config.tools]
+
+
+def create_dynamic_tools_from_launchdarkly(config) -> list:
+    """Instantiate tool implementations for every tool name on the config."""
+    tool_names = extract_tool_names(config)
+    instances = []
+    for name in tool_names:
+        tool = _create_tool_instance(name)
+        if tool is not None:
+            instances.append(tool)
+    return instances
+
+
+def _create_tool_instance(tool_name: str):
+    """Map a tool name to an actual implementation. Add one branch per tool."""
+    if tool_name == "search_kb":
+        from my_tools.search import SearchKBTool
+        return SearchKBTool()
+    elif tool_name == "calculator":
+        from my_tools.calc import CalculatorTool
+        return CalculatorTool()
+    # ... etc
+    return None
+```
+
+Then at the call site:
+
+```python
+config = ai_client.agent_config("support-agent", context, FALLBACK)
+tools = create_dynamic_tools_from_launchdarkly(config)
+
+agent = create_react_agent(
+    model=build_llm(config),
+    tools=tools,
+    prompt=config.instructions,
+)
+```
+
+**What this gives you:**
+
+- Toggle a tool on/off by editing the AI Config in LaunchDarkly — no redeploy needed to remove a tool from production
+- Roll out a new tool to 5% of users by editing targeting rules (combined with `aiconfig-targeting`)
+- Keep the actual tool implementation code in the repo; only metadata lives in LaunchDarkly
+
+### Extracting schemas from existing hardcoded tools
+
+If your tools are defined with LangChain `@tool` or Pydantic `BaseModel` schemas, extract the JSON schema programmatically to pass to `aiconfig-tools` during Stage 3:
+
+```python
+from my_tools import search_kb  # a @tool-decorated function
+
+schema = search_kb.args_schema.model_json_schema()
+# schema is a dict ready to pass as the tool's parameters field
+```
+
+Do not hand-write the schema — LangChain already generated it from the function signature, and Pydantic will keep it in sync. The `aiconfig-tools` delegate accepts raw JSON Schema for the parameters field.
+
+### Dynamic schemas from LaunchDarkly
+
+The devrel tutorial also shows the reverse: reading a JSON schema **from** the AI Config and constructing a Pydantic model at runtime:
+
+```python
+from pydantic import BaseModel, Field, create_model
+
+def _create_dynamic_tool_input(tool_config: dict) -> type[BaseModel]:
+    """Build a Pydantic input schema from an AI Config tool's parameters."""
+    properties = tool_config.get("properties", {})
+    fields = {}
+    for name, cfg in properties.items():
+        py_type = {"string": str, "number": float, "integer": int, "boolean": bool}.get(
+            cfg.get("type"), str
+        )
+        default = ... if name in tool_config.get("required", []) else None
+        fields[name] = (py_type, Field(default=default, description=cfg.get("description", "")))
+    return create_model("DynamicToolInput", **fields)
+```
+
+This lets LaunchDarkly change a tool's parameter schema without redeploying the app. Use it when the tool implementation is generic enough to accept any parameter shape (e.g. a proxy that forwards requests to an external API). For most tools, a static Pydantic schema in the repo is simpler.
+
+## Routing / multi-node hint
+
+If the framework needs to pick between multiple downstream agents (e.g. a supervisor that routes to a security agent or a support agent based on the user input), do **not** roll your own routing. Use LaunchDarkly agent graphs — the graph's edges carry the routing contract, and the supervisor's `instructions` can be auto-injected with the valid routes.
+
+The devrel tutorial's `generic_agent.py` shows a minimal version of this:
+
+```python
+# If this node has outgoing edges with routes, inject them into instructions
+if self.valid_routes:
+    route_instruction = (
+        f"\n\nYou must select one of these routes: {self.valid_routes}. "
+        f'Return your choice in JSON format: {{"route": "<selected_route>"}}'
+    )
+    instructions = instructions + route_instruction
+```
+
+For the full graph pattern, read [agent-graph-reference.md](agent-graph-reference.md) — but again, single-agent migration comes first, and agent graphs are currently **Python-only** in the SDK.
+
+## Keep the provider call in the repo
+
+One rule that applies across all three frameworks: the **provider SDK call** (OpenAI, Anthropic, Bedrock) stays in your code. The AI Config only changes the inputs to that call — model name, instructions, parameters, tool list. It does not replace the provider SDK. That means:
+
+- You keep full control of error handling, retries, timeouts, custom headers
+- You keep full control of streaming logic and backpressure
+- You keep full control of authentication (API keys, IAM roles, Bedrock Converse sessions)
+- The AI Config is additive — removing it gets you back to the original hardcoded app, provided the fallback mirrors the old values

--- a/skills/ai-configs/aiconfig-migrate/references/before-after-examples.md
+++ b/skills/ai-configs/aiconfig-migrate/references/before-after-examples.md
@@ -1,0 +1,268 @@
+# Before/After Examples
+
+Paired code snippets for the Stage 2 call-site swap. Each example shows the same call before extraction and after wrapping with the LaunchDarkly AI SDK. Tools and tracking are deliberately **not** shown here — they are layered on in Stages 3 and 4. See [sdk-ai-tracker-patterns.md](sdk-ai-tracker-patterns.md) for the tracking overlay and [agent-mode-frameworks.md](agent-mode-frameworks.md) for the tool-loading pattern.
+
+---
+
+## Example 1: Python + OpenAI — completion mode
+
+A typical one-shot chat app. Hardcoded model, temperature, max tokens, and system prompt.
+
+### Before
+
+```python
+from openai import OpenAI
+
+openai_client = OpenAI()
+
+def answer(user_question: str) -> str:
+    response = openai_client.chat.completions.create(
+        model="gpt-4o",
+        temperature=0.7,
+        max_tokens=2000,
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant. Answer concisely."},
+            {"role": "user", "content": user_question},
+        ],
+    )
+    return response.choices[0].message.content
+```
+
+### After
+
+```python
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldai.client import LDAIClient, AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
+from openai import OpenAI
+
+openai_client = OpenAI()
+
+ldclient.set_config(Config(os.environ["LD_SDK_KEY"]))
+ai_client = LDAIClient(ldclient.get())
+
+# Fallback mirrors the hardcoded values that were removed.
+FALLBACK = AICompletionConfigDefault(
+    enabled=True,
+    model=ModelConfig(
+        name="gpt-4o",
+        parameters={"temperature": 0.7, "maxTokens": 2000},
+    ),
+    provider=ProviderConfig(name="openai"),
+    messages=[LDMessage(role="system", content="You are a helpful assistant. Answer concisely.")],
+)
+
+def answer(user_id: str, user_question: str) -> str:
+    context = Context.builder(user_id).kind("user").build()
+    config = ai_client.completion_config("chat-assistant", context, FALLBACK)
+
+    if not config.enabled:
+        return ""  # handle disabled path
+
+    params = config.model.parameters or {}
+    response = openai_client.chat.completions.create(
+        model=config.model.name,
+        temperature=params.get("temperature"),
+        max_tokens=params.get("maxTokens"),
+        messages=[m.to_dict() for m in (config.messages or [])] + [
+            {"role": "user", "content": user_question},
+        ],
+    )
+    return response.choices[0].message.content
+```
+
+### What changed
+
+- Model/params/prompt no longer appear as string literals — they come from `config.model.name`, `config.model.parameters`, and `config.messages`
+- `LDAIClient` is initialized once at import time
+- A `Context` is built per request from `user_id` (targeting happens here)
+- Fallback is an `AICompletionConfigDefault` that mirrors the removed hardcoded values
+- `config.enabled` is checked before calling the provider
+- The provider call itself is unchanged — same `openai_client.chat.completions.create`, same return shape
+
+---
+
+## Example 2: Node.js + Anthropic — completion mode
+
+Anthropic separates the system message from the messages array, so this example shows the `convertToAnthropicFormat` helper used in the relaunch guide.
+
+### Before
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic();
+
+export async function answer(userQuestion: string): Promise<string> {
+  const response = await anthropic.messages.create({
+    model: 'claude-sonnet-4-5',
+    max_tokens: 1024,
+    system: 'You are a helpful assistant. Answer concisely.',
+    messages: [{ role: 'user', content: userQuestion }],
+  });
+  const text = response.content.find((b) => b.type === 'text');
+  return text?.type === 'text' ? text.text : '';
+}
+```
+
+### After
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { init, LDContext } from '@launchdarkly/node-server-sdk';
+import { initAi, LDAICompletionConfigDefault } from '@launchdarkly/server-sdk-ai';
+
+const anthropic = new Anthropic();
+const ldClient = init(process.env.LD_SDK_KEY!);
+await ldClient.waitForInitialization({ timeout: 10 });
+const aiClient = initAi(ldClient);
+
+const FALLBACK: LDAICompletionConfigDefault = {
+  enabled: true,
+  model: {
+    name: 'claude-sonnet-4-5',
+    parameters: { maxTokens: 1024 },
+  },
+  provider: { name: 'anthropic' },
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant. Answer concisely.' },
+  ],
+};
+
+function convertToAnthropicFormat(ldMessages?: Array<{ role: string; content: string }>) {
+  let systemMessage: string | undefined;
+  const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+  for (const msg of ldMessages ?? []) {
+    if (msg.role === 'system') {
+      systemMessage = msg.content;
+    } else {
+      messages.push({ role: msg.role as 'user' | 'assistant', content: msg.content });
+    }
+  }
+  return { systemMessage, messages };
+}
+
+export async function answer(userId: string, userQuestion: string): Promise<string> {
+  const context: LDContext = { kind: 'user', key: userId };
+  const aiConfig = await aiClient.completionConfig('chat-assistant', context, FALLBACK);
+
+  if (!aiConfig.enabled) return '';
+
+  const { systemMessage, messages } = convertToAnthropicFormat(aiConfig.messages);
+  messages.push({ role: 'user', content: userQuestion });
+
+  const response = await anthropic.messages.create({
+    model: aiConfig.model?.name ?? 'claude-sonnet-4-5',
+    max_tokens: (aiConfig.model?.parameters?.maxTokens as number) ?? 1024,
+    system: systemMessage,
+    messages,
+  });
+
+  const text = response.content.find((b) => b.type === 'text');
+  return text?.type === 'text' ? text.text : '';
+}
+```
+
+### What changed
+
+- Hardcoded model + system prompt + `max_tokens` are gone
+- `initAi(ldClient)` wraps the base client once at import
+- `convertToAnthropicFormat` hoists the system message out of the `LDMessage` array (since Anthropic takes `system` as a top-level param, not a role in `messages`)
+- `aiConfig.enabled` is checked; the disabled path returns an empty string
+- Provider call is otherwise unchanged
+
+---
+
+## Example 3: Python + LangGraph — agent mode
+
+`create_react_agent` takes `model`, `tools`, and `prompt` as inputs — a natural fit for **agent mode**. The `instructions` string replaces the hardcoded `prompt` argument. Tools remain hardcoded for now (Stage 3 will move them into the config too).
+
+### Before
+
+```python
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+from my_tools import search_kb, calculator
+
+llm = ChatOpenAI(model="gpt-4o", temperature=0.3)
+
+agent = create_react_agent(
+    model=llm,
+    tools=[search_kb, calculator],
+    prompt=(
+        "You are a technical support assistant. Use the search_kb tool to look up "
+        "documentation, and the calculator tool for math. Always cite sources."
+    ),
+)
+
+def run_support(user_question: str) -> str:
+    result = agent.invoke({"messages": [{"role": "user", "content": user_question}]})
+    return result["messages"][-1].content
+```
+
+### After
+
+```python
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldai.client import LDAIClient, AIAgentConfigDefault, ModelConfig, ProviderConfig
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+from my_tools import search_kb, calculator
+
+ldclient.set_config(Config(os.environ["LD_SDK_KEY"]))
+ai_client = LDAIClient(ldclient.get())
+
+FALLBACK = AIAgentConfigDefault(
+    enabled=True,
+    model=ModelConfig(name="gpt-4o", parameters={"temperature": 0.3}),
+    provider=ProviderConfig(name="openai"),
+    instructions=(
+        "You are a technical support assistant. Use the search_kb tool to look up "
+        "documentation, and the calculator tool for math. Always cite sources."
+    ),
+)
+
+def run_support(user_id: str, user_question: str) -> str:
+    context = Context.builder(user_id).kind("user").build()
+    config = ai_client.agent_config("support-agent", context, FALLBACK)
+
+    if not config.enabled:
+        return ""
+
+    params = config.model.parameters or {}
+    llm = ChatOpenAI(
+        model=config.model.name,
+        temperature=params.get("temperature", 0.3),
+    )
+
+    agent = create_react_agent(
+        model=llm,
+        tools=[search_kb, calculator],   # Stage 3 will replace this with config.tools loader
+        prompt=config.instructions,
+    )
+
+    result = agent.invoke({"messages": [{"role": "user", "content": user_question}]})
+    return result["messages"][-1].content
+```
+
+### What changed
+
+- `agent_config()` is called instead of `completion_config()` because the framework expects an `instructions` string
+- `FALLBACK` is an `AIAgentConfigDefault` (note the different type — same fields as completion except `instructions` instead of `messages`)
+- `ChatOpenAI(model=..., temperature=...)` reads both from `config.model`
+- `create_react_agent(prompt=...)` reads from `config.instructions`
+- Tool list is still hardcoded — Stage 3 handles that move (see [agent-mode-frameworks.md](agent-mode-frameworks.md) for the dynamic-tool-factory pattern)
+- Provider-side logic (LangGraph, ReAct loop) is unchanged
+
+---
+
+## Rules of thumb across all three examples
+
+1. **Nothing is added to the business logic.** The provider call, the framework call, the return shape — all unchanged. Only the *source* of model/prompt/params moves.
+2. **Fallback is built from the values you removed.** If the hardcoded model is `gpt-4o`, the fallback model is `gpt-4o`. If the hardcoded temperature is `0.7`, the fallback temperature is `0.7`. Behavior on LaunchDarkly unreachable must be indistinguishable from pre-migration behavior.
+3. **Build a `Context` per request.** The context carries targeting inputs — user ID, plan tier, region, whatever the rollout is keyed on. Reuse the same context the app already uses for feature flag evaluation if one exists.
+4. **Always check `config.enabled`.** Even a successful `completion_config` call can return a disabled config (if the variation is turned off in LaunchDarkly). The disabled path should not call the provider.
+5. **Do not cache the config object across requests.** Call `completion_config` / `agent_config` inside the request handler so LaunchDarkly can re-evaluate targeting per call. One `LDAIClient` instance, many `completion_config` calls.

--- a/skills/ai-configs/aiconfig-migrate/references/fallback-defaults-pattern.md
+++ b/skills/ai-configs/aiconfig-migrate/references/fallback-defaults-pattern.md
@@ -1,0 +1,271 @@
+# Fallback Defaults Pattern
+
+Every `completion_config` / `agent_config` call takes a fallback. The fallback runs when LaunchDarkly is unreachable, the SDK is disabled, or the returned config has `enabled=False`. **It must mirror the hardcoded values you removed** so behavior is unchanged if LaunchDarkly is unavailable.
+
+This doc covers three patterns in order of sophistication. Pick the one that matches the size of the app and the number of AI Configs it uses.
+
+## Pattern 1: Inline fallback (start here)
+
+One config key, one fallback constant. Best for apps with a handful of AI Configs or a single call site.
+
+### Python — completion mode
+
+```python
+from ldai.client import (
+    AICompletionConfigDefault,
+    ModelConfig,
+    ProviderConfig,
+    LDMessage,
+)
+
+CHAT_FALLBACK = AICompletionConfigDefault(
+    enabled=True,
+    model=ModelConfig(
+        name="gpt-4o",
+        parameters={"temperature": 0.7, "maxTokens": 2000},
+    ),
+    provider=ProviderConfig(name="openai"),
+    messages=[
+        LDMessage(role="system", content="You are a helpful assistant. Answer concisely."),
+    ],
+)
+
+# Later in the request handler:
+config = ai_client.completion_config("chat-assistant", context, CHAT_FALLBACK)
+```
+
+### Python — agent mode
+
+```python
+from ldai.client import (
+    AIAgentConfigDefault,
+    ModelConfig,
+    ProviderConfig,
+)
+
+SUPPORT_AGENT_FALLBACK = AIAgentConfigDefault(
+    enabled=True,
+    model=ModelConfig(
+        name="gpt-4o",
+        parameters={"temperature": 0.3},
+    ),
+    provider=ProviderConfig(name="openai"),
+    instructions=(
+        "You are a technical support assistant. Use the search_kb tool to look up "
+        "documentation, and the calculator tool for math. Always cite sources."
+    ),
+)
+
+# Later in the request handler:
+config = ai_client.agent_config("support-agent", context, SUPPORT_AGENT_FALLBACK)
+```
+
+### Node — completion mode
+
+```typescript
+import { LDAICompletionConfigDefault } from '@launchdarkly/server-sdk-ai';
+
+const CHAT_FALLBACK: LDAICompletionConfigDefault = {
+  enabled: true,
+  model: {
+    name: 'gpt-4o',
+    parameters: { temperature: 0.7, maxTokens: 2000 },
+  },
+  provider: { name: 'openai' },
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant. Answer concisely.' },
+  ],
+};
+
+const aiConfig = await aiClient.completionConfig('chat-assistant', context, CHAT_FALLBACK);
+```
+
+### Node — agent mode
+
+```typescript
+import { LDAIAgentConfigDefault } from '@launchdarkly/server-sdk-ai';
+
+const SUPPORT_AGENT_FALLBACK: LDAIAgentConfigDefault = {
+  enabled: true,
+  model: {
+    name: 'gpt-4o',
+    parameters: { temperature: 0.3 },
+  },
+  provider: { name: 'openai' },
+  instructions:
+    'You are a technical support assistant. Use the search_kb tool to look up documentation, and the calculator tool for math. Always cite sources.',
+};
+
+const agent = await aiClient.agentConfig('support-agent', context, SUPPORT_AGENT_FALLBACK);
+```
+
+### When to use inline
+
+- Fewer than ~5 AI Configs in the app
+- Fallback values don't change often (or change in lockstep with code deploys)
+- You want every fallback visible in a single source file for easy review
+
+## Pattern 2: File-backed defaults
+
+A JSON/YAML file holds every config's fallback; a loader at startup builds the default objects. Best for apps with many AI Configs or where the fallback needs to be environment-specific.
+
+### File shape
+
+```json
+{
+  "_metadata": {
+    "environment": "production",
+    "generated_at": "2026-04-14"
+  },
+  "configs": {
+    "chat-assistant": {
+      "mode": "completion",
+      "enabled": true,
+      "model": {
+        "name": "gpt-4o",
+        "parameters": { "temperature": 0.7, "maxTokens": 2000 }
+      },
+      "provider": { "name": "openai" },
+      "messages": [
+        { "role": "system", "content": "You are a helpful assistant. Answer concisely." }
+      ]
+    },
+    "support-agent": {
+      "mode": "agent",
+      "enabled": true,
+      "model": {
+        "name": "gpt-4o",
+        "parameters": { "temperature": 0.3 }
+      },
+      "provider": { "name": "openai" },
+      "instructions": "You are a technical support assistant. Use the search_kb tool..."
+    }
+  }
+}
+```
+
+### Python loader
+
+Adapted from `devrel-agents-tutorial/config_manager.py`:
+
+```python
+import json
+from pathlib import Path
+from ldai.client import (
+    AICompletionConfigDefault,
+    AIAgentConfigDefault,
+    ModelConfig,
+    ProviderConfig,
+    LDMessage,
+)
+
+
+class FallbackLoader:
+    def __init__(self, path: str = ".ai_config_defaults.json"):
+        data = json.loads(Path(path).read_text())
+        self.configs = data.get("configs", {})
+
+    def get(self, config_key: str):
+        if config_key not in self.configs:
+            raise ValueError(
+                f"Fallback for '{config_key}' not found in defaults file. "
+                f"Available: {list(self.configs.keys())}"
+            )
+        entry = self.configs[config_key]
+        mode = entry.get("mode", "completion")
+
+        common = dict(
+            enabled=entry.get("enabled", True),
+            model=ModelConfig(
+                name=entry["model"]["name"],
+                parameters=entry["model"].get("parameters", {}),
+            ),
+            provider=ProviderConfig(name=entry["provider"]["name"]),
+        )
+
+        if mode == "agent":
+            return AIAgentConfigDefault(
+                **common,
+                instructions=entry.get("instructions", ""),
+            )
+        else:
+            return AICompletionConfigDefault(
+                **common,
+                messages=[LDMessage(**m) for m in entry.get("messages", [])],
+            )
+
+
+# Usage
+fallbacks = FallbackLoader()
+config = ai_client.completion_config(
+    "chat-assistant",
+    context,
+    fallbacks.get("chat-assistant"),
+)
+```
+
+### When to use file-backed
+
+- 5+ AI Configs, each with its own fallback
+- Fallback values are derived from the current LaunchDarkly state (see Pattern 3 for generation)
+- You want a single commit to update all fallbacks at once
+- You want different default files per environment (dev vs staging vs prod)
+
+## Pattern 3: Bootstrap-generated defaults
+
+A script fetches the current state of every AI Config from LaunchDarkly and writes the file used by Pattern 2. Best for large apps where keeping fallbacks in sync by hand is a maintenance burden.
+
+The devrel-agents-tutorial has a `bootstrap/create_configs.py` script that does this end-to-end: it creates the AI Configs in LaunchDarkly from a YAML manifest, then writes the `.ai_config_defaults.json` file that the app loads at startup. Use it as prior art — do not reproduce it inline.
+
+### Sketch
+
+```python
+# bootstrap/generate_defaults.py
+import json
+from launchdarkly_api import ApiClient  # or use the MCP server tools
+
+def dump_defaults(api_token: str, project_key: str, environment: str) -> dict:
+    client = ApiClient(api_token)
+    configs = client.list_ai_configs(project_key)
+
+    out = {
+        "_metadata": {"environment": environment, "generated_at": today()},
+        "configs": {},
+    }
+    for cfg in configs:
+        variation = pick_default_variation(cfg, environment)
+        out["configs"][cfg.key] = {
+            "mode": cfg.mode,
+            "enabled": variation.enabled,
+            "model": {"name": variation.model.name, "parameters": variation.model.parameters},
+            "provider": {"name": variation.provider.name},
+            "instructions": variation.instructions if cfg.mode == "agent" else None,
+            "messages": variation.messages if cfg.mode == "completion" else None,
+        }
+
+    return out
+```
+
+### Hooks
+
+- Run the script in CI on every merge to main, commit the updated file
+- Or run it on deploy to bake the file into the container image
+- Or run it manually when you know an AI Config has changed meaningfully
+
+### When to use bootstrap-generated
+
+- 20+ AI Configs
+- You want fallbacks to track production state automatically
+- You have CI capacity to run the generator and commit the file
+
+### Trade-off
+
+Fallback drift is a feature, not a bug. If you regenerate on every deploy, a stale fallback (one that missed a recent production change) only shows up when LaunchDarkly is unreachable — an already-degraded path. If you would rather the fallback be *exactly* the last-shipped production value, regenerate on deploy. If you would rather the fallback be *exactly* the original hardcoded value, use Pattern 1 or commit the file once and never regenerate.
+
+## Critical rules (apply to all three patterns)
+
+1. **Fallback mirrors pre-migration behavior.** If the hardcoded model was `gpt-4o`, the fallback model is `gpt-4o`. If the hardcoded temperature was `0.7`, the fallback temperature is `0.7`. The fallback is the contract that says "app behavior doesn't change if LaunchDarkly is unreachable."
+2. **Always set `enabled=True` in the fallback.** If the fallback has `enabled=False`, the disabled path runs every time LaunchDarkly is unreachable — an outage escalates into a full service outage. Make the fallback a real, working config unless the feature is explicitly off-by-default.
+3. **Fallback must be a fully-specified `AICompletionConfigDefault` / `AIAgentConfigDefault`.** Do not pass `AICompletionConfigDefault(enabled=False)` as a "placeholder" — the SDK will not synthesize missing fields. You must supply `model`, `provider`, and `messages`/`instructions` if `enabled=True`.
+4. **Do not delete the fallback after migration.** It is required for the `enabled=False` path and for SDK-unreachable scenarios. Treat it as load-bearing production code, not scaffolding.
+5. **Keep fallback type imports stable.** `AICompletionConfigDefault` is for completion mode; `AIAgentConfigDefault` is for agent mode. Using the wrong one will fail at runtime when the SDK tries to coerce the fallback.

--- a/skills/ai-configs/aiconfig-migrate/references/phase-1-analysis-checklist.md
+++ b/skills/ai-configs/aiconfig-migrate/references/phase-1-analysis-checklist.md
@@ -1,0 +1,140 @@
+# Phase 1 Analysis Checklist
+
+A read-only audit the skill runs in **Step 1** before touching any code. Do not write files, install packages, or create LaunchDarkly resources during this phase. Produce a structured summary and stop for user confirmation.
+
+## What to scan
+
+### 1. Dependency manifests (most reliable signal)
+
+Check the top-level files for the target service:
+
+| Language | Files |
+|----------|-------|
+| Python | `pyproject.toml`, `requirements.txt`, `setup.py`, `Pipfile`, `uv.lock` |
+| TypeScript / JavaScript | `package.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| Go | `go.mod`, `go.sum` |
+| Ruby | `Gemfile`, `Gemfile.lock` |
+| .NET | `*.csproj`, `packages.config` |
+
+Extract: language, package manager, and any LLM provider SDKs already installed.
+
+### 2. Provider imports
+
+Grep the source tree for provider SDK imports so you know which one the app actually uses (dependencies can be unused):
+
+| Provider | Python grep | TypeScript/JS grep |
+|----------|-------------|---------------------|
+| OpenAI | `from openai`, `import openai` | `from 'openai'`, `require('openai')` |
+| Anthropic | `from anthropic`, `import anthropic` | `from '@anthropic-ai/sdk'` |
+| Bedrock | `import boto3`, `bedrock-runtime` | `@aws-sdk/client-bedrock-runtime` |
+| Gemini | `from google import genai`, `google.generativeai` | `@google/generative-ai` |
+| LangChain | `from langchain`, `langchain_openai`, `langchain_anthropic` | `langchain`, `@langchain/openai` |
+| LangGraph | `from langgraph`, `create_react_agent` | `@langchain/langgraph` |
+| CrewAI | `from crewai` | — |
+
+### 3. Hardcoded model configs
+
+Look for the three things that need to move into the AI Config:
+
+1. **Model name** — grep for string literals:
+   - `"gpt-4o"`, `"gpt-4o-mini"`, `"gpt-4-turbo"`, `"o1"`, `"o1-mini"`
+   - `"claude-opus-"`, `"claude-sonnet-"`, `"claude-haiku-"`, `"claude-3-"`
+   - `"gemini-"`, `"mistral-"`, `"meta.llama"`, `"anthropic.claude-"`
+2. **Parameters** — grep for keys: `temperature=`, `max_tokens=`, `maxTokens:`, `top_p=`, `topP:`, `top_k=`, `stop_sequences=`
+3. **System prompts / instructions** — grep for:
+   - `"role": "system"` (OpenAI/Anthropic completion)
+   - `system="` or `system:` (Anthropic top-level system)
+   - `instructions="` (agent frameworks, CrewAI, LangGraph `create_react_agent(prompt=)`)
+   - Long triple-quoted strings above provider calls
+
+For each hit, record the file path, line number, and current value.
+
+### 4. Existing LaunchDarkly SDK usage
+
+If `LDClient` / `ldclient` is already initialized in the codebase, **reuse it** — do not create a second base client in Stage 2. Grep for:
+
+- Python: `import ldclient`, `ldclient.set_config`, `ldclient.get()`
+- TypeScript/JS: `@launchdarkly/node-server-sdk`, `init(LD_SDK_KEY)`, `@launchdarkly/react-client-sdk`
+- Environment variables: `LD_SDK_KEY`, `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_API_KEY`
+
+### 5. Mode decision: completion or agent
+
+Walk the decision tree once per call site, using the call shape as the primary signal:
+
+| Call shape | Mode |
+|------------|------|
+| `openai.chat.completions.create(messages=[...])` | **completion** |
+| `anthropic.messages.create(system=..., messages=[...])` | **completion** |
+| `bedrock.converse(messages=[...])` | **completion** |
+| `create_react_agent(llm, tools, prompt=...)` | **agent** |
+| `Agent(role=..., goal=..., backstory=...)` (CrewAI) | **agent** |
+| Custom react loop: LLM-call → tool-call → LLM-call | **agent** |
+| One-shot `llm.invoke("some question")` | **completion** |
+
+**Default to completion mode** when unclear — it is more flexible and is the only mode that supports judges attached via the LaunchDarkly UI (Stage 5).
+
+### 6. Monorepo / multi-service scope
+
+If the repo contains multiple services, **ask the user which service to instrument**. Do not migrate every service in one pass.
+
+## SDK routing table
+
+Feeds into Stage 2 (install + wrap). Quoted from the `ai-configs-relaunch-guides/AGENT-SETUP-PROMPT.md` SDK routing table.
+
+| Language | Base SDK | AI SDK | Docs |
+|----------|----------|--------|------|
+| Node.js / TypeScript | `@launchdarkly/node-server-sdk` | `@launchdarkly/server-sdk-ai` | https://docs.launchdarkly.com/sdk/ai/node-js |
+| Python | `launchdarkly-server-sdk` | `launchdarkly-server-sdk-ai` | https://docs.launchdarkly.com/sdk/ai/python |
+| Go | `github.com/launchdarkly/go-server-sdk/v7` | `github.com/launchdarkly/go-server-sdk/ldai` | https://docs.launchdarkly.com/sdk/ai/go |
+| Ruby | `launchdarkly-server-sdk` | `launchdarkly-server-sdk-ai` | https://docs.launchdarkly.com/sdk/ai/ruby |
+| .NET | `LaunchDarkly.ServerSdk` | `LaunchDarkly.ServerSdk.Ai` | https://docs.launchdarkly.com/sdk/ai/dotnet |
+
+**Node.js provider-specific helper packages** (optional, for auto-tracking in Stage 4):
+
+| Provider | Package | Helper |
+|----------|---------|--------|
+| OpenAI | `@launchdarkly/server-sdk-ai-openai` | `OpenAIProvider.createAIMetrics` + `trackMetricsOf` |
+| LangChain | `@launchdarkly/server-sdk-ai-langchain` | **Manual today** — no single-call auto-helper. Use `tracker.trackDuration` + `trackTokens` + `trackSuccess`/`trackError` around `ainvoke`. |
+| Vercel AI SDK | `@launchdarkly/server-sdk-ai-vercel` | `trackVercelAISDKGenerateTextMetrics` |
+
+Python currently ships helper packages for OpenAI (`ldai_openai`) and LangChain (`ldai_langchain`). The LangChain Python package exposes runner classes (`LangChainModelRunner`, `LangChainAgentRunner`, `LangGraphAgentGraphRunner`) and helper functions (`get_ai_metrics_from_response`, `get_ai_usage_from_response`) — **not** a single-node callback handler. For single-node LangChain calls, use manual tracker wiring with `response.usage_metadata`. See [sdk-ai-tracker-patterns.md](sdk-ai-tracker-patterns.md) for the full matrix and the manual snippet.
+
+## Phase 1 output format
+
+Return this shape to the user, then **stop and wait for confirmation**:
+
+```
+Service:             <service name / path>
+Language:            <Python 3.12 / Node.js 20 / Go 1.22 / ...>
+Package manager:     <uv / poetry / pnpm / go mod / ...>
+LLM provider:        <OpenAI / Anthropic / Bedrock / LangChain + OpenAI / ...>
+Existing LD SDK:     <none / launchdarkly-server-sdk already initialized at src/ld.py:12>
+Target mode:         <completion / agent>
+
+Hardcoded migration targets:
+  - <file>:<line>   model="gpt-4o"
+  - <file>:<line>   temperature=0.7, max_tokens=2000
+  - <file>:<line>   system="You are..."  (27 lines)
+
+Tools detected:      <none / ['search', 'calculator'] at file.py:LN>
+Retry wrapper:       <none / @retry(3) at file.py:LN>
+Scope:               <single service / monorepo: picked "service-x">
+
+Proposed plan:
+  Stage 1 (Extract):  Build manifest from the 3 targets above
+  Stage 2 (Wrap):     Create AI Config 'chat-assistant' in completion mode; inline fallback mirrors current values
+  Stage 3 (Tools):    Skipped (no function calling) / Attach 2 tools via aiconfig-tools
+  Stage 4 (Tracking): Inline tracker wiring (track_duration + track_tokens + track_success/error)
+  Stage 5 (Evals):    Attach built-in 'accuracy' judge at 0.25 sampling via aiconfig-online-evals
+```
+
+## STOP
+
+Do not proceed to Stage 1 (Step 2 in the main workflow) until the user confirms:
+
+1. The service boundary is right
+2. The hardcoded targets list is complete
+3. The mode choice matches their intent
+4. The stage plan is acceptable (e.g. skip tools? skip evals for now?)
+
+If the user corrects anything, update the summary and ask again. Do not proceed under ambiguity.

--- a/skills/ai-configs/aiconfig-migrate/references/sdk-ai-tracker-patterns.md
+++ b/skills/ai-configs/aiconfig-migrate/references/sdk-ai-tracker-patterns.md
@@ -122,7 +122,7 @@ config.tracker.track_tool_call("search_kb")
 config.tracker.track_tool_call("search_kb", graph_key="support-flow")
 ```
 
-The Node tracker has no individual `trackToolCall` method — tool-call metrics flow through the provider-specific auto-helpers (`trackOpenAIMetrics`, `trackMetricsOf` with a custom extractor) or via the `trackMetricsOf` wrapper. If you need per-tool-name granularity on Node today, track it as custom data via the base SDK's `ldClient.track()`.
+The Node tracker has no individual `trackToolCall` method — tool-call metrics flow through the `trackMetricsOf` wrapper (the extractor can count tool calls on the response and include them in the `LDAIMetrics` it returns). If you need per-tool-name granularity on Node today, track it as custom data via the base SDK's `ldClient.track()`.
 
 ### `track_tool_calls` / (Python only, batch)
 
@@ -189,87 +189,117 @@ Use alongside `track_eval_scores` if you want both the numeric scores and the ju
 
 ## Auto-tracking helpers
 
-These wrap the provider call and extract duration + tokens + success/error in one step. Prefer them over manual tracking when the helper exists for your provider — fewer moving parts and no chance of drift between manual blocks.
+The canonical tracking surface is **`trackMetricsOf` composed with a provider-package `getAIMetricsFromResponse` extractor** (Tier 2) — or, one level up, the managed runners (`ManagedModel` / `TrackedChat` / `initChat`) which track everything automatically and don't require any tracker calls at all (Tier 1). Both Python and Node SDK READMEs document this tiering exclusively as of this writing.
+
+Legacy single-purpose helpers (`track_openai_metrics`, `track_bedrock_converse_metrics`, `trackVercelAISDKGenerateTextMetrics`) still exist in the SDK source, but no current README uses them. **Do not introduce them in new code.** They're listed below with a `[legacy]` tag so you can recognize them in existing codebases, not so you'll reach for them.
 
 ### Python
 
-| Helper | Signature | Notes |
-|--------|-----------|-------|
-| `track_duration_of(func)` | `tracker.track_duration_of(lambda: provider_call())` | Wraps a sync callable; captures duration. Does not track tokens or success — pair with explicit `track_tokens` + `track_success`. |
-| `track_metrics_of(func, metrics_extractor)` | `tracker.track_metrics_of(func, extractor)` | Sync wrapper; calls `extractor(result)` to get a metrics object, then records tokens + duration + success. Use for custom providers. |
-| `track_metrics_of_async(func, metrics_extractor)` | `await tracker.track_metrics_of_async(async_func, extractor)` | Async variant. |
-| `track_openai_metrics(func)` | `tracker.track_openai_metrics(lambda: openai_client.chat.completions.create(...))` | OpenAI-specific. Extracts tokens from `response.usage` and records duration + success in one call. |
-| `track_bedrock_converse_metrics(res)` | `tracker.track_bedrock_converse_metrics(bedrock_response)` | Bedrock Converse API. Pass the response object, not a callable. Returns the same response so you can chain it. |
+| Helper | Signature | Tier | Notes |
+|--------|-----------|------|-------|
+| `track_metrics_of(func, extractor)` | `tracker.track_metrics_of(func, extractor)` | **2 / 3** | **Canonical generic wrapper.** Sync. Calls `extractor(result)` to get an `LDAIMetrics` object; records tokens + duration + success. Use a provider package's `Provider.get_ai_metrics_from_response` as the extractor for Tier 2, or write a small custom function for Tier 3. |
+| `track_metrics_of_async(func, extractor)` | `await tracker.track_metrics_of_async(async_func, extractor)` | 2 / 3 | Async variant. |
+| `track_duration_of(func)` | `tracker.track_duration_of(lambda: provider_call())` | 4 | Wraps a sync callable; captures duration only. Pair with explicit `track_tokens` + `track_success`. Useful when the response shape makes `track_metrics_of` awkward. |
+| `track_openai_metrics(func)` | `tracker.track_openai_metrics(lambda: openai_client.chat.completions.create(...))` | **[legacy]** | Predates the `ldai_openai` provider package. Replace with `track_metrics_of(call_openai, OpenAIProvider.get_ai_metrics_from_response)`. |
+| `track_bedrock_converse_metrics(res)` | `tracker.track_bedrock_converse_metrics(bedrock_response)` | **[legacy]** | Predates `track_metrics_of`. Replace with a Converse extractor passed to `track_metrics_of`. See [bedrock-tracking.md](../../aiconfig-ai-metrics/references/bedrock-tracking.md). |
 
-Example — OpenAI auto-tracking:
+Example — OpenAI via `track_metrics_of` + the provider package extractor (current pattern):
 ```python
-completion = config.tracker.track_openai_metrics(
-    lambda: openai_client.chat.completions.create(
+from ldai_openai import OpenAIProvider
+
+def call_openai():
+    return openai_client.chat.completions.create(
         model=config.model.name,
         messages=[m.to_dict() for m in config.messages or []],
     )
+
+completion = config.tracker.track_metrics_of(
+    call_openai,
+    OpenAIProvider.get_ai_metrics_from_response,
 )
 ```
 
-Example — Bedrock Converse auto-tracking:
+Example — custom extractor for Anthropic direct (Tier 3):
 ```python
-raw = bedrock_runtime.converse(
-    modelId=config.model.name,
-    messages=[{"role": "user", "content": [{"text": user_input}]}],
+from ldai.providers.types import LDAIMetrics, TokenUsage
+
+def anthropic_extractor(response) -> LDAIMetrics:
+    return LDAIMetrics(
+        success=True,
+        usage=TokenUsage(
+            total=response.usage.input_tokens + response.usage.output_tokens,
+            input=response.usage.input_tokens,
+            output=response.usage.output_tokens,
+        ),
+    )
+
+response = config.tracker.track_metrics_of(
+    lambda: anthropic_client.messages.create(...),
+    anthropic_extractor,
 )
-response = config.tracker.track_bedrock_converse_metrics(raw)
 ```
 
 ### Node.js / TypeScript
 
-| Helper | Signature | Notes |
-|--------|-----------|-------|
-| `trackDurationOf<T>(func)` | `await tracker.trackDurationOf(async () => ...)` | Wraps an async callable; captures duration only. |
-| `trackMetricsOf<T>(extractor, func)` | `await tracker.trackMetricsOf((result) => extractor(result), async () => ...)` | Generic metrics wrapper. `extractor` maps the provider response to `LDAIMetrics`. Use for custom providers or when the per-provider helper doesn't exist. |
-| `trackStreamMetricsOf<T>(streamCreator, extractor)` | `tracker.trackStreamMetricsOf(() => stream, async (s) => metricsFromStream(s))` | Stream variant — extractor returns a promise that resolves once the stream is drained. |
-| `trackOpenAIMetrics<T>(func)` | `await tracker.trackOpenAIMetrics(async () => openai.chat.completions.create(...))` | OpenAI-specific. Extracts tokens from `response.usage` and records everything. |
-| `trackBedrockConverseMetrics<T>(res)` | `tracker.trackBedrockConverseMetrics(bedrockResponse)` | Takes the response directly (not a callable) and returns it. |
-| `trackVercelAISDKGenerateTextMetrics<T>(func)` | `await tracker.trackVercelAISDKGenerateTextMetrics(async () => generateText({...}))` | Vercel AI SDK `generateText`. |
+| Helper | Signature | Tier | Notes |
+|--------|-----------|------|-------|
+| `trackMetricsOf<T>(extractor, func)` | `await tracker.trackMetricsOf((result) => extractor(result), async () => ...)` | **2 / 3** | **Canonical generic wrapper.** `extractor` maps provider response → `LDAIMetrics`. Use a provider package's `Provider.getAIMetricsFromResponse` for Tier 2 (`@launchdarkly/server-sdk-ai-openai`, `-langchain`, `-vercel`) or a small custom function for Tier 3. |
+| `trackStreamMetricsOf<T>(extractor, streamCreator)` | `tracker.trackStreamMetricsOf(async (chunks) => extractor(chunks), () => createStream())` | 2 / 3 | Stream variant. Does **not** capture TTFT automatically — if you need TTFT, use the manual pattern in [streaming-tracking.md](../../aiconfig-ai-metrics/references/streaming-tracking.md). |
+| `trackDurationOf<T>(func)` | `await tracker.trackDurationOf(async () => ...)` | 4 | Wraps an async callable; captures duration only. Pair with explicit `trackTokens` + `trackSuccess`. |
+| `trackOpenAIMetrics<T>(func)` | `await tracker.trackOpenAIMetrics(async () => openai.chat.completions.create(...))` | **[legacy]** | Predates `@launchdarkly/server-sdk-ai-openai`. Replace with `trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, () => ...)`. |
+| `trackBedrockConverseMetrics<T>(res)` | `tracker.trackBedrockConverseMetrics(bedrockResponse)` | **[legacy]** | Replace with a Converse extractor passed to `trackMetricsOf`. |
+| `trackVercelAISDKGenerateTextMetrics<T>(func)` | `await tracker.trackVercelAISDKGenerateTextMetrics(async () => generateText({...}))` | **[legacy]** | Replace with `trackMetricsOf` + `VercelAISDKProvider.getAIMetricsFromResponse` from `@launchdarkly/server-sdk-ai-vercel`. |
 
-Example — OpenAI via the provider helper package:
+Example — OpenAI via `trackMetricsOf` + the provider package (current pattern):
 ```typescript
 import { OpenAIProvider } from '@launchdarkly/server-sdk-ai-openai';
 
 const response = await aiConfig.tracker.trackMetricsOf(
-  (result) => OpenAIProvider.createAIMetrics(result),
+  OpenAIProvider.getAIMetricsFromResponse,
   () => openai.chat.completions.create({
     model: aiConfig.model?.name ?? 'gpt-4o',
-    messages: aiConfig.messages ?? [],
+    messages: [...(aiConfig.messages ?? []), { role: 'user', content: userPrompt }],
   }),
 );
 ```
 
-Example — built-in `trackOpenAIMetrics`:
+Example — LangChain via `trackMetricsOf` (works for any model LangChain wraps, including Anthropic and Bedrock):
 ```typescript
-const response = await aiConfig.tracker.trackOpenAIMetrics(() =>
-  openai.chat.completions.create({
-    model: aiConfig.model?.name ?? 'gpt-4o',
-    messages: aiConfig.messages ?? [],
-  }),
+import { LangChainProvider } from '@launchdarkly/server-sdk-ai-langchain';
+
+const llm = await LangChainProvider.createLangChainModel(aiConfig);
+const response = await aiConfig.tracker.trackMetricsOf(
+  LangChainProvider.getAIMetricsFromResponse,
+  () => llm.invoke(messages),
 );
 ```
 
-### Anthropic has no built-in auto-helper (either SDK)
+### Tier 1 — Managed runners (mention)
 
-Neither Python nor Node ships a `track_anthropic_metrics` helper. For Anthropic direct calls, use manual `trackDuration` + `trackTokens` + `trackSuccess`/`trackError`, or route through Bedrock Converse which does have a helper.
+For chat-loop applications, both SDKs expose a higher-level API that handles tracking end-to-end with no tracker calls at all:
 
-## Manual vs auto decision table
+- Python: `ai_client.create_model(...)` → `ManagedModel`, then `await model.invoke(user_input)`
+- Node: `aiClient.initChat(...)` / `aiClient.createChat(...)` → `TrackedChat`, then `await chat.invoke(userInput)`
 
-| Situation | Recommended pattern |
-|-----------|---------------------|
-| OpenAI SDK (Python or Node) | `track_openai_metrics` / `trackOpenAIMetrics` |
-| Bedrock Converse (Python or Node) | `track_bedrock_converse_metrics` / `trackBedrockConverseMetrics` |
-| Vercel AI SDK `generateText` (Node) | `trackVercelAISDKGenerateTextMetrics` |
-| LangChain (Python or Node) | Use the provider helper package if installed, else manual |
-| Anthropic direct SDK | **Manual** (no auto-helper) |
-| Gemini / Google GenAI direct | **Manual** |
-| Custom provider / proxy | `track_metrics_of` / `trackMetricsOf` with a custom extractor |
-| Streaming response | `trackStreamMetricsOf` (Node) or manual with `track_time_to_first_token` |
+The managed runner handles message history, provider dispatch (via the installed provider package — OpenAI, LangChain, Vercel), and tracker wiring. If the migration target is conversational, this is the right tier and you don't need anything from the tables above.
+
+### Anthropic has no provider package today
+
+Neither `@launchdarkly/server-sdk-ai-anthropic` nor `launchdarkly-server-sdk-ai-anthropic` exists as of this writing. For Anthropic direct calls, write a custom extractor and pass it to `track_metrics_of` / `trackMetricsOf` — see the Python example above or the full walk-through in [anthropic-tracking.md](../../aiconfig-ai-metrics/references/anthropic-tracking.md). If the app is open to LangChain, routing Anthropic through `ChatAnthropic` and the LangChain provider package recovers Tier 2 with zero extractor code.
+
+## Tier decision table
+
+| Situation | Tier | Pattern |
+|-----------|------|---------|
+| Chat loop (history, turn-based), any provider with a package | **1** | `ManagedModel` / `TrackedChat` / `initChat` — no tracker calls |
+| OpenAI direct SDK, non-chat shape | **2** | `trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, fn)` |
+| LangChain / LangGraph (any underlying model), non-chat shape | **2** | `trackMetricsOf(LangChainProvider.getAIMetricsFromResponse, fn)` |
+| Vercel AI SDK, non-chat shape (Node only) | **2** | `trackMetricsOf` with the Vercel provider package's extractor |
+| Anthropic direct SDK | **3** | Custom extractor reading `response.usage.input_tokens` / `output_tokens` |
+| Bedrock Converse (no provider package) | **3** | Custom extractor reading `response.usage.inputTokens` / `outputTokens` (or route via LangChain for Tier 2) |
+| Gemini / Google GenAI, Cohere, custom HTTP | **3** | Custom extractor |
+| Streaming response with TTFT required | **4** | Manual `trackTimeToFirstToken` + `trackDuration` + `trackTokens` + `trackSuccess` — see [streaming-tracking.md](../../aiconfig-ai-metrics/references/streaming-tracking.md) |
+| Streaming response without TTFT (Node) | **2 / 3** | `trackStreamMetricsOf(extractor, streamFn)` |
 
 ## Streaming responses
 

--- a/skills/ai-configs/aiconfig-migrate/references/sdk-ai-tracker-patterns.md
+++ b/skills/ai-configs/aiconfig-migrate/references/sdk-ai-tracker-patterns.md
@@ -1,0 +1,341 @@
+# SDK AI Tracker Patterns
+
+The main novel content of this skill — a per-method reference for the LaunchDarkly AI Config tracker in Python and Node side by side. **No existing skill covers this.** The `launchdarkly-metric-instrument` skill is for `ldClient.track()` feature metrics, which is a different API.
+
+All method names and signatures below are verified against `launchdarkly-server-sdk-ai` (Python) and `@launchdarkly/server-sdk-ai` (`js-core/packages/sdk/server-ai`) main branches. If a method is not listed, it does not exist — do not invent it.
+
+## Two tracker classes
+
+| Class | Where it lives | When you use it |
+|-------|----------------|-----------------|
+| `LDAIConfigTracker` (Python) / `LDAIConfigTracker` (Node) | Attached to each AI Config object as `config.tracker` / `aiConfig.tracker` | **Per-request tracking.** Call from inside your request handler, around the provider call. This is the one this skill wires in Stage 4. |
+| `AIGraphTracker` (Python only) | Returned from `graph.get_tracker()` after `ai_client.agent_graph(key, context)` | **Graph-level tracking.** Covers path, handoffs, total tokens, latency for a multi-node traversal. See [agent-graph-reference.md](agent-graph-reference.md). Python-only — Node SDK has no graph support yet. |
+
+This doc focuses on `LDAIConfigTracker`. For `AIGraphTracker`, see the graph reference.
+
+## Config tracker methods — Python ↔ Node
+
+### `track_success` / `trackSuccess`
+
+Record a successful generation. Required — the Monitoring tab does not populate without it.
+
+```python
+config.tracker.track_success()
+```
+```typescript
+aiConfig.tracker.trackSuccess();
+```
+
+No arguments. Call once per request after the provider call returns.
+
+### `track_error` / `trackError`
+
+Record a failed generation. Required for error-rate metrics.
+
+```python
+config.tracker.track_error()
+```
+```typescript
+aiConfig.tracker.trackError();
+```
+
+Call from the exception path. Do not also call `track_success` in the same request.
+
+### `track_duration` / `trackDuration`
+
+Record latency in milliseconds. Measure wall-clock time across the provider call.
+
+```python
+import time
+start = time.time()
+response = openai_client.chat.completions.create(...)
+config.tracker.track_duration(int((time.time() - start) * 1000))
+```
+```typescript
+const start = Date.now();
+const response = await openai.chat.completions.create(/* ... */);
+aiConfig.tracker.trackDuration(Date.now() - start);
+```
+
+**Python note:** there is no `track_request()` context-manager method on `LDAIConfigTracker`. Some older guides show it; it does not exist. Use `track_duration` + `track_success`/`track_error` explicitly, or use `track_duration_of` / `track_metrics_of` (below) which wrap the whole thing.
+
+### `track_tokens` / `trackTokens`
+
+Record token usage. The shape is `(input, output, total)` in both SDKs.
+
+```python
+from ldai.tracker import TokenUsage
+
+config.tracker.track_tokens(TokenUsage(
+    input=response.usage.prompt_tokens,
+    output=response.usage.completion_tokens,
+    total=response.usage.total_tokens,
+))
+```
+```typescript
+aiConfig.tracker.trackTokens({
+  input: response.usage?.prompt_tokens ?? 0,
+  output: response.usage?.completion_tokens ?? 0,
+  total: response.usage?.total_tokens ?? 0,
+});
+```
+
+Token field names vary by provider. OpenAI's `usage.prompt_tokens` is the input count; Anthropic's `usage.input_tokens` is. Always pull from the provider response, not from a re-tokenization.
+
+### `track_time_to_first_token` / `trackTimeToFirstToken`
+
+For streaming calls, record the time from request-start to first-chunk.
+
+```python
+config.tracker.track_time_to_first_token(time_to_first_token_ms)
+```
+```typescript
+aiConfig.tracker.trackTimeToFirstToken(timeToFirstTokenMs);
+```
+
+Skip for non-streaming calls. See the "Streaming" section below.
+
+### `track_feedback` / `trackFeedback`
+
+Record user feedback (thumbs-up/down). Both SDKs take a `{kind}` object with a `FeedbackKind` enum.
+
+```python
+from ldai.tracker import FeedbackKind
+config.tracker.track_feedback({"kind": FeedbackKind.Positive})
+config.tracker.track_feedback({"kind": FeedbackKind.Negative})
+```
+```typescript
+import { LDFeedbackKind } from '@launchdarkly/server-sdk-ai';
+aiConfig.tracker.trackFeedback({ kind: LDFeedbackKind.Positive });
+aiConfig.tracker.trackFeedback({ kind: LDFeedbackKind.Negative });
+```
+
+Wire this only when the app has a UI that captures the signal — e.g. thumbs-up/down buttons on each response. Persist the `tracker` reference alongside the message so the feedback call lands on the same config that produced the response.
+
+### `track_tool_call` / (Node: no per-call method)
+
+**Python only.** Records a tool invocation on the config that issued it.
+
+```python
+config.tracker.track_tool_call("search_kb")
+# Optional: associate with a graph execution
+config.tracker.track_tool_call("search_kb", graph_key="support-flow")
+```
+
+The Node tracker has no individual `trackToolCall` method — tool-call metrics flow through the provider-specific auto-helpers (`trackOpenAIMetrics`, `trackMetricsOf` with a custom extractor) or via the `trackMetricsOf` wrapper. If you need per-tool-name granularity on Node today, track it as custom data via the base SDK's `ldClient.track()`.
+
+### `track_tool_calls` / (Python only, batch)
+
+```python
+config.tracker.track_tool_calls(["search_kb", "calculator"])
+```
+
+Iterable variant. Call once per request with the full list of tools invoked.
+
+### `track_eval_scores` / `trackEvalScores`
+
+Record judge scores from a programmatic evaluation. See SKILL.md Step 6 and `aiconfig-online-evals`.
+
+The full programmatic direct-judge pattern (Python):
+
+```python
+from ldai.client import AIJudgeConfigDefault
+
+judge = await ai_client.create_judge(
+    judge_key,                               # judge AI Config key in LD
+    ld_context,
+    AIJudgeConfigDefault(enabled=False),     # fallback: skip eval on SDK miss
+)
+
+if judge and judge.enabled:
+    result = await judge.evaluate(
+        input_text,
+        output_text,
+        sampling_rate=0.25,                  # optional; default 1.0 (always eval)
+    )
+    if result:
+        config.tracker.track_eval_scores(result.evals)
+```
+
+**Rules for the Python shape:**
+
+- `create_judge` returns `Optional[Judge]` — guard with `if judge and judge.enabled:` before calling `.evaluate`. A direct `.evaluate()` on a `None` return raises `AttributeError`.
+- The `default` argument is typed `Optional[AIJudgeConfigDefault]`. Do not pass `AICompletionConfigDefault` even though some older examples show it — the type is strict.
+- `sampling_rate` is a parameter on `Judge.evaluate()`, **not** on `create_judge`. It defaults to `1.0` (evaluate every call). Internally the SDK does `if random.random() > sampling_rate: return None`, so `evaluate()` can return `None` at the sampling layer too — hence the `if result:` guard around `track_eval_scores`.
+- The second parameter of `.evaluate()` is a keyword-only `sampling_rate` — positional `input_text` and `output_text` come first.
+
+Node equivalent:
+
+```typescript
+aiConfig.tracker.trackEvalScores(judgeResponse.evals);
+```
+
+(The Node SDK exposes the same `trackEvalScores` method but the judge-creation side of the API is evolving — verify against the current `@launchdarkly/server-sdk-ai` source before writing Node code against it.)
+
+Only needed when you call `create_judge(...).evaluate(...)` directly. Automatic evaluation via `create_chat()` + `invoke()` records scores without this call.
+
+### `track_judge_response` / `trackJudgeResponse`
+
+Record the full structured response from a judge (raw scores + reasoning).
+
+```python
+config.tracker.track_judge_response(judge_response)
+```
+```typescript
+aiConfig.tracker.trackJudgeResponse(judgeResponse);
+```
+
+Use alongside `track_eval_scores` if you want both the numeric scores and the judge's reasoning text stored.
+
+## Auto-tracking helpers
+
+These wrap the provider call and extract duration + tokens + success/error in one step. Prefer them over manual tracking when the helper exists for your provider — fewer moving parts and no chance of drift between manual blocks.
+
+### Python
+
+| Helper | Signature | Notes |
+|--------|-----------|-------|
+| `track_duration_of(func)` | `tracker.track_duration_of(lambda: provider_call())` | Wraps a sync callable; captures duration. Does not track tokens or success — pair with explicit `track_tokens` + `track_success`. |
+| `track_metrics_of(func, metrics_extractor)` | `tracker.track_metrics_of(func, extractor)` | Sync wrapper; calls `extractor(result)` to get a metrics object, then records tokens + duration + success. Use for custom providers. |
+| `track_metrics_of_async(func, metrics_extractor)` | `await tracker.track_metrics_of_async(async_func, extractor)` | Async variant. |
+| `track_openai_metrics(func)` | `tracker.track_openai_metrics(lambda: openai_client.chat.completions.create(...))` | OpenAI-specific. Extracts tokens from `response.usage` and records duration + success in one call. |
+| `track_bedrock_converse_metrics(res)` | `tracker.track_bedrock_converse_metrics(bedrock_response)` | Bedrock Converse API. Pass the response object, not a callable. Returns the same response so you can chain it. |
+
+Example — OpenAI auto-tracking:
+```python
+completion = config.tracker.track_openai_metrics(
+    lambda: openai_client.chat.completions.create(
+        model=config.model.name,
+        messages=[m.to_dict() for m in config.messages or []],
+    )
+)
+```
+
+Example — Bedrock Converse auto-tracking:
+```python
+raw = bedrock_runtime.converse(
+    modelId=config.model.name,
+    messages=[{"role": "user", "content": [{"text": user_input}]}],
+)
+response = config.tracker.track_bedrock_converse_metrics(raw)
+```
+
+### Node.js / TypeScript
+
+| Helper | Signature | Notes |
+|--------|-----------|-------|
+| `trackDurationOf<T>(func)` | `await tracker.trackDurationOf(async () => ...)` | Wraps an async callable; captures duration only. |
+| `trackMetricsOf<T>(extractor, func)` | `await tracker.trackMetricsOf((result) => extractor(result), async () => ...)` | Generic metrics wrapper. `extractor` maps the provider response to `LDAIMetrics`. Use for custom providers or when the per-provider helper doesn't exist. |
+| `trackStreamMetricsOf<T>(streamCreator, extractor)` | `tracker.trackStreamMetricsOf(() => stream, async (s) => metricsFromStream(s))` | Stream variant — extractor returns a promise that resolves once the stream is drained. |
+| `trackOpenAIMetrics<T>(func)` | `await tracker.trackOpenAIMetrics(async () => openai.chat.completions.create(...))` | OpenAI-specific. Extracts tokens from `response.usage` and records everything. |
+| `trackBedrockConverseMetrics<T>(res)` | `tracker.trackBedrockConverseMetrics(bedrockResponse)` | Takes the response directly (not a callable) and returns it. |
+| `trackVercelAISDKGenerateTextMetrics<T>(func)` | `await tracker.trackVercelAISDKGenerateTextMetrics(async () => generateText({...}))` | Vercel AI SDK `generateText`. |
+
+Example — OpenAI via the provider helper package:
+```typescript
+import { OpenAIProvider } from '@launchdarkly/server-sdk-ai-openai';
+
+const response = await aiConfig.tracker.trackMetricsOf(
+  (result) => OpenAIProvider.createAIMetrics(result),
+  () => openai.chat.completions.create({
+    model: aiConfig.model?.name ?? 'gpt-4o',
+    messages: aiConfig.messages ?? [],
+  }),
+);
+```
+
+Example — built-in `trackOpenAIMetrics`:
+```typescript
+const response = await aiConfig.tracker.trackOpenAIMetrics(() =>
+  openai.chat.completions.create({
+    model: aiConfig.model?.name ?? 'gpt-4o',
+    messages: aiConfig.messages ?? [],
+  }),
+);
+```
+
+### Anthropic has no built-in auto-helper (either SDK)
+
+Neither Python nor Node ships a `track_anthropic_metrics` helper. For Anthropic direct calls, use manual `trackDuration` + `trackTokens` + `trackSuccess`/`trackError`, or route through Bedrock Converse which does have a helper.
+
+## Manual vs auto decision table
+
+| Situation | Recommended pattern |
+|-----------|---------------------|
+| OpenAI SDK (Python or Node) | `track_openai_metrics` / `trackOpenAIMetrics` |
+| Bedrock Converse (Python or Node) | `track_bedrock_converse_metrics` / `trackBedrockConverseMetrics` |
+| Vercel AI SDK `generateText` (Node) | `trackVercelAISDKGenerateTextMetrics` |
+| LangChain (Python or Node) | Use the provider helper package if installed, else manual |
+| Anthropic direct SDK | **Manual** (no auto-helper) |
+| Gemini / Google GenAI direct | **Manual** |
+| Custom provider / proxy | `track_metrics_of` / `trackMetricsOf` with a custom extractor |
+| Streaming response | `trackStreamMetricsOf` (Node) or manual with `track_time_to_first_token` |
+
+## Streaming responses
+
+Streaming is trickier because duration and tokens aren't known until the stream completes.
+
+**Python — manual pattern for streaming OpenAI:**
+```python
+import time
+
+start = time.time()
+first_chunk_time = None
+input_tokens = 0
+output_tokens = 0
+
+stream = openai_client.chat.completions.create(stream=True, ...)
+for chunk in stream:
+    if first_chunk_time is None:
+        first_chunk_time = time.time()
+        config.tracker.track_time_to_first_token(int((first_chunk_time - start) * 1000))
+    # accumulate output tokens from chunk.usage if provider emits them
+    # or use a tokenizer for an estimate
+
+config.tracker.track_duration(int((time.time() - start) * 1000))
+config.tracker.track_tokens(TokenUsage(input=input_tokens, output=output_tokens, total=input_tokens + output_tokens))
+config.tracker.track_success()
+```
+
+**Node — use `trackStreamMetricsOf`:**
+```typescript
+const stream = await aiConfig.tracker.trackStreamMetricsOf(
+  () => openai.chat.completions.create({ stream: true, /* ... */ }),
+  async (s) => {
+    // Drain the stream and extract LDAIMetrics
+    return extractMetricsFromDrainedStream(s);
+  },
+);
+```
+
+## Where tracker calls should live
+
+- **Inside a retry wrapper**, not outside it. If your request has 3 retry attempts and 2 fail + 1 succeeds, you want 1 `track_success`. Putting the tracker outside the retry would cause 3 events or 0.
+- **Per request**, not cached across requests. `config.tracker` is attached to a per-request `config` object. Do not stash it in module scope.
+- **Before any return statement.** A tracker call that never runs (because an early return bypasses it) produces silent data loss. Use try/finally in complex handlers if needed.
+- **After the provider returns**, not before. Duration measured from before the provider call; tokens and success/error from the response.
+
+## Troubleshooting: Monitoring tab shows no data
+
+Run the checklist in order. Each step rules out one cause.
+
+1. **SDK key** — is `LD_SDK_KEY` the server-side key (starts with `sdk-`), not the client-side key or the API key?
+2. **Enabled check** — is `config.enabled` / `aiConfig.enabled` `True`? A disabled config will not record traffic. Check the AI Config's targeting in LaunchDarkly and confirm the context matches a rule that serves an enabled variation.
+3. **Any tracker call at all** — did `track_success` / `trackSuccess` fire? Without at least one generation-level call, the Monitoring tab has nothing to show. Log a one-liner next to the call to confirm it runs.
+4. **Config key match** — is the string passed to `completion_config` / `completionConfig` exactly the same as the AI Config key in LaunchDarkly? Keys are case-sensitive.
+5. **Mode match** — if the code calls `completion_config` but the AI Config in LaunchDarkly is in agent mode (or vice versa), the SDK call will error out. Check the mode in the UI.
+6. **Flush on shutdown** — on short-lived processes (tests, scripts), call `ld_client.flush()` before exit. Long-running servers flush automatically on an interval.
+7. **Data delay** — the Monitoring tab updates within 1–2 minutes. If you just deployed, wait and retry before debugging further.
+8. **SDK version** — some tracker methods were added in later minor versions. `track_feedback`, `track_eval_scores`, and the auto-helpers require Python v0.14.0+ or Node v0.16.1+.
+9. **Debug logging** — enable SDK debug logging (`LD_LOG_LEVEL=debug` / `setLevel('debug')`) to see evaluation results and tracker calls in stdout.
+10. **Error path silent** — are you catching exceptions that swallow tracker errors? The tracker should never raise, but if a custom wrapper catches everything, confirm the call fires by logging before and after.
+
+## Common gotchas
+
+- **`track_tokens` token shape.** The Python `TokenUsage` dataclass requires `total` to be set — it is not derived. Compute `total = input + output` if the provider doesn't return one.
+- **`track_feedback` lifecycle.** The feedback call must be made on the *same tracker* that produced the response. Store `config.tracker` alongside the message in your DB or session so a thumbs-up later still routes to the right config.
+- **OpenAI streaming tokens.** OpenAI only emits `usage` in the final chunk when `stream_options={"include_usage": True}` is passed. Without that flag, you have to tokenize manually — `tiktoken` for OpenAI models.
+- **Anthropic token field names.** Anthropic uses `response.usage.input_tokens` and `output_tokens`, not `prompt_tokens`/`completion_tokens`. Do not copy the OpenAI shape.
+- **Bedrock Converse response shape.** `response["usage"]["inputTokens"]` (camelCase, not snake). The auto-helper handles this — prefer it over manual extraction.
+- **Retry loops and `track_duration`.** If you wrap the whole retry in `track_duration`, the value includes backoff sleeps. Either measure only the final-attempt provider call, or document that duration includes retries — don't leave it ambiguous.
+- **Do not cache `config.tracker`.** Each `completion_config` / `agent_config` call returns a new tracker tied to that request's variation. Caching the tracker means future feedback, evals, or token counts land on the wrong config.

--- a/skills/ai-configs/aiconfig-projects/SKILL.md
+++ b/skills/ai-configs/aiconfig-projects/SKILL.md
@@ -128,12 +128,12 @@ Follow the chosen reference guide to implement project management. Key considera
 
 After creating the project, verify it works:
 
-1. **Fetch via API to confirm it exists:**
+1. **Fetch to confirm it exists.** Prefer the MCP `get-project` tool over raw `curl` — it returns a typed object you can inspect directly. If you must call the REST API:
    ```bash
    curl -X GET "https://app.launchdarkly.com/api/v2/projects/{projectKey}?expand=environments" \
      -H "Authorization: {api_token}"
    ```
-   Confirm the response includes the project, environments, and SDK keys.
+   **Do not pipe the response straight into a `.environments.items[]`-style `jq` filter.** The shape of `environments` varies by `expand` parameter — sometimes it's `{items: [...]}`, sometimes a bare array — and a hand-rolled filter will fail with `Cannot index array with string "items"`. Run `jq -e .` first to inspect the actual shape, or use `jq '.environments | if type == "object" then .items else . end'` to handle both.
 
 2. **Test SDK integration:**
    Run a quick verification to ensure the SDK key works:

--- a/skills/ai-configs/aiconfig-tools/SKILL.md
+++ b/skills/ai-configs/aiconfig-tools/SKILL.md
@@ -70,7 +70,7 @@ Use `create-ai-tool` with:
 
 ### Step 3: Attach to Variation
 
-Use `update-ai-config-variation` to attach tools. Pass the tool references in the `tools` field:
+Use `update-ai-config-variation` to attach tools. **Pass only the `tools` field.** Do not bundle `instructions`, `messages`, `model`, or `parameters` into this PATCH unless the user has explicitly asked you to also update those fields. Those fields may have been edited in the LaunchDarkly UI since the variation was created, and including them in a tool-attachment PATCH will silently clobber the UI edits.
 
 ```json
 {
@@ -82,6 +82,8 @@ Use `update-ai-config-variation` to attach tools. Pass the tool references in th
   ]
 }
 ```
+
+If you observe a UI-clear bug where attaching tools wipes other fields, **do not work around it by re-sending those fields from the previous `get-ai-config` response** — that masks the bug and can resurrect stale values that the user has since edited. Report the bug instead.
 
 ### Step 4: Verify
 
@@ -110,6 +112,7 @@ LangGraph, CrewAI, and AutoGen often generate schemas from function definitions.
 - Don't try to attach tools during config creation -- update the variation afterward
 - Don't skip clear tool descriptions (LLM needs them to decide when to call)
 - Don't forget to verify attachment after updating the variation
+- Don't bundle `instructions`, `messages`, `model`, or `parameters` into the tool-attachment PATCH. Send `tools` alone unless the user explicitly asked for a multi-field update — bundled PATCHes silently clobber UI edits to the other fields.
 
 ## Related Skills
 


### PR DESCRIPTION
Add aiconfig-migrate, an orchestrator skill that walks an app from hardcoded LLM prompts to a full LaunchDarkly AI Configs implementation in five stages (extract, wrap, tools, tracking, evals). The skill prints inputs at each stage and tells the user to run the relevant sibling slash-command; it does not auto-invoke other skills.

Also fix four issues found while testing the skill end-to-end:

- aiconfig-create: require modelName in the initial variation call, document the field name explicitly, and end the workflow with an explicit aiconfig-targeting handoff so the new variation is actually servable.
- aiconfig-projects: prefer the MCP get-project tool for verification; warn about response-shape variation in jq filters.
- aiconfig-tools: PATCH the tools field alone, never bundle instructions/messages/model/parameters
- aiconfig-migrate: rewrite all 'delegates to' language as manual hand-offs, and add an explicit aiconfig-targeting step between Stage 2 and Stage 4.