### PR TITLE
Add agentcontrol docs links to applicable skills

### DIFF
--- a/skills/agentcontrol/agent-graphs/SKILL.md
+++ b/skills/agentcontrol/agent-graphs/SKILL.md
@@ -133,8 +133,6 @@ Use `create-agent-graph` with:
 - Root config set correctly
 - All edges verified
 
-Find documentation for this process at https://launchdarkly.com/docs/home/agentcontrol/agent-graphs.md
-
 ## Edge Cases
 
 | Situation | Action |
@@ -150,3 +148,7 @@ Find documentation for this process at https://launchdarkly.com/docs/home/agentc
 - Don't forget handoff data when agents need context from predecessors
 - Don't create overly complex graphs — start simple and add nodes as needed
 - Don't delete a graph without understanding if it's actively used in agent workflows
+
+## Other Resources
+
+To learn more, read [Agent graphs](https://launchdarkly.com/docs/home/agentcontrol/agent-graphs.md).

--- a/skills/agentcontrol/agent-graphs/SKILL.md
+++ b/skills/agentcontrol/agent-graphs/SKILL.md
@@ -133,6 +133,8 @@ Use `create-agent-graph` with:
 - Root config set correctly
 - All edges verified
 
+Find documentation for this process at https://launchdarkly.com/docs/home/agentcontrol/agent-graphs.md
+
 ## Edge Cases
 
 | Situation | Action |

--- a/skills/agentcontrol/configs-create/SKILL.md
+++ b/skills/agentcontrol/configs-create/SKILL.md
@@ -215,6 +215,18 @@ The `create-ai-config-variation` tool validates this format and rejects invalid 
 - Don't drop to raw `curl` + `jq` for verification. Use `get-ai-config` (MCP) — it returns a typed object and avoids brittle `jq` filters that break on response-shape variation.
 - Don't consider the workflow complete until the user has been told to run `configs-targeting`. A created variation that isn't promoted to fallthrough returns `enabled=False` to every consumer.
 
+## More resources
+
+To learn more about creating a config in the LaunchDarkly UI, read [Create configs](https://launchdarkly.com/docs/home/agentcontrol/create.md)
+
+To learn more about configuring the SDK, read:
+
+* [.NET AI SDK reference](https://launchdarkly.com/docs/sdk/ai/dotnet.md)
+* [Go AI SDK reference](https://launchdarkly.com/docs/sdk/ai/go.md)
+* [Node.js (server-side) SDK AI reference](https://launchdarkly.com/docs/sdk/ai/node-js.md)
+* [Python AI SDK reference](https://launchdarkly.com/docs/sdk/ai/python.md)
+* [Ruby AI SDK reference](https://launchdarkly.com/docs/sdk/ai/ruby.md)
+
 ## Related Skills
 
 - `tools` -- Create tools before attaching

--- a/skills/agentcontrol/configs-targeting/SKILL.md
+++ b/skills/agentcontrol/configs-targeting/SKILL.md
@@ -499,9 +499,9 @@ After configuring targeting:
 - `online-evals` - Attach judges
 - `segments` - Create segments for targeting
 
-## References
+## Other Resources
 
-- [Target with AgentControl](https://docs.launchdarkly.com/home/ai-configs/target)
-- [Targeting Rules](https://docs.launchdarkly.com/home/flags/target-rules)
-- [JSON Targeting](https://docs.launchdarkly.com/home/flags/json-targeting)
-- [Guarded Rollouts](https://docs.launchdarkly.com/home/releases/guarded-rollouts)
+- [Target with AgentControl](https://docs.launchdarkly.com/home/ai-configs/target.md)
+- [Targeting Rules](https://docs.launchdarkly.com/home/flags/target-rules.md)
+- [JSON Targeting](https://docs.launchdarkly.com/home/flags/json-targeting.md)
+- [Guarded Rollouts](https://docs.launchdarkly.com/home/releases/guarded-rollouts.md)

--- a/skills/agentcontrol/configs-update/SKILL.md
+++ b/skills/agentcontrol/configs-update/SKILL.md
@@ -88,6 +88,10 @@ Use `get-ai-config` to confirm the response shows your updated values.
 - Don't delete without explicit user confirmation -- always suggest archiving first
 - Don't retry an update because the API response doesn't echo back the exact values you sent -- verify with `get-ai-config` instead
 
+## More resources
+
+To learn more about creating and managing variations, read [Create and manage config variations](https://launchdarkly.com/docs/home/agentcontrol/create-variation.md).
+
 ## Related Skills
 
 - `configs-variations` -- Create variations to test changes side-by-side

--- a/skills/agentcontrol/configs-variations/SKILL.md
+++ b/skills/agentcontrol/configs-variations/SKILL.md
@@ -103,6 +103,10 @@ When the user wants to try a different model, prompt, or parameters, **always cr
 - Don't make decisions on small sample sizes
 - Don't modify or remove the baseline variation -- create new variations alongside it
 - Don't use `update-ai-config-variation` to "replace" a baseline -- create a new variation instead
+   
+## More resources
+
+To learn more about creating and managing variations, read [Create and manage config variations](https://launchdarkly.com/docs/home/agentcontrol/create-variation.md).
 
 ## Related Skills
 

--- a/skills/agentcontrol/online-evals/SKILL.md
+++ b/skills/agentcontrol/online-evals/SKILL.md
@@ -443,8 +443,8 @@ After attaching judges:
 
 ## References
 
-- [Online Evaluations](https://docs.launchdarkly.com/home/ai-configs/online-evaluations)
-- [Custom Judges](https://docs.launchdarkly.com/home/ai-configs/custom-judges)
+- [Online Evaluations](https://docs.launchdarkly.com/home/ai-configs/online-evaluations.md)
+- [Custom Judges](https://docs.launchdarkly.com/home/ai-configs/custom-judges.md)
 
 **Python SDK examples:**
 - [create_judge_example.py](https://github.com/launchdarkly/hello-python-ai/blob/main/features/create_judge/create_judge_example.py) - Evaluate input/output pairs directly via `create_judge` + `evaluate`

--- a/skills/agentcontrol/snippets/SKILL.md
+++ b/skills/agentcontrol/snippets/SKILL.md
@@ -129,3 +129,7 @@ Each update creates a new version. Existing config variations referencing the sn
 - Don't put an entire prompt in a single snippet — break it into focused pieces
 - Don't delete snippets without checking which configs reference them
 - Don't duplicate existing snippets — check `list-prompt-snippets` first
+
+## More resources
+
+To learn more about setting up prompt snippets in the LaunchDarkly UI, read [Prompt snippets](https://launchdarkly.com/docs/home/agentcontrol/snippets.md).


### PR DESCRIPTION
## Summary

Adds links to .md versions of docs files to agentcontrol skills.

## Testing

- [ ] Not applicable
- [ ] Manual (describe below)

## Notes

- 
