### PR TITLE
Add eval-gate job for required status checks

### DIFF
--- a/.github/workflows/eval-skills.yml
+++ b/.github/workflows/eval-skills.yml
@@ -97,7 +97,6 @@ jobs:
     needs: [unit-test, diff]
     if: needs.diff.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -275,3 +274,22 @@ jobs:
           git add skills/**/README.md
           git commit -m "chore(evals): refresh eval-scores.json and README badges"
           git push origin HEAD:${{ github.ref_name }}
+
+  eval-gate:
+    name: "Evaluate gate"
+    needs: [diff, evaluate]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check evaluate results
+        run: |
+          if [[ "${{ needs.diff.outputs.has_changes }}" != "true" ]]; then
+            echo "No suites changed — gate passes"
+            exit 0
+          fi
+          if [[ "${{ needs.evaluate.result }}" == "success" ]]; then
+            echo "All evaluate jobs passed"
+            exit 0
+          fi
+          echo "One or more evaluate jobs failed (result: ${{ needs.evaluate.result }})"
+          exit 1


### PR DESCRIPTION
## Summary

- Adds an `eval-gate` job to the Skill Evals workflow that acts as a single required status check (`Skill Evals / Evaluate gate`) for branch protection
- Removes `continue-on-error: true` from the `evaluate` job so failures propagate to the gate
- The gate passes when no suites changed (skipped evaluate) or all evaluate jobs succeeded, and fails otherwise

This enables a companion [terraform PR](https://github.com/launchdarkly/terraform/pull/24622) to add `Skill Evals / Evaluate gate` as a required status check without needing to list each dynamic matrix evaluate job individually.

## Testing

- [ ] Manual (describe below)

CI will validate the workflow syntax. The gate logic can be verified on a PR that touches `skills/` or `evals/`.

## Notes

- The `aggregate` job still uses `always()` so it continues to run and post score diffs even when evaluate jobs fail

Link to Devin session: https://app.devin.ai/sessions/8d0a1871b1cf40709e0576380970885c
Requested by: @ari-launchdarkly