### PR TITLE
fix: add marketplace.json so /plugin marketplace add works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "launchdarkly-ai-tooling",
+  "owner": {
+    "name": "LaunchDarkly",
+    "email": "support@launchdarkly.com",
+    "url": "https://launchdarkly.com"
+  },
+  "plugins": [
+    {
+      "name": "launchdarkly",
+      "description": "LaunchDarkly agent skills and MCP servers for feature flag management, AgentControl, and metrics",
+      "source": "."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 
 This repo is a [Claude Code plugin](https://code.claude.com/docs/en/create-plugins). Installing it gives you all the skills above plus the LaunchDarkly MCP server.
 
-1. Open Claude Code and run `/plugin install`.
-2. Search for **LaunchDarkly**, or install directly from the repo URL:
+1. Add this repo as a plugin marketplace in Claude Code:
    ```
-   https://github.com/launchdarkly/ai-tooling
+   /plugin marketplace add launchdarkly/ai-tooling
+   ```
+2. Install the plugin:
+   ```
+   /plugin install launchdarkly@launchdarkly-ai-tooling
    ```
 3. Authenticate the LaunchDarkly MCP server when prompted with your [API access token](https://docs.launchdarkly.com/home/account/api).
 


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` so the repo can be registered as a Claude Code plugin marketplace.

Currently, following the README instructions to install via `/plugin install` fails because Claude Code's `/plugin marketplace add launchdarkly/ai-tooling` requires a `marketplace.json` — having only `plugin.json` produces:

```
Error: Marketplace file not found at /Users/<user>/.claude/plugins/marketplaces/launchdarkly-ai-tooling/.claude-plugin/marketplace.json
```

This PR is the minimal fix to unblock that flow:

- **`.claude-plugin/marketplace.json`** — single-plugin marketplace with `"source": "."`, pointing at the plugin defined in `.claude-plugin/plugin.json` at the repo root.
- **`README.md`** — updates the install steps to the commands that actually work (`/plugin marketplace add` then `/plugin install`), instead of "search for LaunchDarkly" (which only finds plugins in marketplaces already added — not this one).

## Things to flag for reviewers

1. **Plugin name collision with `launchdarkly-labs/agent-skills`.** That marketplace also publishes a plugin called `launchdarkly`. A user who adds both marketplaces will have two plugins with the same name. If `ai-tooling` is meant to supersede the labs repo, that's fine — but if they're meant to coexist, one should probably rename. Worth deciding before this lands.
2. **Cursor install instructions in the README are unchanged.** I only fixed the Claude Code section because that's what I was debugging. The Cursor install steps ("Search for **LaunchDarkly** in the marketplace, or install from the repo URL") may have the same "search only works after it's published to a known marketplace" issue — someone who knows Cursor's plugin model should sanity-check.
3. **Not yet listed in `anthropics/claude-plugins-official`.** Until/unless it's submitted there, `/plugin install` browse without first running `/plugin marketplace add` will never find it. The updated README sidesteps this by telling users to add the marketplace explicitly.

## Test plan

- [ ] `git pull` this branch locally
- [ ] In Claude Code: `/plugin marketplace add launchdarkly/ai-tooling` — should succeed
- [ ] `/plugin install launchdarkly@launchdarkly-ai-tooling` — should list and install the plugin
- [ ] Confirm `launchdarkly:*` skills become available (e.g., `/launchdarkly:flag-cleanup`)
- [ ] Confirm the LD MCP server prompts for auth on first use

🤖 Generated with [Claude Code](https://claude.com/claude-code)