### PR TITLE
[REL-13105] Claude code plugin marketplace submission

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "support@launchdarkly.com"
   },
   "homepage": "https://launchdarkly.com",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "license": "Apache-2.0",
   "logo": "logo.svg",
   "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "launchdarkly",
+  "version": "1.0.0",
+  "description": "LaunchDarkly agent skills and MCP server for feature flag management, AI configuration, and metrics",
+  "author": {
+    "name": "LaunchDarkly",
+    "email": "support@launchdarkly.com"
+  },
+  "homepage": "https://launchdarkly.com",
+  "repository": "https://github.com/launchdarkly/agent-skills",
+  "license": "Apache-2.0",
+  "logo": "logo.svg",
+  "keywords": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management",
+    "ai-config",
+    "targeting",
+    "rollout",
+    "cleanup",
+    "mcp"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "launchdarkly",
   "version": "1.0.0",
-  "description": "LaunchDarkly agent skills and MCP server for feature flag management, AI configuration, and metrics",
+  "description": "LaunchDarkly agent skills and MCP servers for feature flag management, AI configuration, and metrics",
   "author": {
     "name": "LaunchDarkly",
     "email": "support@launchdarkly.com"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `ai-configs/aiconfig-variations` | Manage AI Config variations for A/B testing |
 | `ai-configs/aiconfig-tools` | Create and attach tools for function calling |
 | `ai-configs/aiconfig-projects` | Create and manage projects to organize AI Configs |
+| `ai-configs/aiconfig-online-evals` | Attach LLM-as-a-judge evaluators to AI Configs |
+| `ai-configs/aiconfig-targeting` | Configure targeting rules for AI Config rollouts |
+
+### Metrics
+
+| Skill | Description |
+|-------|-------------|
+| `metrics/launchdarkly-metric-choose` | Select the right metric type for an experiment |
+| `metrics/launchdarkly-metric-create` | Create metrics and instrument tracking events |
+| `metrics/launchdarkly-metric-instrument` | Add tracking calls to code for existing metrics |
+
+## Install as a Claude Code Plugin
+
+This repo is a [Claude Code plugin](https://code.claude.com/docs/en/create-plugins). Installing it gives you all the skills above plus the LaunchDarkly MCP server.
+
+1. Open Claude Code and run `/plugin install`.
+2. Search for **LaunchDarkly**, or install directly from the repo URL:
+   ```
+   https://github.com/launchdarkly/agent-skills
+   ```
+3. Authenticate the LaunchDarkly MCP server when prompted with your [API access token](https://docs.launchdarkly.com/home/account/api).
+
+Once installed, skills are available as `/launchdarkly:<skill-name>` across all your projects, and the MCP server can read and modify your flags directly.
 
 ## Install as a Cursor Plugin
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repo is a [Claude Code plugin](https://code.claude.com/docs/en/create-plugi
 1. Open Claude Code and run `/plugin install`.
 2. Search for **LaunchDarkly**, or install directly from the repo URL:
    ```
-   https://github.com/launchdarkly/agent-skills
+   https://github.com/launchdarkly/ai-tooling
    ```
 3. Authenticate the LaunchDarkly MCP server when prompted with your [API access token](https://docs.launchdarkly.com/home/account/api).
 
@@ -57,7 +57,7 @@ This repo is a [Cursor plugin](https://cursor.com/docs/plugins/building). Instal
 1. Open Cursor and go to **Settings > Plugins**.
 2. Search for **LaunchDarkly** in the marketplace, or install from the repo URL:
    ```
-   https://github.com/launchdarkly/agent-skills
+   https://github.com/launchdarkly/ai-tooling
    ```
 Once installed, the skills and MCP server are available across all your projects.
 
@@ -65,11 +65,11 @@ Once installed, the skills and MCP server are available across all your projects
 
 ```bash
 # Clone the repo
-git clone https://github.com/launchdarkly/agent-skills.git
-cd agent-skills
+git clone https://github.com/launchdarkly/ai-tooling.git
+cd ai-tooling
 
 # If your agent supports skills.sh installs:
-npx skills add launchdarkly/agent-skills
+npx skills add launchdarkly/ai-tooling
 
 # Or manually copy a skill into your agent's skills path:
 cp -r skills/feature-flags/launchdarkly-flag-cleanup <your-agent-skills-dir>/

--- a/skills/aiconfig-create
+++ b/skills/aiconfig-create
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-create

--- a/skills/aiconfig-online-evals
+++ b/skills/aiconfig-online-evals
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-online-evals

--- a/skills/aiconfig-projects
+++ b/skills/aiconfig-projects
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-projects

--- a/skills/aiconfig-targeting
+++ b/skills/aiconfig-targeting
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-targeting

--- a/skills/aiconfig-tools
+++ b/skills/aiconfig-tools
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-tools

--- a/skills/aiconfig-update
+++ b/skills/aiconfig-update
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-update

--- a/skills/aiconfig-variations
+++ b/skills/aiconfig-variations
@@ -1,0 +1,1 @@
+ai-configs/aiconfig-variations

--- a/skills/launchdarkly-flag-cleanup
+++ b/skills/launchdarkly-flag-cleanup
@@ -1,0 +1,1 @@
+feature-flags/launchdarkly-flag-cleanup

--- a/skills/launchdarkly-flag-create
+++ b/skills/launchdarkly-flag-create
@@ -1,0 +1,1 @@
+feature-flags/launchdarkly-flag-create

--- a/skills/launchdarkly-flag-discovery
+++ b/skills/launchdarkly-flag-discovery
@@ -1,0 +1,1 @@
+feature-flags/launchdarkly-flag-discovery

--- a/skills/launchdarkly-flag-targeting
+++ b/skills/launchdarkly-flag-targeting
@@ -1,0 +1,1 @@
+feature-flags/launchdarkly-flag-targeting

--- a/skills/launchdarkly-metric-choose
+++ b/skills/launchdarkly-metric-choose
@@ -1,0 +1,1 @@
+metrics/launchdarkly-metric-choose

--- a/skills/launchdarkly-metric-create
+++ b/skills/launchdarkly-metric-create
@@ -1,0 +1,1 @@
+metrics/launchdarkly-metric-create

--- a/skills/launchdarkly-metric-instrument
+++ b/skills/launchdarkly-metric-instrument
@@ -1,0 +1,1 @@
+metrics/launchdarkly-metric-instrument


### PR DESCRIPTION
## Summary

instructions followed: https://code.claude.com/docs/en/plugins#submit-your-plugin-to-the-official-marketplace

- Add `.claude-plugin/plugin.json` to enable installation as a Claude Code plugin.
-  Add flat symlinks under `skills/` so Claude Code's one-level-deep skill discovery resolves to the existing domain-organized `SKILL.md` files. 


## Testing

Manual local testing

Can install plugin ✅ 

<img width="1059" height="324" alt="CleanShot 2026-04-15 at 13 55 50" src="https://github.com/user-attachments/assets/51139916-c066-485d-8afa-b50078701de5" />

Can install plugin skills and use ✅ 

<img width="937" height="497" alt="CleanShot 2026-04-15 at 13 56 48" src="https://github.com/user-attachments/assets/1cdf9cb4-fbd5-4826-9790-81e7f327c7d2" />

<img width="1577" height="507" alt="CleanShot 2026-04-15 at 14 02 46" src="https://github.com/user-attachments/assets/42dabd5f-ea01-4f0e-b5f1-4cee928219d0" />

Can install MCP via plugin and authorize and use ✅ 

<img width="912" height="250" alt="CleanShot 2026-04-15 at 13 58 57" src="https://github.com/user-attachments/assets/ef4d0cda-54eb-43be-9bd4-58ff770f041c" />

<img width="996" height="79" alt="CleanShot 2026-04-15 at 13 59 56" src="https://github.com/user-attachments/assets/722cb2eb-94e5-45bd-952c-9924af269ed2" />

<img width="1191" height="504" alt="CleanShot 2026-04-15 at 14 00 32" src="https://github.com/user-attachments/assets/f6b3875f-f344-451b-8eb5-04002d96ad3f" />

## Notes

Next steps

<img width="987" height="1167" alt="CleanShot 2026-04-15 at 14 06 50" src="https://github.com/user-attachments/assets/10a26aad-6515-47eb-a4cc-eecf0a6ac313" />

<!-- ld-jira-link -->
---
Related Jira issue: [REL-13105: [Tier 2] Claude Code Plugins — Package agent-skills into .claude-plugin/](https://launchdarkly.atlassian.net/browse/REL-13105)
<!-- end-ld-jira-link -->