### PR TITLE
rename references from agent-skills to ai-tooling

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://launchdarkly.com"
   },
   "homepage": "https://launchdarkly.com",
-  "repository": "https://github.com/launchdarkly/agent-skills.git",
+  "repository": "https://github.com/launchdarkly/ai-tooling.git",
   "license": "Apache-2.0",
   "keywords": [
     "launchdarkly",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "support@launchdarkly.com"
   },
   "homepage": "https://launchdarkly.com",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "license": "Apache-2.0",
   "logo": "logo.svg",
   "keywords": [

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd ai-tooling
 npx skills add launchdarkly/ai-tooling
 
 # Or manually copy a skill into your agent's skills path:
-cp -r skills/feature-flags/launchdarkly-flag-cleanup <your-agent-skills-dir>/
+cp -r skills/feature-flags/launchdarkly-flag-cleanup <your-ai-tooling-dir>/
 ```
 
 Then ask your agent something like:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ cd ai-tooling
 npx skills add launchdarkly/ai-tooling
 
 # Or manually copy a skill into your agent's skills path:
-cp -r skills/feature-flags/launchdarkly-flag-cleanup <your-ai-tooling-dir>/
+cp -r skills/feature-flags/launchdarkly-flag-cleanup <your-agent-skills-dir>/
+
 ```
 
 Then ask your agent something like:

--- a/skills/feature-flags/launchdarkly-flag-cleanup/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-cleanup/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Safely automate feature flag cleanup workflows using LaunchDarkly MCP server",
   "version": "1.0.0-experimental",
   "author": "LaunchDarkly",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],
   "tags": [
     "launchdarkly",

--- a/skills/feature-flags/launchdarkly-flag-create/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-create/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Create and configure LaunchDarkly feature flags in a way that fits the existing codebase",
   "version": "1.0.0-experimental",
   "author": "LaunchDarkly",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],
   "tags": [
     "launchdarkly",

--- a/skills/feature-flags/launchdarkly-flag-discovery/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-discovery/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Audit your LaunchDarkly feature flags to understand the landscape, find stale or launched flags, and assess removal readiness",
   "version": "1.0.0-experimental",
   "author": "LaunchDarkly",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],
   "tags": [
     "launchdarkly",

--- a/skills/feature-flags/launchdarkly-flag-targeting/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-targeting/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Control LaunchDarkly feature flag targeting including toggling, rollouts, rules, individual targets, cross-environment copying, and approval workflows",
   "version": "1.0.0-experimental",
   "author": "LaunchDarkly",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],
   "tags": [
     "launchdarkly",

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -157,7 +157,7 @@ Perform these in **order** in the **same assistant turn**, then **stop at D1** u
 | **0** -- Onboarding log | Create or refresh `LAUNCHDARKLY_ONBOARDING.md` (or `docs/...`) | Resumable checklist, context, next-step pointer |
 | **1** -- Explore project | Detect language, framework, existing LD usage, environment type | Stack summary for the user |
 | **2** -- Detect agent | Cursor, Claude Code, Copilot, etc. | Correct `--agent` for `npx skills add` |
-| **3** -- Companion skills | `npx skills add ...` flag skills from `launchdarkly/agent-skills` | `launchdarkly-flag-*` skills available |
+| **3** -- Companion skills | `npx skills add ...` flag skills from `launchdarkly/ai-tooling` | `launchdarkly-flag-*` skills available |
 | **4** -- MCP | Configure LaunchDarkly MCP; user restarts; agent auto-verifies on next turn | MCP tools (or ldcli/API fallback) |
 | **5** -- SDK install | detect -> plan -> apply ([sdk-install](sdk-install/SKILL.md)) | Packages + init wired to env vars |
 | **6** -- First flag | Create boolean flag, evaluate, toggle, add interactive demo ([first-flag](first-flag/SKILL.md)) | End-to-end proof + visible "wow" moment |
@@ -227,15 +227,15 @@ Determine which coding agent is running so MCP config and `npx skills add --agen
 
 Install flag-management skills from the public repo so later steps can delegate when appropriate (see **Bundled vs public** below).
 
-**From `launchdarkly/agent-skills` (flag workflows):**
+**From `launchdarkly/ai-tooling` (flag workflows):**
 
 ```bash
-npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create launchdarkly-flag-discovery launchdarkly-flag-targeting launchdarkly-flag-cleanup -y --agent <detected-agent>
+npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create launchdarkly-flag-discovery launchdarkly-flag-targeting launchdarkly-flag-cleanup -y --agent <detected-agent>
 ```
 
 Replace `<detected-agent>` with the value from Step 2. Confirm success; skip skills already installed.
 
-**Bundled vs public:** Orchestration and setup for this flow live **in this folder** -- parent [SKILL.md](SKILL.md), nested [mcp-configure](mcp-configure/SKILL.md), [sdk-install](sdk-install/SKILL.md) (detect / plan / apply), [first-flag](first-flag/SKILL.md), and `references/` ([SDK recipes](references/sdk/recipes.md), [snippets](references/sdk/snippets/), summary, editor rules, etc.). The command above installs **flag-management** skills from the public [launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) repo only.
+**Bundled vs public:** Orchestration and setup for this flow live **in this folder** -- parent [SKILL.md](SKILL.md), nested [mcp-configure](mcp-configure/SKILL.md), [sdk-install](sdk-install/SKILL.md) (detect / plan / apply), [first-flag](first-flag/SKILL.md), and `references/` ([SDK recipes](references/sdk/recipes.md), [snippets](references/sdk/snippets/), summary, editor rules, etc.). The command above installs **flag-management** skills from the public [launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) repo only.
 
 ### Step 4: Configure the MCP Server
 
@@ -264,7 +264,7 @@ Create and evaluate a boolean flag; toggle and observe end-to-end.
 
 Install or refresh flag skills via:
 
-`npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <detected-agent>`
+`npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create -y --agent <detected-agent>`
 
 See D9 in [first-flag](first-flag/SKILL.md) for the blocking stop on auth errors.
 
@@ -352,4 +352,4 @@ This is **not** the same file as `LAUNCHDARKLY_ONBOARDING.md`. The onboarding lo
 
 **Public flag skills (install via Step 3)**
 
-- [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) -- `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, `launchdarkly-flag-cleanup`
+- [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) -- `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, `launchdarkly-flag-cleanup`

--- a/skills/onboarding/first-flag/SKILL.md
+++ b/skills/onboarding/first-flag/SKILL.md
@@ -14,7 +14,7 @@ The SDK is connected. Now help the user create their first feature flag and see 
 
 This skill is nested under [LaunchDarkly onboarding](../SKILL.md); the parent **Step 6** is **first flag**. **Prior:** [Apply code changes](../sdk-install/apply/SKILL.md).
 
-**Optional -- Flag Create skill already installed:** If the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) is available in the session (install with `npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <agent>`), you may use it for **creating the flag** and **choosing evaluation code** that matches the repo. You must still complete **default off -> verify OFF -> toggle on -> verify ON** (Steps 3-5 below). **Do not** require that skill: this page stays the full fallback when it is missing or MCP-only flows conflict with the user's setup.
+**Optional -- Flag Create skill already installed:** If the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) is available in the session (install with `npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create -y --agent <agent>`), you may use it for **creating the flag** and **choosing evaluation code** that matches the repo. You must still complete **default off -> verify OFF -> toggle on -> verify ON** (Steps 3-5 below). **Do not** require that skill: this page stays the full fallback when it is missing or MCP-only flows conflict with the user's setup.
 
 ## Security: Credential handling
 
@@ -350,7 +350,7 @@ The user has successfully:
 
 This is the "proof point" moment -- the user has a working feature flag they can toggle in real-time. The demo element makes it tangible and shareable.
 
-**Encourage the next skill:** Suggest they **install or enable** the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (`npx skills add launchdarkly/agent-skills --skill launchdarkly-flag-create -y --agent <agent>`) so future work -- creating flags that match repo conventions, wrapping features, and verifying wiring -- has a dedicated playbook. Offer to help them add it if they are unsure how.
+**Encourage the next skill:** Suggest they **install or enable** the **`launchdarkly-flag-create`** skill from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) (`npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create -y --agent <agent>`) so future work -- creating flags that match repo conventions, wrapping features, and verifying wiring -- has a dedicated playbook. Offer to help them add it if they are unsure how.
 
 ## Error handling
 
@@ -373,7 +373,7 @@ For non-auth errors (flag creation failures, SDK key mismatches, flags returning
 
 **Next steps to suggest:**
 
-- **Install** **`launchdarkly-flag-create`** from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) if it is not already available -- this onboarding flow only covers a first boolean flag; that skill guides real-world flag creation aligned with existing code patterns (requires LaunchDarkly MCP per that skill's prerequisites).
+- **Install** **`launchdarkly-flag-create`** from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) if it is not already available -- this onboarding flow only covers a first boolean flag; that skill guides real-world flag creation aligned with existing code patterns (requires LaunchDarkly MCP per that skill's prerequisites).
 - Use **`launchdarkly-flag-targeting`** from the same distribution to set up percentage rollouts and targeting rules
 - Read the [LaunchDarkly docs](https://docs.launchdarkly.com) for advanced topics like contexts, experimentation, and metrics
 

--- a/skills/onboarding/marketplace.json
+++ b/skills/onboarding/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Onboard a project to LaunchDarkly: kickoff roadmap, resumable log, explore repo, MCP, companion flag skills, nested SDK install (detect/plan/apply), first flag.",
   "version": "0.1.0",
   "author": "LaunchDarkly",
-  "repository": "https://github.com/launchdarkly/agent-skills",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],
   "tags": [
     "launchdarkly",

--- a/skills/onboarding/references/1.9-editor-rules.md
+++ b/skills/onboarding/references/1.9-editor-rules.md
@@ -13,19 +13,19 @@ After onboarding, do two things:
    - `launchdarkly-flag-targeting`
    - `launchdarkly-flag-cleanup`  
    **Optional:** `onboarding` (for more SDK onboarding later).  
-   **Preferred:** Install the **LaunchDarkly** plugin **`launchdarkly@launchdarkly-agent-skills`** from **[github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills)**, which packages these skills—then confirm in the UI or CLI that those skill names are available.
+   **Preferred:** Install the **LaunchDarkly** plugin **`launchdarkly@launchdarkly-ai-tooling`** from **[github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling)**, which packages these skills—then confirm in the UI or CLI that those skill names are available.
    - **Claude Code:** After any required marketplace setup for that repo (see the repository README or `claude plugin` / Anthropic docs for your CLI version), install with:
      ```bash
-     claude plugin install launchdarkly@launchdarkly-agent-skills
+     claude plugin install launchdarkly@launchdarkly-ai-tooling
      ```
      If the command name or flags differ in your build, use `claude plugin --help` and match the plugin coordinate above. **Verify** the four standard skills (above) show up as usable after install.
    - **Cursor:** Install or enable skills from the same distribution per current Cursor docs (marketplace / plugin UI pointing at this repo or copied folders). **Verify** the four `launchdarkly-flag-*` skills are listed or discoverable.
-   - **Fallback (no plugin):** Copy skill directories from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (or this monorepo’s published plugin) into the user’s skills location so each folder contains a `SKILL.md` for `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, and `launchdarkly-flag-cleanup`. Optional: include **`onboarding`** from this repo’s onboarding path. List any copied paths in the rules file so agents know where to read `SKILL.md`.
+   - **Fallback (no plugin):** Copy skill directories from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) (or this monorepo’s published plugin) into the user’s skills location so each folder contains a `SKILL.md` for `launchdarkly-flag-create`, `launchdarkly-flag-discovery`, `launchdarkly-flag-targeting`, and `launchdarkly-flag-cleanup`. Optional: include **`onboarding`** from this repo’s onboarding path. List any copied paths in the rules file so agents know where to read `SKILL.md`.
 2. **Write an editor rule** — The rule must tell *future* agents to **read and follow** those skills for flag work. Do **not** bake in SDK documentation URLs; procedures and compatibility live in each skill’s `SKILL.md`. Deep links to SDK docs belong in `LAUNCHDARKLY.md` if you already created that summary.
 
 ## Default skill set (feature flags)
 
-Unless the user opts out, treat **all** of these as the standard kit and mention each one in the generated rule. They are published in [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills) (same four skills as in step 1 above):
+Unless the user opts out, treat **all** of these as the standard kit and mention each one in the generated rule. They are published in [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) (same four skills as in step 1 above):
 
 | Skill `name` (frontmatter) | Purpose |
 |----------------------------|---------|
@@ -73,7 +73,7 @@ This project uses LaunchDarkly for feature flag management.
 
 ## Agent: use LaunchDarkly skills (required)
 
-Ensure the **LaunchDarkly** agent skills below are installed (`launchdarkly@launchdarkly-agent-skills` plugin from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills), or equivalent copies on disk). For any substantive flag work, **open that skill’s `SKILL.md` and follow it**—do not improvise from generic flag advice alone.
+Ensure the **LaunchDarkly** agent skills below are installed (`launchdarkly@launchdarkly-ai-tooling` plugin from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling), or equivalent copies on disk). For any substantive flag work, **open that skill’s `SKILL.md` and follow it**—do not improvise from generic flag advice alone.
 
 | Skill | When to use it |
 |-------|------------------|
@@ -129,7 +129,7 @@ For flag work, follow the LaunchDarkly agent skills when available: **`launchdar
 
 ### For JetBrains (IntelliJ, WebStorm, Rider, etc.)
 
-There is **no** JetBrains-specific rules template in this reference (`.idea/` only indicates the IDE family). **Do not silently skip:** tell the user you detected JetBrains and that they should rely on **`LAUNCHDARKLY.md`** ([Onboarding Summary](1.8-summary.md)) plus installing **`launchdarkly@launchdarkly-agent-skills`** (same as Claude Code) or copying skill folders manually.
+There is **no** JetBrains-specific rules template in this reference (`.idea/` only indicates the IDE family). **Do not silently skip:** tell the user you detected JetBrains and that they should rely on **`LAUNCHDARKLY.md`** ([Onboarding Summary](1.8-summary.md)) plus installing **`launchdarkly@launchdarkly-ai-tooling`** (same as Claude Code) or copying skill folders manually.
 
 Reasonable options to suggest:
 
@@ -139,7 +139,7 @@ Reasonable options to suggest:
 
 ### For other editors (not Cursor, Claude Code, Copilot, VS Code, or JetBrains)
 
-If the editor doesn't have a rules system, skip creating a rules file. Rely on `LAUNCHDARKLY.md` and tell the user which LaunchDarkly skills to install (`launchdarkly@launchdarkly-agent-skills` or copied skill folders from [github.com/launchdarkly/agent-skills](https://github.com/launchdarkly/agent-skills)).
+If the editor doesn't have a rules system, skip creating a rules file. Rely on `LAUNCHDARKLY.md` and tell the user which LaunchDarkly skills to install (`launchdarkly@launchdarkly-ai-tooling` or copied skill folders from [github.com/launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling)).
 
 ## Step 3: Fill in the Placeholders
 


### PR DESCRIPTION
## Summary

Clean up stale references

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/ai-tooling/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
