### PR TITLE
REL-13318: soften the skill language and requirements

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -238,7 +238,7 @@
       "name": "sdk-install",
       "description": "Install and initialize the correct LaunchDarkly SDK during onboarding by running nested skills in order: detect, plan, apply. Parent onboarding Step 6 is first flag.",
       "path": "skills/onboarding/sdk-install",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "compatibility": "Requires a supported language/framework in the project. SDK credentials are required by [Apply](apply/SKILL.md), not for [Detect](detect/SKILL.md) / [Plan](plan/SKILL.md) alone (see parent onboarding **Prerequisites**)."
     }

--- a/skills.json
+++ b/skills.json
@@ -81,7 +81,7 @@
       "name": "apply",
       "description": "Apply LaunchDarkly SDK onboarding: install dependency (or dual-SDK pair), configure env and secrets with consent, add init at entrypoint(s), verify compile. Nested under sdk-install; next is run.",
       "path": "skills/onboarding/sdk-install/apply",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "compatibility": "Requires integration plan and LaunchDarkly credentials (see parent onboarding)"
     },
@@ -212,7 +212,7 @@
       "name": "onboarding",
       "description": "Onboard a project to LaunchDarkly: kickoff roadmap, resumable log, explore repo, MCP, companion flag skills, nested SDK install (detect/plan/apply), first flag. Use when adding LaunchDarkly, setting up or integrating feature flags in a project, SDK integration, or 'onboard me'.",
       "path": "skills/onboarding",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "compatibility": "Requires an MCP-capable coding agent, `npx` on PATH for optional skill installs, and a LaunchDarkly account. SDK keys, client-side IDs, mobile keys, and API tokens are only needed when the step that uses them runs (see Prerequisites).",
       "tags": [
@@ -230,7 +230,7 @@
       "name": "plan",
       "description": "Generate a minimal LaunchDarkly SDK integration plan from detected stack: choose SDK type(s), dual-SDK server+client when required, files to change, env conventions. Nested under sdk-install; follows detect, precedes apply.",
       "path": "skills/onboarding/sdk-install/plan",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "compatibility": "Requires completed or equivalent detect context (see sibling detect skill)"
     },

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -146,7 +146,7 @@ When the user invokes this onboarding flow (for example by asking you to follow 
 
 Perform these in **order** in the **same assistant turn**, then proceed directly into Steps 0-3:
 
-1. **Task list:** Call your native task tool ([Progress Tracking](#progress-tracking)) and create **one task per step for Steps 0 through 6** (seven tasks minimum — one for each numbered row in the table below). Do this **before** rendering the roadmap so progress tracking is in place.
+1. **Task list:** Call your native task tool ([Progress Tracking](#progress-tracking)) and create **one task per step for Steps 0 through 6** (seven tasks minimum — one each for Steps 0, 1, 2, 3, 4, 5, and 6, even though Steps 0-3 are grouped as a single row below). Do this **before** rendering the roadmap so progress tracking is in place.
 2. **Roadmap:** Give the user a brief, friendly preview of what you are about to do. Keep it conversational -- a short paragraph or a compact list is fine. Do not render a large table by default (the table below is your internal reference). The user should understand the arc (explore the project, set up tooling, install the SDK, create a first flag) without seeing step numbers or internal labels.
 3. **Begin Steps 0-3 immediately.** These steps do not require a LaunchDarkly account or any user action. Run them in the background and surface only the results: what you found (language, framework, agent) and what you installed (companion skills). Do not narrate each step as a separate heading -- summarize them together when presenting findings to the user. Account status is inferred later (see [Prerequisites](#prerequisites)).
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -15,10 +15,12 @@ Orchestrates LaunchDarkly setup in an existing codebase: on kickoff, show a **ro
 ## Prerequisites
 
 - **`npx`:** Available on PATH when using `npx skills add` to install companion skills (see Step 3).
-- **LaunchDarkly account (outset only):** Early in onboarding -- right after the [Kickoff roadmap](#kickoff-onboarding-roadmap) if the log does not already say -- ask **only** whether the user already has a LaunchDarkly account (they can sign in at [https://app.launchdarkly.com](https://app.launchdarkly.com)). **Do not** ask in the same turn for SDK keys, client-side IDs, mobile keys, API access tokens, or whether keys are in env; defer those until the step that needs them (below).
-  - **If they do not have an account yet:** Point them to https://app.launchdarkly.com/signup?source=agent. Continue with repo exploration, agent detection, and companion skills where those do not require LaunchDarkly API access; MCP OAuth and SDK work wait on account access.
-  - **If they have an account:** Proceed through the workflow. Still **do not** prompt for SDK key material until **Step 5** [Apply code changes](sdk-install/apply/SKILL.md) (or until **run** if they prefer to paste into env later).
-- **Keys and tokens (defer -- do not bundle with the account question):** Collect these only when the path requires them -- never as part of the initial "do you have an account?" prompt.
+- **LaunchDarkly account (deferred -- inferred, not asked upfront):** Do NOT ask whether the user has a LaunchDarkly account at the start. Instead, let the workflow reveal account status naturally:
+  - **Steps 0-3** (log, explore, detect, install skills) do not require an account. Run them first.
+  - **Step 4 (MCP):** Present the MCP install link. If the user completes OAuth successfully, they have an account -- confirmed, no question needed.
+  - **Step 5 (SDK keys):** If MCP is not configured (or the user declined it), account status becomes relevant at D7 when the user needs to provide keys. If they cannot provide keys, offer the signup link: https://app.launchdarkly.com/signup?source=agent.
+  - This eliminates the upfront "Do you have an account?" question and lets the workflow itself surface whether the user needs to sign up.
+- **Keys and tokens (defer until needed):** Collect these only when the path requires them.
   - **Step 4 -- MCP:** **Hosted MCP** uses OAuth; no API token or SDK key needed to configure it. **Local `npx` MCP** (federal/EU, etc.): API access token per [mcp-configure](mcp-configure/SKILL.md) and [MCP Config Templates](mcp-configure/references/mcp-config-templates.md).
   - **Step 5 -- SDK:** **SDK keys / client-side ID / mobile key** when wiring env in [Apply code changes](sdk-install/apply/SKILL.md), after the integration plan is confirmed. **`ldcli` / REST** for discovery: use **`ldcli login`** or an access token when you first run those commands, not at hello.
   - **Key type must match the integration:** server-side SDK -> **SDK key**; browser/client-side SDK -> **Client-side ID**; mobile -> **Mobile key**. Env variable names and bundler rules: [Apply code changes](sdk-install/apply/SKILL.md).
@@ -105,17 +107,16 @@ Do NOT treat the user's initial request (e.g. "onboard me," "set up LaunchDarkly
 
 | ID | Location | Question |
 |----|----------|----------|
-| D1 | Kickoff | Do you have a LaunchDarkly account? |
 | D4-LOCAL | Step 4 (local MCP) | User chooses whether to handle the access token themselves (recommended) or let the agent help |
 | D5-NOAPP | Step 5 -- detect | No runnable app found: user points to app or requests demo |
 | D5-UNCLEAR | Step 5 -- detect | Weak evidence: user confirms the correct app folder |
 | D5 | Step 5 -- detect | SDK confirmation / one-vs-both-SDKs scope choice |
-| D6 | Step 5 -- plan | Approve the integration plan before any code changes |
-| D7 | Step 5 -- apply | User chooses how secrets are set up: user-specified location, user handles it, or `.env` fallback |
+| D6 | Step 5 -- plan | Integration plan preview (non-blocking: present plan and continue unless user objects) |
+| D7 | Step 5 -- apply | User chooses how secrets are set up: user-specified location, user handles it, or `.env` fallback. If user cannot provide keys, offer signup link. |
 | D8 | Step 5 -- apply | Approval before changing non-LaunchDarkly dependencies |
 | D9 | Step 6 | Auth errors (401/403): stop, do not retry automatically |
 
-**Non-blocking** (you may proceed automatically): Step 0 onboarding log (write it directly), Step 1 exploration (read-only), Step 3 skill install (installs to agent config, not the user's repo), Step 5 detect (file reads only), compile check (Step 5 apply Step 4), follow-through file writes (`LAUNCHDARKLY.md`, editor rules).
+**Non-blocking** (you may proceed automatically): Steps 0-3 (log, explore, detect agent, install skills -- no user input needed), D6 plan preview (present and continue unless user objects), Step 5 detect (file reads only), compile check (Step 5 apply Step 4), follow-through file writes (`LAUNCHDARKLY.md`, editor rules).
 
 ## Core Principles
 
@@ -125,7 +126,7 @@ Do NOT treat the user's initial request (e.g. "onboard me," "set up LaunchDarkly
 4. **Validate end-to-end:** Confirm the SDK is connected before treating the first flag as proof of success.
 5. **Paper trail:** Keep the Step 0 onboarding log current so another agent or session can continue without re-deriving context.
 6. **Orient the user first:** On a fresh onboarding request, show the [Kickoff roadmap](#kickoff-onboarding-roadmap) before substantive work so the user knows the full arc.
-7. **Stage credential questions:** Confirm **account** at the outset; ask for **SDK keys / tokens** only in Step 4-5 when that step's skill says they are required ([Prerequisites](#prerequisites)).
+7. **Defer credential questions:** Do not ask about account status or keys upfront. Account status is inferred through MCP OAuth (Step 4) or surfaced at D7 (Step 5) when keys are needed. Ask for **SDK keys / tokens** only in Step 4-5 when that step's skill says they are required ([Prerequisites](#prerequisites)).
 8. **Deep-link to the dashboard:** When generating LaunchDarkly dashboard URLs and the **project key** and/or **environment key** are known (from MCP tools, user input, or the onboarding log), construct the most specific URL possible instead of linking to a generic page. Use these patterns:
 
    | What you need to show | URL pattern |
@@ -144,73 +145,59 @@ When the user invokes this onboarding flow (for example by asking you to follow 
 
 ### Kickoff sequence (new run — before any numbered step)
 
-Perform these in **order** in the **same assistant turn**, then **stop at D1** until the user answers:
+Perform these in **order** in the **same assistant turn**, then proceed directly into Steps 0-3:
 
-1. **Task list:** Call your native task tool ([Progress Tracking](#progress-tracking)) and create **one task per step for Steps 0 through 6** (seven tasks minimum — one for each numbered row in the table below). Do this **before** rendering the roadmap table so progress tracking is in place before you pause on D1.
-2. **Roadmap:** Render the roadmap table below in the user-visible reply (adjust row wording only if an [Edge case](#edge-cases) will obviously skip a step). The roadmap is a chat artifact only -- **do not** create a file for it unless the user asks.
-3. **D1:** Call your structured question tool for the account question (see **D1** below). **Do not** create or update `LAUNCHDARKLY_ONBOARDING.md`, explore the repo for Step 1, detect the agent for Step 2, or run **`npx`** (or any shell install) for Step 3 until the user has answered D1.
+1. **Task list:** Call your native task tool ([Progress Tracking](#progress-tracking)) and create **one task per step for Steps 0 through 6** (seven tasks minimum — one for each numbered row in the table below). Do this **before** rendering the roadmap so progress tracking is in place.
+2. **Roadmap:** Give the user a brief, friendly preview of what you are about to do. Keep it conversational -- a short paragraph or a compact list is fine. Do not render a large table by default (the table below is your internal reference). The user should understand the arc (explore the project, set up tooling, install the SDK, create a first flag) without seeing step numbers or internal labels.
+3. **Begin Steps 0-3 immediately.** These steps do not require a LaunchDarkly account or any user action. Run them in the background and surface only the results: what you found (language, framework, agent) and what you installed (companion skills). Do not narrate each step as a separate heading -- summarize them together when presenting findings to the user. Account status is inferred later (see [Prerequisites](#prerequisites)).
 
-- **Resuming:** If `LAUNCHDARKLY_ONBOARDING.md` already exists, read it first per [Step 0](#step-0-create-or-refresh-the-onboarding-log). Show the same roadmap with a **Status** column filled from the log, or a shorter "where we are" summary -- whichever keeps the user oriented. Refresh the task list to match the log if needed; if D1 (account status) is already recorded in the log, **do not** ask D1 again -- continue from the log's **Next step**.
+- **Resuming:** If `LAUNCHDARKLY_ONBOARDING.md` already exists, read it first per [Step 0](#step-0-create-or-refresh-the-onboarding-log). Show a shorter "where we are" summary. Refresh the task list to match the log; continue from the log's **Next step**.
 
 | Step | What happens | You get |
 |------|--------------|---------|
-| **0** -- Onboarding log | Create or refresh `LAUNCHDARKLY_ONBOARDING.md` (or `docs/...`) | Resumable checklist, context, next-step pointer |
-| **1** -- Explore project | Detect language, framework, existing LD usage, environment type | Stack summary for the user |
-| **2** -- Detect agent | Cursor, Claude Code, Copilot, etc. | Correct `--agent` for `npx skills add` |
-| **3** -- Companion skills | `npx skills add ...` flag skills from `launchdarkly/ai-tooling` | `launchdarkly-flag-*` skills available |
-| **4** -- MCP | Configure LaunchDarkly MCP; user restarts; agent auto-verifies on next turn | MCP tools (or ldcli/API fallback) |
+| **0-3** -- Setup | Create onboarding log, explore project, detect agent, install companion skills (`npx skills add` from `launchdarkly/ai-tooling`) | Stack summary, agent ID, `launchdarkly-flag-*` skills available |
+| **4** -- MCP | Configure LaunchDarkly MCP; user restarts; agent auto-verifies on next turn | MCP tools (or ldcli/API fallback); account confirmed via OAuth |
 | **5** -- SDK install | detect -> plan -> apply ([sdk-install](sdk-install/SKILL.md)) | Packages + init wired to env vars |
 | **6** -- First flag | Create boolean flag, evaluate, toggle, add interactive demo ([first-flag](first-flag/SKILL.md)) | End-to-end proof + visible "wow" moment |
-| **Follow-through** | Optional: `LAUNCHDARKLY.md`, editor rules ([1.8-summary](references/1.8-summary.md), [1.9-editor-rules](references/1.9-editor-rules.md)) | Durable docs for the repo |
+| **Follow-through** | `LAUNCHDARKLY.md`, editor rules ([1.8-summary](references/1.8-summary.md), [1.9-editor-rules](references/1.9-editor-rules.md)) | Durable docs for the repo |
 
-**D1 -- BLOCKING** (end of kickoff sequence): Call your structured question tool now.
-
-- question: "Do you already have a LaunchDarkly account you can sign into?"
-- options:
-  - "Yes, I have an account" -> proceed through full workflow
-  - "No / not yet" -> point to https://app.launchdarkly.com/signup?source=agent, continue Steps 1-3 only
-- STOP. Do not write the question as text. Do not continue until the user selects an option.
-
-If they need an account, point them to https://app.launchdarkly.com/signup?source=agent and explain which later steps (MCP, SDK keys) will wait on it. Then proceed with [Step 0](#step-0-create-or-refresh-the-onboarding-log) (or the log's **Next step** if resuming).
+After presenting the roadmap preview, proceed directly into Steps 0-3 (they require no user input or account). Then continue with [Step 4](#step-4-configure-the-mcp-server).
 
 ## Workflow
 
 Follow **Steps 0-6** in order unless an **Edge case** says otherwise. When **Step 6** (first flag) completes successfully, continue with [Default follow-through](#default-follow-through-not-numbered-steps).
 
-### Step 0: Create or Refresh the Onboarding Log
+### Steps 0-3: Setup (run silently -- do not narrate each step)
 
-Before substantive work, give this run a **durable paper trail** so a new agent or a later session can see what was decided, what ran, and what is next.
+These four steps run automatically without user input. Perform them all, then present a single summary of what you found and what you set up. Do NOT show individual step headings, log-creation messages, or install output to the user.
 
-1. **Look for an existing log** at the repo root: `LAUNCHDARKLY_ONBOARDING.md`. If the project keeps docs under `docs/`, prefer `docs/LAUNCHDARKLY_ONBOARDING.md` when that folder already exists and the root file is absent.
-2. **Create or update the log file.** This is part of the onboarding workflow -- write it directly without asking for permission.
-3. **If resuming:** read the log first, align with the stated **next step**, and only redo work the log marks incomplete or invalid.
-4. **What to write** (update after each numbered step finishes or when something important changes):
+**Step 0: Onboarding log.** Create or refresh `LAUNCHDARKLY_ONBOARDING.md` silently.
+
+1. Look for an existing log at the repo root: `LAUNCHDARKLY_ONBOARDING.md`. If the project keeps docs under `docs/`, prefer `docs/LAUNCHDARKLY_ONBOARDING.md` when that folder already exists and the root file is absent.
+2. Create or update the log file directly without asking for permission.
+3. If resuming: read the log first, align with the stated **next step**, and only redo work the log marks incomplete or invalid.
+4. What to write (update after each numbered step finishes or when something important changes):
    - **Checklist:** Steps 0-6 with status (`not started` / `in progress` / `done` / `skipped` + brief reason).
    - **Context:** coding agent id (once known), language/framework summary, monorepo target path if any, LaunchDarkly **project key** and **environment key** when known (never paste secrets or full SDK keys -- say "stored in env" or "user provided offline").
    - **MCP:** configured yes/no, hosted vs fallback, link to config path if relevant.
    - **Commands run:** e.g. `npx skills add ...` (no secrets).
    - **Blockers / errors:** what failed and what was tried.
    - **Next step:** single explicit step number and name (e.g. "Step 5: Install and Initialize the SDK").
-5. **After errors:** append or edit the log with what broke and where you are resuming.
+5. After errors: append or edit the log with what broke and where you are resuming.
 
-This file is a **working** log during onboarding. After success, the user may delete it, archive it, or fold facts into `LAUNCHDARKLY.md` ([Onboarding Summary](references/1.8-summary.md)).
+This file is a **working** log during onboarding. After success, it is deleted and replaced with `LAUNCHDARKLY.md` ([Onboarding Summary](references/1.8-summary.md)).
 
-### Step 1: Explore the Project
+**Step 1: Explore the project.** Understand what you are integrating.
 
-Understand what you are integrating before installing packages.
-
-1. **Identify language and framework.** Check dependency files: `package.json`, `go.mod`, `requirements.txt` / `pyproject.toml` / `Pipfile`, `pom.xml` / `build.gradle`, `Gemfile`, `*.csproj` / `*.sln`, `Cargo.toml`, etc.
-2. **Check for existing LaunchDarkly usage.** Search for `launchdarkly`, `ldclient`, `ld-client`, `LDClient`, `@launchdarkly`.
+1. Identify language and framework. Check dependency files: `package.json`, `go.mod`, `requirements.txt` / `pyproject.toml` / `Pipfile`, `pom.xml` / `build.gradle`, `Gemfile`, `*.csproj` / `*.sln`, `Cargo.toml`, etc.
+2. Check for existing LaunchDarkly usage. Search for `launchdarkly`, `ldclient`, `ld-client`, `LDClient`, `@launchdarkly`.
    - If already present: note SDK version and patterns; you may shorten or skip [Step 5](#step-5-install-and-initialize-the-sdk) per edge cases.
    - If not present: plan full SDK setup.
-3. **Identify environment type:** server-side app, client SPA, mobile, edge, etc. -- this drives SDK choice.
-4. **Summarize to the user:** language, framework, environment type, whether LD is already integrated.
+3. Identify environment type: server-side app, client SPA, mobile, edge, etc. -- this drives SDK choice.
 
 Deep detection details: [Detect repository stack](sdk-install/detect/SKILL.md) (nested under [sdk-install](sdk-install/SKILL.md)).
 
-### Step 2: Detect the Agent Environment
-
-Determine which coding agent is running so MCP config and `npx skills add --agent` use the right target. **Infer the agent silently — do not ask the user.**
+**Step 2: Detect the agent environment.** Infer silently -- do not ask the user.
 
 1. Check for indicators (in priority order — stop at the first strong match):
    - **Cursor:** `.cursor/`, `.cursorrules`, or `CURSOR_` env vars
@@ -218,16 +205,10 @@ Determine which coding agent is running so MCP config and `npx skills add --agen
    - **Windsurf:** `.windsurfrules`
    - **GitHub Copilot:** `.github/copilot/`
    - **Codex:** `~/.codex/`, `AGENTS.md`
+2. If multiple indicators are present, pick the one whose runtime you are **currently executing inside**. If none match, default to the agent whose tool surface you observe at runtime.
+3. Remember the agent id for Step 3 (e.g. `cursor`, `claude-code`).
 
-2. If multiple indicators are present, pick the one whose runtime you are **currently executing inside** (e.g. if you have access to Cursor-specific tools like `AskQuestion` or `TodoWrite`, you are in Cursor). If none of the indicators match, default to the agent whose tool surface you observe at runtime.
-
-3. Remember the agent id for Step 3 (e.g. `cursor`, `claude-code`). Mention the detected agent briefly when presenting the Step 1/2 summary so the user can correct you if wrong, but do not block on a question.
-
-### Step 3: Install Companion Skills
-
-Install flag-management skills from the public repo so later steps can delegate when appropriate (see **Bundled vs public** below).
-
-**From `launchdarkly/ai-tooling` (flag workflows):**
+**Step 3: Install companion skills.** Install flag-management skills from the public repo so later steps can delegate when appropriate.
 
 ```bash
 npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create launchdarkly-flag-discovery launchdarkly-flag-targeting launchdarkly-flag-cleanup -y --agent <detected-agent>
@@ -236,6 +217,8 @@ npx skills add launchdarkly/ai-tooling --skill launchdarkly-flag-create launchda
 Replace `<detected-agent>` with the value from Step 2. Confirm success; skip skills already installed.
 
 **Bundled vs public:** Orchestration and setup for this flow live **in this folder** -- parent [SKILL.md](SKILL.md), nested [mcp-configure](mcp-configure/SKILL.md), [sdk-install](sdk-install/SKILL.md) (detect / plan / apply), [first-flag](first-flag/SKILL.md), and `references/` ([SDK recipes](references/sdk/recipes.md), [snippets](references/sdk/snippets/), summary, editor rules, etc.). The command above installs **flag-management** skills from the public [launchdarkly/ai-tooling](https://github.com/launchdarkly/ai-tooling) repo only.
+
+**After Steps 0-3 complete:** Present a single summary to the user covering what you found (language, framework, environment type, whether LD is already integrated, detected agent). Then proceed to [Step 4](#step-4-configure-the-mcp-server).
 
 ### Step 4: Configure the MCP Server
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires an MCP-capable coding agent, `npx` on PATH for optional skill installs, and a LaunchDarkly account. SDK keys, client-side IDs, mobile keys, and API tokens are only needed when the step that uses them runs (see Prerequisites).
 metadata:
   author: launchdarkly
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # LaunchDarkly SDK Onboarding
@@ -111,7 +111,6 @@ Do NOT treat the user's initial request (e.g. "onboard me," "set up LaunchDarkly
 | D5-NOAPP | Step 5 -- detect | No runnable app found: user points to app or requests demo |
 | D5-UNCLEAR | Step 5 -- detect | Weak evidence: user confirms the correct app folder |
 | D5 | Step 5 -- detect | SDK confirmation / one-vs-both-SDKs scope choice |
-| D6 | Step 5 -- plan | Integration plan preview (non-blocking: present plan and continue unless user objects) |
 | D7 | Step 5 -- apply | User chooses how secrets are set up: user-specified location, user handles it, or `.env` fallback. If user cannot provide keys, offer signup link. |
 | D8 | Step 5 -- apply | Approval before changing non-LaunchDarkly dependencies |
 | D9 | Step 6 | Auth errors (401/403): stop, do not retry automatically |
@@ -151,7 +150,7 @@ Perform these in **order** in the **same assistant turn**, then proceed directly
 2. **Roadmap:** Give the user a brief, friendly preview of what you are about to do. Keep it conversational -- a short paragraph or a compact list is fine. Do not render a large table by default (the table below is your internal reference). The user should understand the arc (explore the project, set up tooling, install the SDK, create a first flag) without seeing step numbers or internal labels.
 3. **Begin Steps 0-3 immediately.** These steps do not require a LaunchDarkly account or any user action. Run them in the background and surface only the results: what you found (language, framework, agent) and what you installed (companion skills). Do not narrate each step as a separate heading -- summarize them together when presenting findings to the user. Account status is inferred later (see [Prerequisites](#prerequisites)).
 
-- **Resuming:** If `LAUNCHDARKLY_ONBOARDING.md` already exists, read it first per [Step 0](#step-0-create-or-refresh-the-onboarding-log). Show a shorter "where we are" summary. Refresh the task list to match the log; continue from the log's **Next step**.
+- **Resuming:** If `LAUNCHDARKLY_ONBOARDING.md` already exists, read it first per [Steps 0-3](#steps-0-3-setup-run-silently----do-not-narrate-each-step). Show a shorter "where we are" summary. Refresh the task list to match the log; continue from the log's **Next step**.
 
 | Step | What happens | You get |
 |------|--------------|---------|
@@ -236,7 +235,7 @@ If the project **already has LaunchDarkly installed and initialized** (see [dete
 
 Otherwise hand off to [LaunchDarkly SDK Install (onboarding)](sdk-install/SKILL.md), which runs nested skills in order: [Detect repository stack](sdk-install/detect/SKILL.md) -> [Generate integration plan](sdk-install/plan/SKILL.md) -> [Apply code changes](sdk-install/apply/SKILL.md), using [SDK recipes](references/sdk/recipes.md) and [SDK snippets](references/sdk/snippets/). If the user asked for **both** server and client (e.g. API + SPA, Next.js server + browser), follow [Dual SDK integrations](sdk-install/plan/SKILL.md#dual-sdk-integrations) through plan and apply so **both** SDKs are really installed and initialized.
 
-**Blocking decision points inside Step 5** (see nested skills): D5 (SDK scope), D6 (plan approval), D7 (secret consent), D8 (dependency changes). Do NOT batch tool calls across these boundaries.
+**Blocking decision points inside Step 5** (see nested skills): D5 (SDK scope), D7 (secret consent), D8 (dependency changes). Do NOT batch tool calls across these boundaries. D6 (plan preview) is non-blocking -- present the plan and continue unless the user objects.
 
 ### Step 6: Create Your First Feature Flag
 
@@ -304,7 +303,7 @@ This is **not** the same file as `LAUNCHDARKLY_ONBOARDING.md`. The onboarding lo
 
 **Continuity**
 
-- Step 0 -- `LAUNCHDARKLY_ONBOARDING.md` (working log; see [Step 0](#step-0-create-or-refresh-the-onboarding-log))
+- Step 0 -- `LAUNCHDARKLY_ONBOARDING.md` (working log; see [Steps 0-3](#steps-0-3-setup-run-silently----do-not-narrate-each-step))
 
 **Step 4 -- MCP (nested skill is primary)**
 

--- a/skills/onboarding/sdk-install/SKILL.md
+++ b/skills/onboarding/sdk-install/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires a supported language/framework in the project. SDK credentials are required by [Apply](apply/SKILL.md), not for [Detect](detect/SKILL.md) / [Plan](plan/SKILL.md) alone (see parent onboarding **Prerequisites**).
 metadata:
   author: launchdarkly
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # LaunchDarkly SDK Install (onboarding)
@@ -15,7 +15,7 @@ Installs and initializes the right LaunchDarkly SDK for the user’s project by 
 ## Prerequisites
 
 - Project context from parent **Step 1: Explore the Project** (reuse it; only re-run deep detection if something is unclear)
-- **SDK key / client-side ID / mobile key:** Needed when you reach [Apply code changes](apply/SKILL.md) (env wiring). **Do not** ask the user for these during detect or plan solely because you opened this skill—follow parent onboarding: account is confirmed early; key material is collected at apply (see parent [Prerequisites](../SKILL.md#prerequisites)).
+- **SDK key / client-side ID / mobile key:** Needed when you reach [Apply code changes](apply/SKILL.md) (env wiring). **Do not** ask the user for these during detect or plan solely because you opened this skill—follow parent onboarding: account status is inferred via MCP OAuth (Step 4) or surfaced at D7 in apply; key material is collected at apply (see parent [Prerequisites](../SKILL.md#prerequisites)).
 
 ## Key types (summary)
 
@@ -29,12 +29,12 @@ Installs and initializes the right LaunchDarkly SDK for the user’s project by 
 
 ## Workflow — run these nested skills in order
 
-Execute **all three** unless the [detect decision tree](detect/SKILL.md#decision-tree) short-circuits (e.g. skip to apply only). Each nested skill contains **blocking decision points** (marked `D<N> -- BLOCKING`) where you must call your structured question tool and wait for the user's response before continuing. Do NOT batch tool calls across these boundaries.
+Execute **all three** unless the [detect decision tree](detect/SKILL.md#decision-tree) short-circuits (e.g. skip to apply only). Each nested skill may contain decision points — some **blocking** (marked `D<N> -- BLOCKING`, where you must call your structured question tool and wait for the user's response before continuing) and some **non-blocking** (where you present information and continue unless the user objects). Do NOT batch tool calls across blocking boundaries.
 
 | Order | Nested skill | Role |
 |-------|----------------|------|
 | 1 | [Detect repository stack](detect/SKILL.md) | Language, package manager, monorepo target, entrypoint, existing LD usage |
-| 2 | [Generate integration plan](plan/SKILL.md) | SDK choice, files to change, env plan -- confirm with user before edits |
+| 2 | [Generate integration plan](plan/SKILL.md) | SDK choice, files to change, env plan -- presented to user (non-blocking; see plan SKILL.md D6) |
 | 3 | [Apply code changes](apply/SKILL.md) | Install package(s), `.env` / secrets with consent, init code, compile check (**both** tracks when [dual-SDK plan](plan/SKILL.md#dual-sdk-integrations)) |
 
 Shared references for all steps: [SDK recipes](../references/sdk/recipes.md), [SDK snippets](../references/sdk/snippets/).

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires integration plan and LaunchDarkly credentials (see parent onboarding)
 metadata:
   author: launchdarkly
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Apply code changes (SDK install)

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -83,9 +83,10 @@ If the user **declines** broader changes: keep only the LD package addition if p
 **If the user chooses option 4 ("I don't have an account yet"):**
 1. Point them to https://app.launchdarkly.com/signup?source=agent
 2. Explain that SDK key setup requires an account -- they can complete setup after signing up
-3. Write placeholder variable names to `.env` (no real values) so the code compiles
-4. Continue with Step 3 (init code) using the placeholder env var references. The app will fail to connect to LaunchDarkly until real keys are set, which is expected.
-5. Note in the onboarding log that key setup is pending account creation
+3. Ensure `.env` is in `.gitignore` before writing (same check as option 3 / [Write to `.env`](#write-to-env-when-the-user-consents))
+4. Write placeholder variable names to `.env` (no real values) so the code compiles
+5. Continue with Step 3 (init code) using the placeholder env var references. The app will fail to connect to LaunchDarkly until real keys are set, which is expected.
+6. Note in the onboarding log that key setup is pending account creation
 
 ### Fetching keys via MCP
 

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -16,7 +16,7 @@ This skill is nested under [LaunchDarkly SDK Install (onboarding)](../SKILL.md);
 
 **Dual SDK:** If the approved plan is **dual SDK** ([plan: Dual SDK integrations](../plan/SKILL.md#dual-sdk-integrations)), you must complete Steps 1-3 **for both tracks** -- **two** packages in the manifest, **two** install commands run (or equivalent), **two** credential lines where needed, **two** inits in **different** entrypoints per recipe. **Do not** claim the second SDK is set up without performing its real install and init. If the plan only listed one track but the user asked for both, **stop** and return to [plan](../plan/SKILL.md) -- do not invent the second half from memory.
 
-**Credential timing:** This is the first nested step where you ask the user for **SDK key / client-side ID / mobile key** (or consent to fetch/write them). Earlier onboarding should have confirmed only **account** access, not key material ([parent Prerequisites](../../SKILL.md#prerequisites)).
+**Credential timing:** This is the first nested step where you ask the user for **SDK key / client-side ID / mobile key** (or consent to fetch/write them). Account status is not asked upfront -- it is inferred earlier via MCP OAuth (parent Step 4) or surfaced here at D7 (option 4) if the user has no account yet ([parent Prerequisites](../../SKILL.md#prerequisites)).
 
 ## Step 1: Install the SDK dependency
 

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -60,7 +60,7 @@ If the user **declines** broader changes: keep only the LD package addition if p
   - "I'll tell you where to put it"
   - "I'll set up the secret myself -- just tell me what variable name to use"
   - "Write it to a `.env` file for me"
-  - "I don't have an account yet -- help me sign up" -> point to https://app.launchdarkly.com/signup?source=agent, pause SDK key setup until account is ready
+  - "I don't have an account yet -- help me sign up" -> point to https://app.launchdarkly.com/signup?source=agent, write placeholders and continue (real keys deferred until account is ready)
 - STOP. Do not write the question as text. Do not fetch keys from LaunchDarkly or write real values into the repo without the user selecting an option first. Do not infer the answer from context or prior conversation -- always present this choice.
 
 **If the user chooses option 1 ("Tell me where to put it"):**

--- a/skills/onboarding/sdk-install/apply/SKILL.md
+++ b/skills/onboarding/sdk-install/apply/SKILL.md
@@ -54,13 +54,14 @@ If the user **declines** broader changes: keep only the LD package addition if p
 
 ### Permission before secrets
 
-**D7 -- BLOCKING:** Call your structured question tool now.
+**D7 -- BLOCKING (MANDATORY -- DO NOT SKIP):** Call your structured question tool now. This decision point exists for security compliance -- the user must explicitly choose how secrets are handled. Skipping this and proceeding to write keys without consent is a critical failure.
 - question: "The SDK needs an SDK key (or client-side ID / mobile key) for your environment. How would you like to set up the secret?"
 - options:
   - "I'll tell you where to put it"
   - "I'll set up the secret myself -- just tell me what variable name to use"
   - "Write it to a `.env` file for me"
-- STOP. Do not write the question as text. Do not fetch keys from LaunchDarkly or write real values into the repo without the user selecting an option first.
+  - "I don't have an account yet -- help me sign up" -> point to https://app.launchdarkly.com/signup?source=agent, pause SDK key setup until account is ready
+- STOP. Do not write the question as text. Do not fetch keys from LaunchDarkly or write real values into the repo without the user selecting an option first. Do not infer the answer from context or prior conversation -- always present this choice.
 
 **If the user chooses option 1 ("Tell me where to put it"):**
 1. Ask where they want the secret written (file path, secrets manager, etc.)
@@ -78,6 +79,13 @@ If the user **declines** broader changes: keep only the LD package addition if p
 1. Ask how they want to provide the key: paste it, or have the agent fetch it via MCP/API
 2. Follow the [Write to `.env`](#write-to-env-when-the-user-consents) section below
 3. Ensure `.env` is in `.gitignore` before writing any real values
+
+**If the user chooses option 4 ("I don't have an account yet"):**
+1. Point them to https://app.launchdarkly.com/signup?source=agent
+2. Explain that SDK key setup requires an account -- they can complete setup after signing up
+3. Write placeholder variable names to `.env` (no real values) so the code compiles
+4. Continue with Step 3 (init code) using the placeholder env var references. The app will fail to connect to LaunchDarkly until real keys are set, which is expected.
+5. Note in the onboarding log that key setup is pending account creation
 
 ### Fetching keys via MCP
 

--- a/skills/onboarding/sdk-install/plan/SKILL.md
+++ b/skills/onboarding/sdk-install/plan/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires completed or equivalent detect context (see sibling detect skill)
 metadata:
   author: launchdarkly
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Generate integration plan (SDK install)

--- a/skills/onboarding/sdk-install/plan/SKILL.md
+++ b/skills/onboarding/sdk-install/plan/SKILL.md
@@ -125,14 +125,11 @@ Only LaunchDarkly SDK packages will be added unless the user explicitly approves
 
 After presenting the plan:
 
-**D6 -- BLOCKING:** Call your structured question tool now.
-- question: "Here's the integration plan. Does this look right?"
-- options:
-  - "Yes, approve and proceed" -> begin applying
-  - "I'd like to change something" -> let user specify changes
-- STOP. Do not write the question as text. Do not begin installing packages, writing files, or modifying code until the user selects an option.
+**D6 -- NON-BLOCKING (proceed unless objected):** Present the plan summary to the user with a note like "Here's what I'm going to do -- say stop or let me know if anything looks wrong." Then **continue into [Apply code changes](../apply/SKILL.md)** without waiting for explicit approval. If the user objects or says something looks wrong, stop and adjust the plan before continuing.
 
-If the entrypoint is ambiguous or multiple SDKs could apply, ask those specific questions as part of the plan presentation (each as its own blocking decision point using the same pattern).
+This is intentionally non-blocking to reduce ceremony. The plan is visible to the user and they can interrupt at any time. The real safety gates are D7 (secret consent) and D8 (non-LD dependency changes) in the apply step.
+
+If the entrypoint is ambiguous or multiple SDKs could apply, those specific questions **are** blocking -- ask them as part of the plan presentation using your structured question tool and wait for an answer before proceeding.
 
 **Do not** ask for SDK keys, client-side IDs, or mobile keys as part of plan confirmation -- the parent flow collects those at [Apply code changes](../apply/SKILL.md). The **Key type** column above is for technical planning only, not a prompt for secrets.
 


### PR DESCRIPTION
## Summary

**D1 removal + deferred account inference**
- Removed the upfront "Do you have a LaunchDarkly account?" question (D1) from the blocking decision points table
- Rewrote the Prerequisites section so account status is inferred naturally -- Steps 0-3 run without an account, Step 4 (MCP OAuth) confirms it implicitly, and D7 catches the remaining case
- Added a fourth option to D7 in `sdk-install/apply/SKILL.md`: "I don't have an account yet -- help me sign up," with handling instructions for writing placeholder environment variables

**D7 enforcement strengthening**
- Added `(MANDATORY -- DO NOT SKIP)` enforcement language to D7 in `sdk-install/apply/SKILL.md`
- Added "always present this choice" instruction so the agent cannot silently skip the secret-consent gate
- This closes the gap left by D1 removal -- D7 now catches the no-account case that D1 used to handle

**D6 softening**
- Changed D6 (plan approval) from `BLOCKING` to `NON-BLOCKING (proceed unless objected)` in `sdk-install/plan/SKILL.md`
- The agent now presents the plan and continues unless the user explicitly objects, reducing ceremony

**Steps 0-3 collapse + roadmap verbosity reduction**
- Restructured Steps 0-3 into a single silent setup phase -- the agent runs all four steps without narrating each one, then presents a combined summary
- Collapsed the roadmap table rows for Steps 0-3 into a single row in the internal reference table
- Changed the user-facing roadmap from a large table to a brief conversational preview
- Added an "After Steps 0-3 complete" instruction for presenting findings

**Devin Review bug fixes**
- Removed D6 from the blocking decision points table (`SKILL.md:114`) — it was contradicting the non-blocking semantics defined in `plan/SKILL.md`
- Updated the Step 5 summary (`SKILL.md:238`) to remove D6 from the blocking list and note it as non-blocking
- Fixed two broken markdown anchors (`#step-0-create-or-refresh-the-onboarding-log` → `#steps-0-3-setup-run-silently----do-not-narrate-each-step`) at lines 153 and 306
- Bumped `metadata.version` from `0.1.0` to `0.2.0` in all three SKILL.md files per CONTRIBUTING.md versioning rule

### Human review checklist
- [ ] Verify the long markdown anchor `#steps-0-3-setup-run-silently----do-not-narrate-each-step` renders and navigates correctly (four hyphens for the `--` in the heading)
- [ ] Confirm D6 is consistently described as non-blocking across all references in `SKILL.md`
- [ ] Confirm `0.2.0` is the appropriate version bump for these behavior changes

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- <!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/ai-tooling/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->Link to Devin session: https://app.devin.ai/sessions/aa7be2676195437cb4089d84489f4604
Requested by: @ari-launchdarkly
<!-- ld-jira-link -->
---
Related Jira issue: [REL-13318: Tweak the language around the agent-skill to smooth the process out a little more](https://launchdarkly.atlassian.net/browse/REL-13318)
<!-- end-ld-jira-link -->