### PR TITLE
ci: trigger eval-skills on every PR so required checks always report

### DIFF
--- a/.github/workflows/eval-skills.yml
+++ b/.github/workflows/eval-skills.yml
@@ -13,11 +13,14 @@ name: Skill Evals
 # touching one skill costs roughly one suite's worth of API tokens.
 
 on:
+  # No `paths:` filter on pull_request — branch protection requires
+  # "Unit tests", "Aggregate scores", and "Evaluate gate" on every PR, and a
+  # path-filtered workflow leaves those checks stuck in "Expected — Waiting
+  # for status to be reported" for PRs that don't touch skills/ or evals/,
+  # blocking merge. The workflow fires on every PR; the `diff` job and the
+  # job-level `if:` conditions ensure that unchanged-skills PRs short-circuit
+  # to skipped (which counts as success for required checks).
   pull_request:
-    paths:
-      - "skills/**"
-      - "evals/**"
-      - ".github/workflows/eval-skills.yml"
   schedule:
     # 09:17 UTC daily - off the hour to avoid lining up with API rate limits.
     - cron: "17 9 * * *"


### PR DESCRIPTION
## Summary
The required checks come from a path-filtered workflow, so PRs that don't touch `skills/**` or `evals/**` never trigger it and get stuck "waiting for status to report." This PR removes the path filter so the workflow fires on every PR. Nothing is weakened: the diff job inside the workflow already gates the actual eval work on whether skills changed, and skipped required checks count as passing in branch protection. Net cost: ~40s of cheap CI per PR; no extra API tokens.

---

Branch protection on `main` requires three status checks — **Unit tests**, **Aggregate scores**, and **Evaluate gate** — all of which are produced by `.github/workflows/eval-skills.yml`. The workflow is currently path-filtered:

```yaml
on:
  pull_request:
    paths:
      - "skills/**"
      - "evals/**"
      - ".github/workflows/eval-skills.yml"
```

For any PR that doesn't touch one of those paths, the workflow never triggers, so the three required checks stay forever in `Expected — Waiting for status to be reported` and the PR is `BLOCKED` from merging even with every other check green and reviews approved.

[#74](https://github.com/launchdarkly/ai-tooling/pull/74) hit this — it only changed `.claude-plugin/marketplace.json` and `README.md`, so the workflow never fired and the merge button has been stuck for days.

## Fix

Remove the trigger-level `paths:` filter so the workflow runs on every PR. The cost is small:

- The `diff` job is preserved — it still computes whether any skills actually changed.
- `evaluate` and `aggregate` already have job-level `if: needs.diff.outputs.has_changes == 'true'` guards, so they skip cleanly on PRs that don't touch skills.
- GitHub treats **skipped** required checks as **passing**, so non-skill PRs still satisfy branch protection without running any actual evals.
- The only always-on cost added per PR is the `unit-test` job (~30s) and the `diff` job (~10s).

The cron-schedule and `workflow_dispatch` triggers are unchanged.

## Test plan

- [ ] Merge this PR (it touches `.github/workflows/eval-skills.yml`, so the workflow self-triggers under the old paths filter — required checks will report on this PR via the existing rule).
- [ ] Confirm `#74` unblocks once this lands — push an empty/no-op commit there so the new trigger fires, and verify all three required checks report SUCCESS or SKIPPED.
- [ ] Open a follow-up PR touching only a non-skills file (e.g. `README.md`) and confirm the three required checks report there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)