### PR TITLE
Enrich should-flag-change + add targeting context-availability reference

### DIFF
--- a/evals/launchdarkly-flag-create/promptfooconfig.yaml
+++ b/evals/launchdarkly-flag-create/promptfooconfig.yaml
@@ -166,3 +166,70 @@ tests:
           return { pass: isTemp, score: isTemp ? 1 : 0.5, reason: `temporary=${a.temporary}` };
         metric: temporary_flag_set
         weight: 1
+
+  # ------------------------------------------------------------------
+  # Test 4: Targeting-context availability — client-side flag, server-only signal
+  # A React (client-side) app where the user wants to target by a
+  # server/request-scoped signal (region derived from the request IP) that the
+  # browser context never carries. The Context Availability reference says a
+  # client-side flag can only target kinds/attributes shipped to the browser, so
+  # the agent should create the flag with client-side availability AND flag that
+  # the requested targeting won't fire in the browser as-is, suggesting an
+  # available approach (ship the attribute to the client, or evaluate server-side).
+  # ------------------------------------------------------------------
+  - description: "Targeting context: warns a client-side flag can't target a server-only signal"
+    vars:
+      user_request: >
+        Create a feature flag for our new promo banner and target it to users in
+        the EU. We detect region on the server from the request IP. Project key is
+        "web-app".
+      codebase_context: >
+        React single-page app using launchdarkly-react-client-sdk (client-side).
+        The LDContext shipped to the browser is built at login with { kind: 'user',
+        key: user.id, email: user.email, plan: user.plan } — it does NOT include
+        the request IP or a server-derived region. Region is only known on the
+        server request handler, not in the browser.
+      mock_files:
+        "package.json": '{"dependencies":{"launchdarkly-react-client-sdk":"^3.1.0","react":"^18.2.0"}}'
+        "src/ld.js": "import { withLDProvider } from 'launchdarkly-react-client-sdk';\n// context built at login: { kind: 'user', key: user.id, email: user.email, plan: user.plan }\n"
+        "src/App.jsx": "import { useFlags } from 'launchdarkly-react-client-sdk';\nconst { promoBanner } = useFlags();\n"
+    assert:
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const pass = tools.includes('create-flag');
+          return { pass, score: pass ? 1 : 0, reason: 'Tools: ' + tools.join(' -> ') };
+        metric: calls_create_flag
+        weight: 2
+
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'create-flag');
+          if (!call) return { pass: false, score: 0, reason: 'No create-flag call' };
+          const a = call.arguments || {};
+          // React app -> the flag must be client-side available to be read in the browser.
+          const csa = a.clientSideAvailability || {};
+          const clientSide = csa.usingEnvironmentId === true || a.clientSide === true;
+          return { pass: clientSide, score: clientSide ? 1 : 0.5, reason: `clientSideAvailability=${JSON.stringify(a.clientSideAvailability)}` };
+        metric: client_side_available
+        weight: 2
+
+      - type: llm-rubric
+        value: |
+          The user asked to create a client-side (React) flag and target EU users by a
+          region the app derives ON THE SERVER from the request IP — a signal the
+          browser LDContext never carries (it ships only user id/email/plan).
+          Score 1.0 if ALL of the following hold:
+          1. The agent created the flag (with client-side availability, since it's read
+             in the browser via useFlags()).
+          2. The agent recognized that the requested targeting will NOT fire in the
+             browser as-is, because a client-side flag can only target context
+             kinds/attributes shipped to the browser — the server-derived region is
+             not one of them.
+          3. The agent suggested a workable alternative: ship a region attribute onto
+             the client context (e.g. via identify), or evaluate the flag server-side
+             where the region is known.
+          Deduct 0.34 for each criterion missed.
+        metric: context_availability_reasoning
+        weight: 3

--- a/evals/should-flag-change/promptfooconfig.yaml
+++ b/evals/should-flag-change/promptfooconfig.yaml
@@ -6,7 +6,10 @@
 # The should-flag-change skill is an ADVISORY, READ-ONLY skill. Given a code
 # change (a <git_diff> block, optionally plus surrounding source), it decides
 # whether the change should ship behind a LaunchDarkly feature flag and ends by
-# calling the `recommend-flag` tool with { recommend, confidence, reasons }.
+# calling the `recommend-flag` tool with { recommend, verdict, confidence, reasons }.
+# `verdict` is the finer taxonomy signal — suggested / already-flagged / not-suited —
+# and the `verdict_taxonomy` assertions below check that already-flagged (protected by
+# an existing/ancestor gate) stays distinct from not-suited (nothing to flag).
 # It must NEVER create, toggle, or modify a flag.
 #
 # Two-tier evaluation, expressed as two labeled providers. Each fixture targets
@@ -389,6 +392,16 @@ tests:
         metric: stayed_advisory
         weight: 2
 
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'recommend-flag');
+          const a = (call && call.arguments) || {};
+          const pass = a.verdict === 'not-suited';
+          return { pass, score: pass ? 1 : 0, reason: `verdict=${a.verdict} (expected not-suited: pure refactor)` };
+        metric: verdict_taxonomy
+        weight: 2
+
       - type: llm-rubric
         value: |
           The change extracts inline currency formatting into a formatCurrency helper
@@ -473,6 +486,16 @@ tests:
         metric: risk_calibrated
         weight: 1
 
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'recommend-flag');
+          const a = (call && call.arguments) || {};
+          const pass = a.verdict === 'not-suited';
+          return { pass, score: pass ? 1 : 0, reason: `verdict=${a.verdict} (expected not-suited: docs+tests only)` };
+        metric: verdict_taxonomy
+        weight: 2
+
       - type: llm-rubric
         value: |
           The change touches only README.md (documentation) and a test file. No
@@ -530,8 +553,13 @@ tests:
           const a = call.arguments || {};
           const hasReasons = Array.isArray(a.reasons) && a.reasons.length > 0;
           const validConf = ['low','medium','high'].includes(a.confidence);
-          const pass = typeof a.recommend === 'boolean' && hasReasons && validConf;
-          return { pass, score: pass ? 1 : 0, reason: `recommend=${a.recommend} confidence=${a.confidence} reasons=${(a.reasons||[]).length}` };
+          // verdict is optional but, when present, must be one of the three enum values
+          // and must agree with the recommend boolean (suggested <-> true).
+          const verdictOk = a.verdict === undefined
+            || (['suggested','already-flagged','not-suited'].includes(a.verdict)
+                && (a.verdict === 'suggested') === (a.recommend === true));
+          const pass = typeof a.recommend === 'boolean' && hasReasons && validConf && verdictOk;
+          return { pass, score: pass ? 1 : 0, reason: `recommend=${a.recommend} verdict=${a.verdict} confidence=${a.confidence} reasons=${(a.reasons||[]).length}` };
         metric: emitted_structured_verdict
         weight: 2
 
@@ -622,6 +650,16 @@ tests:
         metric: stayed_advisory
         weight: 2
 
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'recommend-flag');
+          const a = (call && call.arguments) || {};
+          const pass = a.verdict === 'already-flagged';
+          return { pass, score: pass ? 1 : 0, reason: `verdict=${a.verdict} (expected already-flagged: gated in the diff)` };
+        metric: verdict_taxonomy
+        weight: 2
+
       - type: llm-rubric
         value: |
           The diff adds a new /reports/export endpoint, but it is ALREADY gated
@@ -689,6 +727,16 @@ tests:
           const pass = called.length === 0;
           return { pass, score: pass ? 1 : 0, reason: pass ? 'stayed advisory' : 'called mutating tools: ' + called.join(', ') };
         metric: stayed_advisory
+        weight: 2
+
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'recommend-flag');
+          const a = (call && call.arguments) || {};
+          const pass = a.verdict === 'suggested';
+          return { pass, score: pass ? 1 : 0, reason: `verdict=${a.verdict} (expected suggested: new ungated path)` };
+        metric: verdict_taxonomy
         weight: 2
 
       - type: llm-rubric
@@ -920,6 +968,16 @@ tests:
           const pass = called.length === 0;
           return { pass, score: pass ? 1 : 0, reason: pass ? 'stayed advisory' : 'called mutating tools: ' + called.join(', ') };
         metric: stayed_advisory
+        weight: 2
+
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const call = traj.find(t => t.tool === 'recommend-flag');
+          const a = (call && call.arguments) || {};
+          const pass = a.verdict === 'already-flagged';
+          return { pass, score: pass ? 1 : 0, reason: `verdict=${a.verdict} (expected already-flagged: off ancestor gate)` };
+        metric: verdict_taxonomy
         weight: 2
 
       - type: llm-rubric

--- a/skills.json
+++ b/skills.json
@@ -253,7 +253,7 @@
       "name": "launchdarkly-flag-create",
       "description": "Create and configure LaunchDarkly feature flags in a way that fits the existing codebase. Use when the user wants to create a new flag, wrap code in a flag, add a feature toggle, or set up an experiment. Guides exploration of existing patterns before creating.",
       "path": "skills/feature-flags/launchdarkly-flag-create",
-      "version": "1.0.0-experimental",
+      "version": "1.1.0-experimental",
       "license": "Apache-2.0",
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
       "tags": [
@@ -291,7 +291,7 @@
       "name": "launchdarkly-flag-targeting",
       "description": "Control LaunchDarkly feature flag targeting including toggling flags on/off, percentage rollouts, targeting rules, individual targets, and copying flag configurations between environments. Use when the user wants to change who sees a flag, roll out to a percentage, add targeting rules, or promote config between environments.",
       "path": "skills/feature-flags/launchdarkly-flag-targeting",
-      "version": "1.0.0-experimental",
+      "version": "1.1.0-experimental",
       "license": "Apache-2.0",
       "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
       "tags": [
@@ -405,7 +405,7 @@
       "name": "should-flag-change",
       "description": "Decide whether a given code change should be placed behind a LaunchDarkly feature flag. Use when a developer asks whether a change should be behind a flag, when reviewing a diff or pull request, or when running in CI on a PR. Reads the diff and surrounding code, then emits a structured advisory recommendation. Read-only: it never creates or modifies flags.",
       "path": "skills/feature-flags/should-flag-change",
-      "version": "0.1.0-experimental",
+      "version": "0.2.0-experimental",
       "license": "Apache-2.0",
       "compatibility": "Advisory and read-only. Works on all platforms. Does NOT require the LaunchDarkly MCP server. Reads code with standard file tools (Read/Grep/Glob) and returns a structured verdict via the `recommend-flag` tool.",
       "tags": [

--- a/skills/feature-flags/launchdarkly-flag-create/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-create/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires the remotely hosted LaunchDarkly MCP server
 metadata:
   author: launchdarkly
-  version: "1.0.0-experimental"
+  version: "1.1.0-experimental"
 ---
 
 # LaunchDarkly Flag Create & Configure
@@ -45,7 +45,7 @@ Before creating anything, understand how this codebase uses feature flags.
    - **Naming convention**: Are keys `kebab-case`, `snake_case`, `camelCase`?
    - **Organization**: Are flag keys co-located with features, or centralized in a constants file?
    - **Default values**: What defaults do existing evaluations use?
-   - **Context/user construction**: How does this codebase build the user/context object passed to the SDK?
+   - **Context/user construction**: How does this codebase build the user/context object passed to the SDK? This determines which context kinds and attributes any future targeting can use — and it differs by surface (server vs client vs anonymous). See [Context Availability](../launchdarkly-flag-targeting/references/context-availability.md) before planning a rule, individual target, or rollout.
 
 4. **Check LaunchDarkly project conventions.** Optionally use `list-flags` to see existing flags:
    - What tags are commonly used?
@@ -128,3 +128,4 @@ Multiple instructions can be batched in a single call. These changes are project
 
 - [Flag Types and Patterns](references/flag-types.md): Boolean vs multivariate, naming conventions, configuration best practices
 - [SDK Evaluation Patterns](references/sdk-evaluation-patterns.md): How to evaluate flags in each SDK, including common wrapper patterns
+- [Context Availability](../launchdarkly-flag-targeting/references/context-availability.md): Which context kinds/attributes targeting can use, matched to the surface where the flag is read (relevant once the flag will target rather than being a plain on/off switch)

--- a/skills/feature-flags/launchdarkly-flag-create/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-create/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "launchdarkly-flag-create",
   "description": "Create and configure LaunchDarkly feature flags in a way that fits the existing codebase",
-  "version": "1.0.0-experimental",
+  "version": "1.1.0-experimental",
   "author": "LaunchDarkly",
   "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],

--- a/skills/feature-flags/launchdarkly-flag-targeting/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-targeting/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires the remotely hosted LaunchDarkly MCP server
 metadata:
   author: launchdarkly
-  version: "1.0.0-experimental"
+  version: "1.1.0-experimental"
 ---
 
 # LaunchDarkly Flag Targeting & Rollout
@@ -69,6 +69,8 @@ Based on what the user wants and what you found, choose the right tool and strat
 | "Roll out to X%" | `update-rollout` with `rolloutType: "percentage"` | Weights must sum to 100 |
 | "Enable for beta users" | `update-targeting-rules`: add a rule with clause | Rules are ANDed within, ORed between |
 | "Add specific users" | `update-individual-targets` | Highest priority, overrides all rules |
+
+**Before writing a rule, individual target, or percentage rollout, confirm the context supports it.** A rule that names a context kind or attribute the flag's evaluation doesn't carry silently never matches; individual targets match the context **key**, not an attribute like email; and a rollout can only bucket by a kind present where the flag is read. See [Context Availability](references/context-availability.md) to pick a context that will actually fire.
 | "Full rollout" | `update-rollout` with `rolloutType: "variation"` | Serve one variation to everyone |
 | "Copy from staging" | `copy-flag-config` | Promote tested config to production |
 
@@ -129,5 +131,6 @@ When any mutation tool returns `requiresApproval: true`, the direct change was b
 ## References
 
 - [Targeting Patterns](references/targeting-patterns.md): Rollout strategies, rule construction, individual targeting, and cross-environment copying
+- [Context Availability](references/context-availability.md): Which context kinds/attributes a rule, target, or rollout can use — matching the kind to the surface where the flag is read, key vs attribute, and rollout bucketing
 - [Safety Checklist](references/safety-checklist.md): Pre-change verification, approval workflows, environment awareness
 - [Approval Workflows](references/approval-workflows.md): Creating, checking, and applying approval requests

--- a/skills/feature-flags/launchdarkly-flag-targeting/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-targeting/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "launchdarkly-flag-targeting",
   "description": "Control LaunchDarkly feature flag targeting including toggling, rollouts, rules, individual targets, cross-environment copying, and approval workflows",
-  "version": "1.0.0-experimental",
+  "version": "1.1.0-experimental",
   "author": "LaunchDarkly",
   "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],

--- a/skills/feature-flags/launchdarkly-flag-targeting/references/context-availability.md
+++ b/skills/feature-flags/launchdarkly-flag-targeting/references/context-availability.md
@@ -1,0 +1,134 @@
+# Targeting context availability
+
+Which **context kinds** and **attributes** a flag can actually target depends on
+where the flag is evaluated. A targeting rule, individual target, or percentage
+rollout that names a context kind or attribute the evaluation doesn't carry
+**silently never matches** — the context falls through to the default rule (or the
+off variation). This reference explains how to pick a context that will actually
+fire, and how to determine it deterministically from your own code rather than
+guessing.
+
+Read this whenever a flag plan involves a **targeting rule**, an
+**individual/expiring target**, a **percentage rollout**, or **self-targeting** —
+i.e. any time you pick a `contextKind` or attribute.
+
+## TL;DR
+
+- **Target only kinds present on the surface where the flag is read.** A flag read
+  in a browser (client-side SDK) can only match kinds your app actually puts in the
+  client context; a flag read on the server can match whatever the server builds.
+  A rule on a kind that isn't in the evaluation context never matches.
+- **A context's key is not an attribute.** Individual targets match the context
+  **key**; everything else (email, plan, country, …) is an **attribute** and must
+  be a targeting **rule**. Targeting an email as if it were a key is the single most
+  common mistake — see [Key vs attribute](#key-vs-attribute).
+- **Percentage rollouts bucket by one context kind.** A ramp needs that kind
+  present in the evaluation context, or it can't bucket — see
+  [Rollout bucketing](#rollout-bucketing).
+- **Availability is conditional, not global.** The same app can carry different
+  kinds/attributes in different code paths (authenticated vs anonymous, request
+  handler vs background job). Decide per surface, not once for the whole app.
+
+## Match the kind to the surface where the flag is read
+
+The context passed to an SDK's `variation` call is assembled by *your* code, and it
+differs by where that code runs:
+
+- **Server-side evaluation.** The server builds the context from whatever it has in
+  scope — often a user/account plus request-scoped data. Kinds and attributes are
+  whatever your server-side context builder puts in.
+- **Client-side / browser evaluation.** The browser only sees the context your app
+  ships to it (typically at page load, then updated via an identify call). This is
+  usually a **strict subset** of what the server has: request-scoped or
+  server-only kinds are not present, and an anonymous / pre-auth page (login,
+  signup) may carry *no* user/account context at all.
+- **Mobile evaluation.** Similar to client-side: the app controls the context and
+  it reflects the signed-in (or anonymous) state on the device.
+
+Implications:
+
+- A flag read in **both** server and client code should target only kinds present
+  in **both** contexts.
+- A client-side flag evaluated on an **anonymous / pre-auth** page cannot match a
+  user- or account-scoped rule — plan the fallthrough / off variation for the case
+  where nothing matches.
+- Client SDKs can add attributes at runtime (via an identify call) only to a kind
+  the shipped context already has; they generally can't conjure a brand-new kind on
+  a page that never carried it. Don't plan a rule on a kind the surface never sees.
+
+## Key vs attribute
+
+Every context has exactly one **key** (its stable identifier) plus any number of
+**attributes**.
+
+- **Individual / expiring targets match the key.** "Target this specific user" means
+  their context **key**, not their email or name.
+- **Everything else is a rule on an attribute.** To target by email, plan, country,
+  version, etc., write a targeting **rule** with a clause on that attribute
+  (`contextKind` + `attribute` + `op` + `values`).
+
+The classic trap: a context keyed by an opaque user ID, where email is an
+*attribute*. Adding the email as an individual **target** matches nothing (the key
+is the ID, not the email); email targeting must be a **rule** on the email
+attribute. Confirm your context's key from the code that builds it before choosing
+between an individual target and a rule.
+
+## Rollout bucketing
+
+A percentage rollout (and a guarded/progressive ramp) hashes a context to place it
+in a bucket, using **one** context kind — the rollout's `bucketBy` / rollout
+context kind (defaults to the flag's default kind). That kind must be present in the
+evaluation context for the ramp to work.
+
+- If a flag is only ever evaluated in a context that **lacks** the bucketing kind
+  (e.g. a background job with no user context when the ramp buckets by user), the
+  ramp can't place it — the context falls through instead of ramping.
+- Choose a bucketing kind that is present everywhere the flag is read, and stable
+  per subject so a given subject stays in the same bucket as the percentage grows.
+
+## Set `contextKind` explicitly
+
+A rule clause with no explicit `contextKind` defaults to the SDK's default kind
+(historically `user`). If your app targets a different kind, always set
+`contextKind` explicitly so a rule doesn't silently land on the wrong kind and fail
+to match.
+
+## Determine availability deterministically from your code
+
+Don't guess which kinds/attributes exist — read the code that builds the context:
+
+1. **Find where the context is constructed.** Search for the SDK context builder in
+   your codebase — e.g. `LDContext`, `newContext` / `ContextBuilder` (Go),
+   `LDContext.builder` (Java), `Context.builder` / `LDContext` (JS/React),
+   `Context.create` (Python), or the object literal passed to `variation` /
+   `useLDClient` / `identify`. That call site is the source of truth for the kinds
+   and attributes available at that evaluation.
+2. **Compare the surfaces.** If the flag is read on more than one surface
+   (server + client, authenticated + anonymous), read each surface's context
+   construction and target only what they share.
+3. **Confirm the key.** Read what value is used as the context `key` so you know
+   whether a subject is targetable as an individual target (by key) or only via a
+   rule (by attribute).
+4. **Cross-check a neighbor.** Inspect an existing flag's rules (their `contextKind`
+   / `attribute`) to confirm the convention already in use, and a rollout's
+   bucketing kind to confirm what ramps bucket by.
+
+## Common mistakes
+
+- Targeting a client-side flag by a server-only or request-scoped kind — it never
+  fires in the browser.
+- Writing a user/account rule on a flag evaluated on an anonymous / pre-auth page,
+  where no such context exists.
+- Adding an email (or any attribute) as an **individual target** when the context
+  key is an opaque ID — email must be a **rule** on the email attribute.
+- Planning a percentage rollout bucketed by a kind that isn't present where the flag
+  is read — the ramp can't bucket.
+- Omitting `contextKind` on a clause and silently targeting the default kind.
+- Assuming a kind/attribute is global — availability is conditional per code path;
+  decide per surface.
+
+## See also
+
+- [Targeting Patterns](targeting-patterns.md): rule construction, individual
+  targeting, percentage rollouts, and cross-environment copying.
+- [Safety Checklist](safety-checklist.md): pre-change verification and approvals.

--- a/skills/feature-flags/should-flag-change/README.md
+++ b/skills/feature-flags/should-flag-change/README.md
@@ -30,7 +30,7 @@ Ad hoc, while working on a change:
 Should this change be behind a feature flag?
 ```
 
-In CI on a pull request, the skill is fed the PR's git diff and reads the repository to assess it, then emits a `recommend-flag` verdict (`{ recommend, confidence, reasons }`) that a check can parse.
+In CI on a pull request, the skill is fed the PR's git diff and reads the repository to assess it, then emits a `recommend-flag` verdict (`{ recommend, verdict, confidence, reasons }`) that a check can parse.
 
 ## Output
 
@@ -39,12 +39,15 @@ The skill ends by calling the `recommend-flag` tool:
 ```json
 {
   "recommend": true,
+  "verdict": "suggested",
   "confidence": "medium",
   "reasons": [
     "New public endpoint added in src/routes/export.ts — user-facing path with no existing gate"
   ]
 }
 ```
+
+`recommend` is the boolean a CI check keys on. `verdict` is the finer signal: `suggested` (a new flag is warranted), `already-flagged` (protected by an existing / ancestor flag — covered, not a new flag), or `not-suited` (genuinely nothing to flag). Keeping `already-flagged` distinct from `not-suited` is what lets a dashboard track real flag coverage.
 
 ## Structure
 

--- a/skills/feature-flags/should-flag-change/SKILL.md
+++ b/skills/feature-flags/should-flag-change/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: "Advisory and read-only. Works on all platforms. Does NOT require the LaunchDarkly MCP server. Reads code with standard file tools (Read/Grep/Glob) and returns a structured verdict via the `recommend-flag` tool."
 metadata:
   author: launchdarkly
-  version: "0.1.0-experimental"
+  version: "0.2.0-experimental"
 ---
 
 # Should This Change Be Behind a Flag?
@@ -65,6 +65,12 @@ Skip exploration only when the change is unambiguous on its face (e.g. a docs-on
 
 ### Step 3: Assess against the decision framework
 
+**The user-observability test — apply before any `recommend: false`.** Before you land on "no flag," answer one question: **would a user on any live, unguarded path experience a difference from this change?** If yes — and the code is not already behind an off/mid-rollout ancestor gate — it is **not** a free skip; treat it as at least Ambiguous and pick a side deliberately. The phrases that most often mask a missed flag are **"low-risk bug fix," "visual polish," and "purely additive"** — none of them, on its own, makes a change skippable:
+
+- **"Additive" is not "safe."** A newly-shown panel, a new row, a now-populated dropdown, or a newly-surfaced suggestion is still a user-visible behavior change that can regress.
+- **A default-value change is flag-worthy even at one line.** If a control now opens/sorts/loads differently by default, a user experiences it without opting in.
+- **"Low-risk bug fix" only skips when the fix is invisible to users.** A fix that changes what a user experiences on a live, unprotected path is a behavior change; size and intent don't downgrade it.
+
 **Recommend a flag (`recommend: true`) when the change:**
 
 | Signal | Why it wants a flag |
@@ -96,6 +102,15 @@ Skip exploration only when the change is unambiguous on its face (e.g. a docs-on
 
 For ambiguous cases, pick the defensible side and make your reasons show that you weighed both directions. Honor the false-negative-over-false-positive principle when the ambiguous change touches a risky or user-facing path. **Any change that falls in this Ambiguous table MUST NOT be reported with `high` confidence** — an honestly borderline call is `low` or `medium` by definition, regardless of which verdict you land on.
 
+### Decision posture (tie-breaker for genuinely balanced cases)
+
+The user-observability test and the false-negative-over-false-positive principle come first. When they don't settle it — the change is truly balanced with no dominant signal — the tie-breaker depends on the team's release posture. State which posture you applied so the call is auditable.
+
+- **Conservative (default, human-in-the-loop):** an extra flag costs review, registry churn, and cleanup debt, so a genuinely balanced change → lean `recommend: false` and route it to tests/review.
+- **Low-overhead (automated release and automated flag cleanup are in place):** the cost of an extra flag is near zero while a missed flag ships unguarded to users, so a genuinely balanced **customer-visible** change → lean `recommend: true`.
+
+Absent any signal about the team's setup, assume the conservative posture. This tie-breaker only applies to the last-mile balanced call; it never overrides the user-observability test or a clear risk/user-facing signal.
+
 ### Step 4: Emit the verdict
 
 End by calling the **`recommend-flag`** tool exactly once, with your structured recommendation. This is the deliverable — CI parses it to post the PR check, and it is the last thing you do.
@@ -103,6 +118,7 @@ End by calling the **`recommend-flag`** tool exactly once, with your structured 
 ```
 recommend-flag({
   recommend: boolean,            // true = should be behind a flag
+  verdict: "suggested" | "already-flagged" | "not-suited",  // the specific outcome; see below
   confidence: "low" | "medium" | "high",
   risk: "low" | "medium" | "high",  // optional: blast radius / severity of the change itself
   reasons: [                     // concise, evidence-based; each cites a file/behavior
@@ -116,9 +132,14 @@ Rules for the verdict:
 
 - **Call the tool exactly once, as the final step.** Do not call it before you've explored.
 - **`reasons` must be specific and evidence-based.** Reference the files, symbols, or behaviors you actually observed. Avoid generic statements like "this is risky."
+- **Set `verdict` to the specific outcome — keep `already-flagged` distinct from `not-suited`.** `recommend: true` always pairs with `verdict: "suggested"`. `recommend: false` splits into two outcomes that must not be collapsed into one "no flag" bucket:
+  - `already-flagged` — the change is *already protected*: it ships behind a flag check in the diff, or it lives inside an off / mid-rollout ancestor gate. There **is** a flag; it just isn't a *new* one. Name the flag key (and, for an ancestor, its rollout state) in `reasons`.
+  - `not-suited` — there is *genuinely nothing to flag*: a pure refactor, docs/comments, tests, dependency bump, or build/CI/tooling change with no user-observable behavior change.
+
+  `recommend` stays the boolean a CI check keys on; `verdict` is the finer signal a dashboard uses to track flag coverage. Collapsing `already-flagged` into `not-suited` hides real coverage and inflates the apparent "nothing to flag" rate — a change protected by an ancestor gate is *covered*, not *unneeded*.
 - **Calibrate `confidence` — do not default to `high`.** Reserve `high` for genuinely clear-cut changes you fully understand (a docs-only diff, an obvious pure refactor, a plainly new user-facing endpoint). Use `medium` when the verdict is sound but you couldn't verify every call site, and `low` when the change is ambiguous, borderline, or touches money/security/data on a live path where reasonable reviewers could disagree. **If you weighed both directions in Step 3 — i.e. the change is in the Ambiguous table — `confidence` MUST be `low` or `medium`, never `high`, even when you land firmly on a verdict.** Confidence is about how clear-cut the *call* is, not how strongly you hold your conclusion. **Any reason you could not verify against the actual code caps `confidence` at `medium`, and you must name it as unverified.**
 - **Set `risk` (optional but recommended) to the change's blast radius — separate from `confidence`.** Confidence is how clear-cut the call is; risk is how much damage the change could do. They're orthogonal: a plainly-new-endpoint is a clear call (`high` confidence) that might be low blast radius, while an auth-fallthrough tweak can be both `high` confidence and `high` risk. Anchor it: `low` = small, additive, isolated change; `medium` = modified business logic / moderate blast radius; `high` = cross-cutting, API-contract, data-migration, or auth/payments/data-integrity change. A downstream check can use `risk` to prioritize.
-- **Then summarize in prose** for the human: restate the verdict, the key reasons, and — if you recommended a flag — a one-line suggestion of what kind (e.g. "a boolean release flag defaulting to the old behavior"). Note whether the change is a **net-new path** (the flag-off control renders nothing, so a guarded rollout must lean on existing global/service metrics — feature-specific before/after comparisons are one-armed) or an **incremental change to a live path** (both variations exercise comparable code, so feature-specific metrics compare cleanly); this tells the release step what its rollout can actually measure. Point them at the flag create skill to actually create it.
+- **Then summarize in prose** for the human: restate the verdict, the key reasons, and — if you recommended a flag — a one-line suggestion of what kind (e.g. "a boolean release flag defaulting to the old behavior"). Note whether the change is a **net-new path** (the flag-off control renders nothing, so a guarded rollout must lean on existing global/service metrics — feature-specific before/after comparisons are one-armed) or an **incremental change to a live path** (both variations exercise comparable code, so feature-specific metrics compare cleanly); this tells the release step what its rollout can actually measure. Point them at the flag create skill to actually create it. If the flag you're suggesting will **target** (a rule, individual target, or percentage rollout) rather than being a plain on/off switch, also point them at [Context Availability](../launchdarkly-flag-targeting/references/context-availability.md) so the targeting names a context kind/attribute that actually exists where the flag is read.
 
 If the `recommend-flag` tool is not available in your environment, emit the exact same object as a fenced ` ```json ` block labeled `recommend-flag` so it can still be parsed, then give the prose summary.
 
@@ -126,9 +147,9 @@ If the `recommend-flag` tool is not available in your environment, emit the exac
 
 | Situation | Action |
 |-----------|--------|
-| Diff is empty or only whitespace | `recommend: false`, `confidence: high`, reason noting no behavioral change |
-| Diff mixes a refactor with a real behavior change | Judge on the behavior change; recommend a flag if that part warrants it, and say which part drove the verdict |
-| Change is already behind a flag — in the diff, or an ancestor gate that's off/mid-rollout | `recommend: false` (already gated); name the flag key and, for an ancestor, its rollout state. If the ancestor is fully launched or a permanent config gate, it isn't protecting this change — judge normally. |
+| Diff is empty or only whitespace | `recommend: false`, `verdict: not-suited`, `confidence: high`, reason noting no behavioral change |
+| Diff mixes a refactor with a real behavior change | Judge on the behavior change; recommend a flag if that part warrants it (`verdict: suggested`), and say which part drove the verdict |
+| Change is already behind a flag — in the diff, or an ancestor gate that's off/mid-rollout | `recommend: false`, `verdict: already-flagged`; name the flag key and, for an ancestor, its rollout state. If the ancestor is fully launched or a permanent config gate, it isn't protecting this change — judge normally (likely `verdict: suggested`). |
 | You can't read the surrounding code (no repo access, ad hoc snippet) | Decide from the diff alone; lower `confidence` and say exploration was unavailable |
 | The change is a hotfix / revert | Usually `recommend: false` unless it re-introduces a risky path; explain |
 
@@ -139,4 +160,5 @@ If the `recommend-flag` tool is not available in your environment, emit the exac
 - **Don't decide from the diff alone when you could read the code.** Line-level diffs hide blast radius.
 - **Don't be vague.** "Might be risky" is not a reason; "changes the auth fallthrough in `middleware/auth.ts:42` which every route depends on" is.
 - **Don't skip the `recommend-flag` call.** Prose without the structured verdict is not a usable result.
+- **Don't collapse `already-flagged` into `not-suited`.** A change protected by an ancestor gate is *covered*, not *nothing to flag* — record the two distinctly.
 - **Don't over-flag trivial changes.** Recommending a flag for a README edit erodes trust in the recommendation.

--- a/skills/feature-flags/should-flag-change/marketplace.json
+++ b/skills/feature-flags/should-flag-change/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "should-flag-change",
   "description": "Decide whether a given code change should be placed behind a LaunchDarkly feature flag. Advisory and read-only.",
-  "version": "0.1.0-experimental",
+  "version": "0.2.0-experimental",
   "author": "LaunchDarkly",
   "repository": "https://github.com/launchdarkly/ai-tooling",
   "skills": ["./"],


### PR DESCRIPTION
## Summary
Stacked on #101. Layers the portable, de-LaunchDarkly-internal strengths from our internal flag-planning skills onto the public feature-flag family, plus one new SDK-agnostic reference.

- **should-flag-change**: explicit user-observability gate before any "no flag"; a `verdict` field (`suggested` / `already-flagged` / `not-suited`) that keeps *already-flagged* distinct from *not-suited* so ancestor-gated coverage isn't miscounted; a generalized conservative-vs-low-overhead decision posture. Stays MCP-free / CI-oriented.
- **New reference** `launchdarkly-flag-targeting/references/context-availability.md`: target only context kinds present on the surface where the flag is read (server/client/anonymous), key-vs-attribute, and rollout bucketing. Wired into flag-targeting, flag-create, and should-flag-change.
- **Evals**: verdict-taxonomy assertions across should-flag-change fixtures; a client-side-flag-targets-a-server-only-signal fixture in flag-create.
- Version bumps + regenerated `skills.json`; `validate_skills.py` and catalog `--check` pass.

## Test plan
- [ ] `python3 scripts/generate_catalog.py --check` is clean
- [ ] `python3 scripts/validate_skills.py` passes
- [ ] `npm run eval:should-flag-change` and `npm run eval:flag-create` with an Anthropic key

Made with [Cursor](https://cursor.com)