### PR TITLE
test(evals): eval suite for launchdarkly-metric-create

### DIFF
--- a/evals/launchdarkly-metric-create/promptfooconfig.yaml
+++ b/evals/launchdarkly-metric-create/promptfooconfig.yaml
@@ -1,0 +1,237 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+#
+# End-to-end evaluation of the launchdarkly-metric-create skill, in the MAIN
+# harness (mocked MCP tools + trajectory assertions). Supersedes the lighter
+# tests/evals/metrics/metric-create.eval.yaml (raw-text-into-Haiku, rubric-only).
+#
+# Cases are picked by the three-lens method and grounded in usage data
+# (Snowflake GOALS): click 46% / pageview 45% / custom 9% of all metrics, so the
+# frequency-weighted golden path is a pageview or click metric — NOT custom.
+#   1  golden path (pageview)  — the most common metric, created with no code
+#   2  golden path (click)     — second most common; needs a selector
+#   3  cost of being wrong     — custom event not flowing -> don't create a dead metric
+#   4  cost of being wrong     — duplicate check before creating
+#   5  safety                  — LD project key vs local codebase name, don't conflate
+#
+# Run:  promptfoo eval -c shared/defaults.yaml -c launchdarkly-metric-create/promptfooconfig.yaml
+description: "End-to-end evaluation of the launchdarkly-metric-create skill"
+
+prompts:
+  - file://../../skills/metrics/launchdarkly-metric-create/SKILL.md
+
+providers:
+  - id: file://../providers/claude-skill-agent-sdk.js
+    label: claude-skill-agent-sdk
+    config:
+      skill_slug: launchdarkly-metric-create
+      expose_mcp_tools: true
+      allow_builtins: true          # custom path may read/edit code to instrument
+      expose_ask_question: true     # skill confirms URL match kind, event key, etc.
+
+tests:
+  # ==================================================================
+  # LENS 1 — Golden path: pageview metric (the 45% case, no code)
+  # ==================================================================
+  - description: "Golden path (pageview): create a pageview metric for a URL, no instrumentation"
+    vars:
+      max_turns: 20
+      mock_ask_question_answers:
+        - ["substring"]
+      user_request: >
+        In LaunchDarkly project "my-app", create a metric that fires when users
+        visit our /checkout page.
+    assert:
+      - type: javascript
+        value: |
+          const call = (output.trajectory||[]).find(t=>t.tool==='create-metric');
+          if(!call) return { pass:false, score:0, reason:'No create-metric call' };
+          const a = call.arguments||{};
+          const isPageview = a.kind==='pageview';
+          const hasUrls = Array.isArray(a.urls) && a.urls.length>0;
+          const score = (isPageview?0.6:0)+(hasUrls?0.4:0);
+          return { pass:isPageview && hasUrls, score, reason:`kind=${a.kind} urls=${JSON.stringify(a.urls||[])}` };
+        metric: creates_pageview_with_url
+        weight: 3
+      # No SDK instrumentation for a pageview metric — it fires automatically.
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const traj = output.trajectory || [];
+          const edited = traj.some(t=>['Edit','Write'].includes(t.tool));
+          const instrumented = tools.includes('get-environment') || edited;
+          return { pass:!instrumented, score:!instrumented?1:0, reason: instrumented?'Unnecessarily instrumented a pageview metric':'No code changes (correct for pageview)' };
+        metric: no_instrumentation_for_pageview
+        weight: 2
+      # Verifies after creating.
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const c = tools.indexOf('create-metric'); const v = tools.lastIndexOf('get-metric');
+          const pass = c>=0 && v>c;
+          return { pass, score: pass?1:(c>=0?0.6:0), reason:`create@${c} verify@${v}` };
+        metric: verifies_after_create
+        weight: 1
+      - type: llm-rubric
+        value: |
+          Score 1.0 if all met, deduct 0.33 each:
+          1. The agent chose a pageview metric (not custom) because the user described visiting a URL.
+          2. It set a sensible URL match rule for /checkout and confirmed the match kind (substring/exact/canonical/regex).
+          3. It did NOT add any SDK track() call or code changes — pageview needs none.
+        metric: pageview_workflow_quality
+        weight: 2
+
+  # ==================================================================
+  # LENS 1 / 3 — Golden path variant: click metric (the 46% case)
+  # ==================================================================
+  - description: "Golden path (click): create a click metric with a selector"
+    vars:
+      max_turns: 20
+      mock_ask_question_answers:
+        - ["substring"]
+      user_request: >
+        In LaunchDarkly project "my-app", track clicks on the ".add-to-cart-btn"
+        button on our product pages (URL contains /products).
+    assert:
+      - type: javascript
+        value: |
+          const call = (output.trajectory||[]).find(t=>t.tool==='create-metric');
+          if(!call) return { pass:false, score:0, reason:'No create-metric call' };
+          const a = call.arguments||{};
+          const isClick = a.kind==='click';
+          const hasSelector = typeof a.selector==='string' && a.selector.length>0;
+          const hasUrls = Array.isArray(a.urls) && a.urls.length>0;
+          const score = (isClick?0.4:0)+(hasSelector?0.4:0)+(hasUrls?0.2:0);
+          return { pass:isClick && hasSelector, score, reason:`kind=${a.kind} selector=${a.selector||'?'} urls=${JSON.stringify(a.urls||[])}` };
+        metric: creates_click_with_selector
+        weight: 3
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const traj = output.trajectory || [];
+          const instrumented = tools.includes('get-environment') || traj.some(t=>['Edit','Write'].includes(t.tool));
+          return { pass:!instrumented, score:!instrumented?1:0, reason: instrumented?'Unnecessarily instrumented a click metric':'No code changes (correct for click)' };
+        metric: no_instrumentation_for_click
+        weight: 2
+      - type: llm-rubric
+        value: |
+          Score 1.0 if both met, deduct 0.5 each:
+          1. The agent chose a click metric and captured the CSS selector (.add-to-cart-btn) and the URL scope.
+          2. It did not fall back to a custom metric requiring a track() call.
+        metric: click_workflow_quality
+        weight: 2
+
+  # ==================================================================
+  # LENS 2 — Cost of being wrong: custom event not flowing
+  # A custom metric whose event never fires records nothing. The skill
+  # must check event health (list-metric-events) and instrument or warn
+  # BEFORE creating — not silently create a dead metric.
+  # ==================================================================
+  - description: "Cost of wrong (custom): event not flowing — check health, don't create a dead metric"
+    vars:
+      max_turns: 24
+      user_request: >
+        In LaunchDarkly project "my-app", create a custom metric for the event
+        "signup-submitted" so I can measure signups.
+      mock_files:
+        "package.json": '{"dependencies":{"launchdarkly-react-client-sdk":"^3.0.0","react":"^18.0.0"}}'
+        "src/Signup.jsx": "export function Signup(){\n  const onSubmit = () => { /* submit signup */ };\n  return null;\n}\n"
+    assert:
+      # Must check event health before creating.
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const checkedIdx = tools.indexOf('list-metric-events');
+          const createIdx = tools.indexOf('create-metric');
+          const checkedFirst = checkedIdx>=0 && (createIdx<0 || checkedIdx<createIdx);
+          return { pass:checkedFirst, score:checkedFirst?1:0, reason:`list-metric-events@${checkedIdx} create-metric@${createIdx}` };
+        metric: checks_event_health_first
+        weight: 3
+      # If it creates the metric, it must have instrumented the event (track call) — not create a dead metric.
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const traj = output.trajectory || [];
+          const created = tools.includes('create-metric');
+          const instrumented = traj.some(t=>['Edit','Write'].includes(t.tool)) || tools.includes('get-environment');
+          // Acceptable: (a) instrument then create, or (b) do not create yet (ask/warn).
+          const pass = created ? instrumented : true;
+          return { pass, score: pass?1:0, reason:`created=${created} instrumented=${instrumented}` };
+        metric: no_dead_metric
+        weight: 3
+      - type: llm-rubric
+        value: |
+          The event "signup-submitted" is NOT in the flowing events. Score 1.0 if both met, deduct 0.5 each:
+          1. The agent recognizes the event is not flowing and treats instrumenting it (a track() call) as the default next step, rather than silently creating a metric that would record nothing.
+          2. If it proceeds to create the metric, it first wires up the event (or explicitly gets the user's ok to create-first-instrument-later and warns the metric will have no data until then).
+        metric: dead_metric_quality
+        weight: 2
+
+  # ==================================================================
+  # LENS 2 — Cost of being wrong: duplicate check
+  # "checkout-completed" already exists (in list-metrics mock). The skill
+  # must check and not blindly create a second one.
+  # ==================================================================
+  - description: "Cost of wrong: duplicate — check list-metrics, don't re-create an existing metric"
+    vars:
+      max_turns: 20
+      user_request: >
+        In LaunchDarkly project "my-app", create a custom metric for the event
+        "checkout-completed".
+    assert:
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const listed = tools.includes('list-metrics') || tools.includes('list-metric-events');
+          return { pass:listed, score:listed?1:0, reason:`inventory tools: ${tools.filter(t=>t.startsWith('list-')).join(', ')||'none'}` };
+        metric: checks_for_duplicates
+        weight: 3
+      # Should not create a second checkout-completed metric.
+      - type: javascript
+        value: |
+          const created = (output.trajectory||[]).filter(t=>t.tool==='create-metric');
+          const dupNew = created.some(c=>{const a=c.arguments||{}; return (a.eventKey==='checkout-completed'||a.key==='checkout-completed');});
+          return { pass:!dupNew, score:!dupNew?1:0, reason: dupNew?'Created a duplicate checkout-completed metric':'Did not duplicate' };
+        metric: no_duplicate_created
+        weight: 3
+      - type: llm-rubric
+        value: |
+          A metric for "checkout-completed" already exists. Score 1.0 if both met, deduct 0.5 each:
+          1. The agent surfaces the existing metric rather than creating a duplicate.
+          2. It asks the user whether to reuse the existing one or intentionally create another, instead of silently proceeding.
+        metric: duplicate_quality
+        weight: 2
+
+  # ==================================================================
+  # SAFETY — LD project key vs local codebase name
+  # The user names a local folder; the skill must not treat it as the LD
+  # projectKey — it should confirm the LaunchDarkly project.
+  # ==================================================================
+  - description: "Safety: don't treat the local codebase name as the LaunchDarkly project key"
+    vars:
+      max_turns: 18
+      user_request: >
+        Create a metric in my app at ./checkout_proj that fires when users visit
+        the /pricing page.
+    assert:
+      # If it creates, projectKey must NOT be the local folder name.
+      - type: javascript
+        value: |
+          const call = (output.trajectory||[]).find(t=>t.tool==='create-metric');
+          const asks = (output.trajectory||[]).filter(t=>t.tool==='ask-question');
+          if(!call){
+            const text=(asks.map(a=>a.arguments&&a.arguments.prompt||'').join(' ')+' '+String(output.response||'')).toLowerCase();
+            const askedProject=/project key|launchdarkly project|which.*project/.test(text);
+            return { pass:askedProject, score:askedProject?1:0.4, reason:'No create yet; askedProject='+askedProject };
+          }
+          const pk=(call.arguments||{}).projectKey||'';
+          const pass = pk!=='checkout_proj' && !/checkout_proj/.test(pk);
+          return { pass, score: pass?1:0, reason:`projectKey=${pk}` };
+        metric: project_not_codebase
+        weight: 3
+      - type: llm-rubric
+        value: |
+          "./checkout_proj" is a local codebase path, not a LaunchDarkly project key. Score 1.0 if both met, deduct 0.5 each:
+          1. The agent does not assume "checkout_proj" is the LaunchDarkly project key.
+          2. It asks for / confirms the LaunchDarkly project key separately from the local app.
+        metric: project_confusion_quality
+        weight: 2

--- a/evals/mocks/tool-responses.json
+++ b/evals/mocks/tool-responses.json
@@ -1,4 +1,40 @@
 {
+  "list-metrics": {
+    "metrics": [
+      { "key": "checkout-completed", "name": "Checkout completed", "kind": "custom", "eventKey": "checkout-completed", "measureType": "occurrence", "successCriteria": "HigherThanBaseline", "tags": ["growth"] },
+      { "key": "page-load-time", "name": "Page load time", "kind": "custom", "measureType": "value", "unit": "ms", "successCriteria": "LowerThanBaseline", "tags": ["performance"] },
+      { "key": "error-rate", "name": "Error rate", "kind": "custom", "measureType": "occurrence", "successCriteria": "LowerThanBaseline", "tags": ["guardrail"] }
+    ],
+    "totalCount": 3,
+    "pageInfo": { "limit": 20, "offset": 0 }
+  },
+  "list-metric-events": {
+    "events": [
+      { "eventKey": "checkout-completed", "count": 1820, "lastSeen": "2026-07-05T00:00:00Z" },
+      { "eventKey": "add-to-cart-clicked", "count": 940, "lastSeen": "2026-07-05T00:00:00Z" },
+      { "eventKey": "page-viewed", "count": 5100, "lastSeen": "2026-07-05T00:00:00Z" }
+    ],
+    "totalCount": 3
+  },
+  "create-metric": {
+    "key": "{{key}}",
+    "name": "{{name}}",
+    "kind": "{{kind}}",
+    "_id": "metric-0001",
+    "_creationDate": 1751760000000
+  },
+  "get-metric": {
+    "key": "{{metricKey}}",
+    "name": "Metric",
+    "kind": "custom",
+    "_id": "metric-0001"
+  },
+  "get-environment": {
+    "key": "{{environmentKey}}",
+    "name": "{{environmentKey}}",
+    "clientSideId": "651a0c0f9e1a2b0012ab34cd",
+    "_links": { "self": { "href": "https://app.launchdarkly.com/api/v2/projects/my-app/environments/{{environmentKey}}" } }
+  },
   "list-flags": {
     "flags": [
       {

--- a/evals/package.json
+++ b/evals/package.json
@@ -15,6 +15,8 @@
     "eval:flag-create:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-create/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
     "eval:flag-command": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-command/promptfooconfig.yaml --env-file .env --no-cache -o launchdarkly-flag-command/results.json",
     "eval:flag-command:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-command/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
+    "eval:metric-create": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-metric-create/promptfooconfig.yaml --env-file .env --no-cache -o launchdarkly-metric-create/results.json",
+    "eval:metric-create:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-metric-create/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
     "eval:all": "node scripts/aggregate.js --run",
     "eval:aggregate": "node scripts/aggregate.js",
     "eval:diff": "node scripts/diff-changed-skills.js",

--- a/evals/scripts/_manifest.js
+++ b/evals/scripts/_manifest.js
@@ -49,6 +49,12 @@ const SUITES = [
     skillDir: "skills/feature-flags/launchdarkly-flag-command",
     readme: "skills/feature-flags/launchdarkly-flag-command/README.md",
   },
+  {
+    suite: "launchdarkly-metric-create",
+    skillKey: "metrics/launchdarkly-metric-create",
+    skillDir: "skills/metrics/launchdarkly-metric-create",
+    readme: "skills/metrics/launchdarkly-metric-create/README.md",
+  },
 ];
 
 /**

--- a/evals/tools/definitions.json
+++ b/evals/tools/definitions.json
@@ -509,5 +509,76 @@
       },
       "required": ["projectKey"]
     }
+  },
+  {
+    "name": "list-metrics",
+    "description": "Search and browse metrics in a project. Matching is LITERAL case-insensitive substring, not semantic. Use to check for duplicate metrics and understand naming conventions.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "projectKey": { "type": "string", "description": "The project key" },
+        "query": { "type": "string", "description": "Search by metric name or key (literal case-insensitive substring)" },
+        "limit": { "type": "number", "description": "Max number of results (default 20)" }
+      },
+      "required": ["projectKey"]
+    }
+  },
+  {
+    "name": "list-metric-events",
+    "description": "List recent event keys with activity in a project, to check whether a custom event is already flowing before creating a metric for it.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "projectKey": { "type": "string", "description": "The project key" },
+        "environmentKey": { "type": "string", "description": "Environment key (defaults to production)" }
+      },
+      "required": ["projectKey"]
+    }
+  },
+  {
+    "name": "create-metric",
+    "description": "Create a metric. kind is 'custom' (needs eventKey and a track() call in code), 'pageview' (needs urls, fires automatically, no code), or 'click' (needs urls and a selector, no code). Prefer pageview/click when they would work.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "projectKey": { "type": "string", "description": "The project key" },
+        "key": { "type": "string", "description": "Metric key (kebab-case)" },
+        "name": { "type": "string", "description": "Human-readable name" },
+        "kind": { "type": "string", "enum": ["custom", "pageview", "click"], "description": "Metric kind" },
+        "eventKey": { "type": "string", "description": "Event key (custom metrics only)" },
+        "urls": { "type": "array", "items": { "type": "object", "properties": { "kind": { "type": "string", "enum": ["substring", "exact", "canonical", "regex"] }, "url": { "type": "string" }, "pattern": { "type": "string" } } }, "description": "URL match rules (pageview and click)" },
+        "selector": { "type": "string", "description": "CSS selector (click only)" },
+        "measureType": { "type": "string", "enum": ["count", "occurrence", "value"], "description": "How events aggregate" },
+        "successCriteria": { "type": "string", "enum": ["HigherThanBaseline", "LowerThanBaseline"], "description": "Which direction is good" },
+        "unit": { "type": "string", "description": "Unit for value metrics (e.g. ms, USD)" },
+        "description": { "type": "string", "description": "Metric description" },
+        "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags" }
+      },
+      "required": ["projectKey", "key", "name", "kind"]
+    }
+  },
+  {
+    "name": "get-metric",
+    "description": "Get a metric by key to verify it after creation.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "projectKey": { "type": "string", "description": "The project key" },
+        "metricKey": { "type": "string", "description": "The metric key" }
+      },
+      "required": ["projectKey", "metricKey"]
+    }
+  },
+  {
+    "name": "get-environment",
+    "description": "Get an environment, including its client-side SDK id (clientSideId), used when instrumenting a custom event.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "projectKey": { "type": "string", "description": "The project key" },
+        "environmentKey": { "type": "string", "description": "The environment key" }
+      },
+      "required": ["projectKey", "environmentKey"]
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Adds the first **metrics** eval in the main harness, for the **launchdarkly-metric-create** skill. Supersedes the lighter `tests/evals/metrics/metric-create.eval.yaml` (raw-text-into-Haiku, rubric-only, no tool mocking) with a proper mocked-tool + trajectory suite.

Grounded in usage data (Snowflake GOALS: click 46% / pageview 45% / custom 9%), so the frequency-weighted golden path is a **pageview or click** metric, not custom — the case the prior thin eval underweighted.

**Five cases (three-lens method):**
1. Golden path (pageview) — creates a pageview metric with a URL rule, no instrumentation.
2. Golden path (click) — creates a click metric with a selector.
3. Cost of being wrong — a custom event not flowing: checks event health, doesn't create a dead metric.
4. Cost of being wrong — duplicate check before creating.
5. Safety — doesn't treat a local codebase name as the LaunchDarkly project key.

**Shared infra (new metric tool support in the harness):** adds `create-metric`, `get-metric`, `list-metrics`, `list-metric-events`, `get-environment` tool defs + mocks, manifest entry, and npm scripts.

> Note: `list-metrics` / `list-metric-events` are also added in #96 — trivial dedupe when both land (keep this branch's fixed-event-set `list-metric-events` mock).

## Testing

- YAML, manifest, JSON, and package all validate locally.
- Full run needs `ANTHROPIC_API_KEY`; CI (or `npm run eval:metric-create`) will execute it. Expect some assertion tuning on the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

via LD Research 🤖