### PR TITLE
feat: add flag-drift and segment-create skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `feature-flags/launchdarkly-flag-create` | Create new feature flags in a way that fits existing codebase patterns |
 | `feature-flags/launchdarkly-flag-targeting` | Control targeting, rollouts, rules, and cross-environment config |
 | `feature-flags/launchdarkly-flag-cleanup` | Safely remove flags from code using LaunchDarkly as the source of truth |
+| `feature-flags/launchdarkly-segment-create` | Create reusable audience segments with targeting rules or individual targets, and wire them into flags |
 
 ### AI Configs
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `feature-flags/launchdarkly-flag-create` | Create new feature flags in a way that fits existing codebase patterns |
 | `feature-flags/launchdarkly-flag-targeting` | Control targeting, rollouts, rules, and cross-environment config |
 | `feature-flags/launchdarkly-flag-cleanup` | Safely remove flags from code using LaunchDarkly as the source of truth |
+| `feature-flags/launchdarkly-flag-drift` | Detect and reconcile drift between an in-code SDK fallback default and the LaunchDarkly default rule |
 | `feature-flags/launchdarkly-segment-create` | Create reusable audience segments with targeting rules or individual targets, and wire them into flags |
 
 ### AI Configs

--- a/skills.json
+++ b/skills.json
@@ -117,6 +117,14 @@
         "devops",
         "mcp"
       ]
+    },
+    {
+      "name": "launchdarkly-segment-create",
+      "description": "Create and configure LaunchDarkly segments \u2014 reusable audience definitions for flag targeting. Use when the user wants to create a segment, add targeting rules to a segment, add individual contexts to a segment, or wire an existing segment into a feature flag's targeting rules.",
+      "path": "skills/feature-flags/launchdarkly-segment-create",
+      "version": "1.0.0-experimental",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server"
     }
   ]
 }

--- a/skills.json
+++ b/skills.json
@@ -101,6 +101,25 @@
       ]
     },
     {
+      "name": "launchdarkly-flag-drift",
+      "description": "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation.",
+      "path": "skills/feature-flags/launchdarkly-flag-drift",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feature-management",
+        "flag-drift",
+        "default-drift",
+        "sdk",
+        "reconciliation",
+        "devops",
+        "mcp"
+      ]
+    },
+    {
       "name": "launchdarkly-flag-targeting",
       "description": "Control LaunchDarkly feature flag targeting including toggling flags on/off, percentage rollouts, targeting rules, individual targets, and copying flag configurations between environments. Use when the user wants to change who sees a flag, roll out to a percentage, add targeting rules, or promote config between environments.",
       "path": "skills/feature-flags/launchdarkly-flag-targeting",

--- a/skills/feature-flags/launchdarkly-flag-drift/README.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/README.md
@@ -1,0 +1,66 @@
+# LaunchDarkly Flag Drift Skill
+
+An Agent Skill for detecting and reconciling drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule, keeping outage behavior consistent with production.
+
+## Overview
+
+This skill teaches agents how to:
+- Resolve a flag's current default rule (fallthrough) value from LaunchDarkly
+- Locate the fallback default argument in every SDK evaluation and declaration in code
+- Compare the two and detect drift
+- Reconcile only the in-code default when it has drifted, without removing the flag or changing its evaluation
+- Open a well-scoped pull request that documents the change
+
+## Installation (Local)
+
+For now, install by placing this skill directory where your agent client loads skills.
+
+Examples:
+
+- **Generic**: copy `skills/feature-flags/launchdarkly-flag-drift/` into your client's skills path
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment. The remote server provides higher-level, agent-optimized tools that orchestrate multiple API calls and return pruned, actionable responses.
+
+Refer to your LaunchDarkly account settings for instructions on connecting to the remotely hosted MCP server.
+
+## Usage
+
+Once installed, the skill activates automatically when you ask about flag default drift:
+
+```
+The default rule for `new-checkout-flow` changed in production. Check if the code default drifted
+```
+
+```
+Does the hardcoded default for `dark-mode` still match LaunchDarkly?
+```
+
+```
+Open a PR to sync the in-code default for `enable-new-billing` with its fallthrough
+```
+
+## Structure
+
+```
+launchdarkly-flag-drift/
+├── SKILL.md
+├── marketplace.json
+├── README.md
+└── references/
+    ├── sdk-default-patterns.md
+    └── pr-template.md
+```
+
+## Related
+
+- [LaunchDarkly Flag Cleanup](../launchdarkly-flag-cleanup/SKILL.md): Remove a flag from code entirely
+- [LaunchDarkly Flag Targeting](../launchdarkly-flag-targeting/SKILL.md): Change the default rule in LaunchDarkly instead of the code
+- [LaunchDarkly MCP Server](https://github.com/launchdarkly/mcp-server)
+- [LaunchDarkly Docs](https://docs.launchdarkly.com)
+- [Agent Skills Specification](https://agentskills.io/specification)
+
+## License
+
+Apache-2.0

--- a/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: launchdarkly-flag-drift
+description: "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation."
+license: Apache-2.0
+compatibility: Requires the remotely hosted LaunchDarkly MCP server
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly Flag Drift Detection
+
+You're using a skill that will guide you through checking whether a feature flag's **in-code SDK fallback default** has drifted from its **LaunchDarkly default rule (fallthrough)**, and reconciling the code if it has. Your job is to determine the flag's current default rule value from LaunchDarkly, locate the default argument passed to every SDK evaluation in code, compare them, and, only when they differ, update the in-code default so it matches. You never remove the flag or change its evaluation logic.
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment.
+
+**Required MCP tools:**
+- `get-flag`: fetch the flag's configuration in a specific environment (fallthrough, variations, offVariation)
+
+**Optional MCP tools:**
+- `list-flags`: find the flag key if the user only described the flag by name
+
+## Core Concept: The SDK Fallback Default Is Not the Off Variation
+
+Every SDK evaluation call takes a **fallback default**: the value returned when LaunchDarkly is unreachable, the client is uninitialized, or the flag is unavailable. This is a code-side safety value, distinct from the flag's `offVariation` (served when the flag is toggled off) and from its `fallthrough` (the default rule served when no targeting rule matches).
+
+This skill treats one specific invariant as "correct": **the in-code fallback default should match the current default rule (fallthrough) value** for the source environment. When they diverge, that's *drift*. Reconciling it keeps the value returned during an outage consistent with what most users would otherwise receive.
+
+Some teams intentionally keep the fallback as a conservative/off value instead. Treat a mismatch as a finding to surface, not always an automatic edit. See Edge Cases.
+
+## Workflow
+
+### Step 1: Identify the Flag and Source Environment
+
+1. **Get the flag key.** If the user described the flag by name, use `list-flags` to resolve the key. Confirm before proceeding.
+2. **Confirm the environment.** The fallthrough is environment-specific; a default rule that changed in `production` may differ in `staging`. Always confirm which environment is the source of truth. If not specified, ask rather than assume.
+
+### Step 2: Determine the Expected Default from LaunchDarkly
+
+Use `get-flag` for the flag key and source environment. Read:
+- `fallthrough`: the default rule. If it points to a single `variation` (an index), that's your expected value. If it's a percentage `rollout`, there is **no single default value**, so stop and handle as an edge case.
+- `variations`: map `fallthrough.variation` (the index) to `variations[index].value`. This resolved value is the **expected default**.
+- `offVariation` and flag type: useful context for the comparison and for spotting type mismatches.
+
+Never guess the fallthrough value. Always resolve it from `get-flag`.
+
+### Step 3: Locate Every In-Code Default
+
+Find every place the flag is evaluated in code and, critically, the **default/fallback argument** passed to the SDK call. Search for the flag key across the codebase, then identify the default in each hit.
+
+- The default is typically the **last positional argument** to `variation(...)` / `*Variation(...)` calls (e.g. `boolVariation("<key>", context, <default>)`).
+- Teams often wrap the SDK. Check wrapper/registry/config layers that declare a default once per flag, annotation- or struct-tag-based defaults, and generated default files.
+
+See [SDK Default Patterns](references/sdk-default-patterns.md) for the full set of patterns by language and abstraction, and how to distinguish the default argument from the context argument.
+
+### Step 4: Compare and Decide
+
+Normalize both sides before comparing (see Edge Cases for JSON/number/type notes), then:
+
+| Result | Action |
+|--------|--------|
+| In-code default **matches** the expected default | **No drift.** Report `drift_detected: false` and stop. Do not open a PR. |
+| In-code default **differs** | **Drift detected.** Proceed to Step 5 to reconcile. |
+| Multiple evaluations with **different** in-code defaults | Drift. Reconcile all of them to the expected value and note the prior inconsistency. |
+
+### Step 5: Reconcile the In-Code Default
+
+Update **only** the default/fallback argument so it matches the expected value.
+
+- Do **not** change evaluation logic, branching, or off-path behavior.
+- Do **not** remove the flag or its evaluation.
+- If the default lives in a **generated file**, do not hand-edit it. Update the source of truth (the constructor/registry/annotation) and regenerate using the project's codegen command. Note `requires_generation: true` in your summary.
+
+**Example (before then after), expected default = `true`:**
+
+```typescript
+// Before: outage returns false even though the default rule now serves true
+const enabled = await ldClient.variation('new-checkout-flow', context, false);
+
+// After: fallback default reconciled to match the fallthrough
+const enabled = await ldClient.variation('new-checkout-flow', context, true);
+```
+
+The surrounding `if (enabled) { ... } else { ... }` branching is left untouched.
+
+### Step 6: Validate Before Committing
+
+Run the project's configured checks scoped to the changed files. Discover them from `package.json` scripts, a `Makefile`, `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md`, or the CI config. Typically: format, lint, type-check, build, and the relevant tests.
+
+**Hard stop:** if any check fails and you cannot fix it, do not commit or push. Narrow your change instead. Never ship code that fails format/lint/type-check/build/test.
+
+### Step 7: Open the Pull Request
+
+Only after validation passes. Use [references/pr-template.md](references/pr-template.md). The description must state: the flag key, the source environment, the old vs new in-code default, and that **only** the SDK fallback default changed (the flag and its evaluation are preserved).
+
+- Follow the repository's contribution conventions (branch naming, commit style). Check `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md` first.
+- A clear default: branch `fix/flag-default-drift-<flag-key>`, commit `fix: sync in-code default for <flag-key> to match fallthrough`.
+
+### Step 8: Report a Structured Summary
+
+Produce a concise summary with these fields:
+
+```
+flag_key:            <key>
+drift_detected:      true | false
+old_default:         <in-code value before, or n/a>
+new_default:         <expected value / value written, or n/a>
+files_modified:      [<paths>]
+pr_url:              <url or null>
+requires_generation: true | false
+notes:               <anything the reviewer should know>
+```
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Fallthrough is a **percentage rollout** | There is no single default value. Report the split, do not auto-edit, and ask the user which value the fallback should represent. |
+| Fallback appears **intentionally conservative** (matches `offVariation` or a safe value) | Surface the mismatch and confirm intent before changing. Some teams keep the fallback as a safe value on purpose. |
+| In-code default lives in a **generated file** | Edit the source of truth and regenerate; never hand-edit generated output. Set `requires_generation: true`. |
+| **Type mismatch** between code default and the variation's type | Flag as a bug in the PR/summary; the default and variation types should agree. |
+| **JSON / object / float** defaults | Compare by normalized value, not string form (`{"a":1}` == `{ "a": 1 }`, `0` == `0.0`). |
+| Flag **not found** or wrong environment | Inform the user; check for typos in the key and confirm the environment. |
+| **Dynamic flag keys** (`flag-${id}`) | Automated detection may be incomplete; flag for manual review. |
+| Environments **disagree** on the fallthrough | The fallback can only match one. Confirm which environment is the source of truth. |
+| Flag spans **multiple repositories** | This skill operates on the current repo. Note other repos that also reference the key so they can be reconciled separately. |
+
+## What NOT to Do
+
+- Don't remove the flag or its evaluation; this skill only touches the default argument.
+- Don't change evaluation logic, branching, or off-path behavior beyond the fallback default.
+- Don't hand-edit generated files; regenerate from the source of truth.
+- Don't open a PR when there is no drift.
+- Don't guess the fallthrough value; resolve it from `get-flag`.
+- Don't ship code that fails format, lint, type-check, build, or tests.
+
+## References
+
+- [SDK Default Patterns](references/sdk-default-patterns.md): Where the fallback default lives by language, wrapper, annotation, and generated-file pattern; how to find it
+- [PR Template](references/pr-template.md): Structured PR description for a drift reconciliation
+- [Flag Cleanup](../launchdarkly-flag-cleanup/SKILL.md): If the goal is to remove the flag entirely, not reconcile its default
+- [Flag Targeting](../launchdarkly-flag-targeting/SKILL.md): If the goal is to change the default rule in LaunchDarkly instead of the code

--- a/skills/feature-flags/launchdarkly-flag-drift/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-drift/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "launchdarkly-flag-drift",
+  "description": "Detect and reconcile drift between an in-code SDK fallback default and a LaunchDarkly default rule",
+  "version": "0.1.0",
+  "author": "LaunchDarkly",
+  "repository": "https://github.com/launchdarkly/agent-skills",
+  "skills": ["./"],
+  "tags": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management",
+    "flag-drift",
+    "default-drift",
+    "sdk",
+    "reconciliation",
+    "devops",
+    "mcp"
+  ],
+  "requirements": {
+    "mcp-servers": ["@launchdarkly/mcp-server"]
+  }
+}

--- a/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
@@ -1,0 +1,72 @@
+# PR Template for Flag Default Drift
+
+Use this template when opening a pull request that reconciles an in-code SDK fallback default with the LaunchDarkly default rule (fallthrough). The change is intentionally narrow: only the default argument moves. The flag and its evaluation stay.
+
+```markdown
+## Sync in-code default: `{flag-key}`
+
+### Summary
+- **Flag**: `{flag-key}`
+- **Source environment**: `{environment}`
+- **Old in-code default**: `{old value}`
+- **New in-code default**: `{new value}` (matches current default rule / fallthrough)
+- **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
+
+### Why
+The flag's default rule (fallthrough) in `{environment}` serves `{new value}`, but the
+hardcoded fallback in code returned `{old value}` when LaunchDarkly is unreachable.
+This drift meant an outage would serve a different value than normal operation. This PR
+reconciles the fallback so the outage value matches the default rule.
+
+### Changes
+- Files modified: `{list files}`
+- Occurrences updated: `{count}`
+- Requires code generation: `{yes/no}` {if yes, note the command run, e.g. `make generate`}
+
+### Not changed
+- Flag evaluation and branching logic
+- Off-path behavior (`offVariation`)
+- The flag itself (not removed, not archived)
+
+### Reviewer checklist
+- [ ] New default matches the fallthrough value from `get-flag` for `{environment}`
+- [ ] Only the default argument changed (no logic/branching edits)
+- [ ] Default type matches the flag's variation type
+- [ ] Generated files (if any) were regenerated, not hand-edited
+- [ ] Format, lint, type-check, build, and tests pass
+```
+
+## Example
+
+```markdown
+## Sync in-code default: `new-checkout-flow`
+
+### Summary
+- **Flag**: `new-checkout-flow`
+- **Source environment**: `production`
+- **Old in-code default**: `false`
+- **New in-code default**: `true` (matches current default rule / fallthrough)
+- **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
+
+### Why
+The default rule in `production` now serves `true`, but the code fallback returned `false`
+during outages. This PR reconciles the fallback to `true` so behavior is consistent when
+LaunchDarkly is unreachable.
+
+### Changes
+- Files modified: `CheckoutService.ts`
+- Occurrences updated: 1
+- Requires code generation: no
+
+### Not changed
+- The `if (enabled) { renderNew() } else { renderOld() }` branching
+- `offVariation` behavior
+- The flag itself
+
+### Reviewer checklist
+- [x] New default matches the fallthrough value from `get-flag` for `production`
+- [x] Only the default argument changed (no logic/branching edits)
+- [x] Default type matches the flag's variation type
+- [x] No generated files involved
+- [x] Format, lint, type-check, build, and tests pass
+```

--- a/skills/feature-flags/launchdarkly-flag-drift/references/sdk-default-patterns.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/references/sdk-default-patterns.md
@@ -1,0 +1,144 @@
+# SDK Default Patterns Reference
+
+How to find the **fallback default**: the value the SDK returns when LaunchDarkly is unreachable, uninitialized, or the flag is unavailable. This is the argument this skill compares against the flag's default rule (fallthrough) and, on drift, the only thing it changes.
+
+## How to Spot the Default Argument
+
+In a direct SDK evaluation, the arguments are usually: **flag key**, **context/user**, **default**. The default is almost always the **last positional argument**. Do not confuse it with the context.
+
+```text
+ldClient.<typed>Variation( "<flag-key>", <context>, <DEFAULT> )
+                            ^ key         ^ context   ^ the value this skill checks
+```
+
+The default's type should match the flag's variation type (bool flag → boolean default, string flag → string default, etc.). A type mismatch is a bug worth flagging.
+
+## Direct Evaluation by Language
+
+### JavaScript / TypeScript (Node & client)
+
+```typescript
+ldClient.variation('flag-key', context, defaultValue);
+ldClient.boolVariation('flag-key', context, false);      // default = false
+ldClient.stringVariation('flag-key', context, 'control'); // default = 'control'
+ldClient.numberVariation('flag-key', context, 0);
+ldClient.jsonVariation('flag-key', context, {});
+ldClient.variationDetail('flag-key', context, defaultValue);
+```
+
+React SDK note: `useFlags()` reads already-evaluated values and does not expose a per-call default. The default for those flags is set where `LDProvider` / `asyncWithLDProvider` is configured (`flags` bootstrap / default map). Check the provider setup, not the call site.
+
+### Python
+
+```python
+ld_client.variation('flag-key', context, default_value)
+ld_client.bool_variation('flag-key', context, False)
+ld_client.string_variation('flag-key', context, 'control')
+ld_client.int_variation('flag-key', context, 0)
+ld_client.variation_detail('flag-key', context, default_value)
+```
+
+### Go
+
+```go
+ldClient.BoolVariation("flag-key", context, false)      // default = false
+ldClient.StringVariation("flag-key", context, "control")
+ldClient.IntVariation("flag-key", context, 0)
+ldClient.JSONVariation("flag-key", context, ldvalue.Null())
+ldClient.BoolVariationDetail("flag-key", context, false)
+```
+
+### Java / Kotlin
+
+```java
+ldClient.boolVariation("flag-key", context, false);
+ldClient.stringVariation("flag-key", context, "control");
+ldClient.intVariation("flag-key", context, 0);
+ldClient.jsonValueVariation("flag-key", context, LDValue.ofNull());
+```
+
+### Ruby
+
+```ruby
+ld_client.variation('flag-key', context, default_value)
+ld_client.bool_variation('flag-key', context, false)
+ld_client.string_variation('flag-key', context, 'control')
+```
+
+### .NET (C#)
+
+```csharp
+ldClient.BoolVariation("flag-key", context, false);
+ldClient.StringVariation("flag-key", context, "control");
+ldClient.IntVariation("flag-key", context, 0);
+ldClient.JsonVariation("flag-key", context, LdValue.Null);
+```
+
+## Abstraction Patterns (where the default is declared once)
+
+Many teams don't call the SDK directly at each site. They declare the default in a central place, then read the flag by key elsewhere. When present, the default in these declarations is the value to check and reconcile.
+
+### Wrapper / service method
+
+```typescript
+featureFlags.getBool('flag-key', false);   // default = false
+featureFlags.getValue('flag-key', 'control');
+```
+
+Open the wrapper implementation to confirm how the passed value flows into the underlying `variation(...)` call.
+
+### Registry / config map (one default per flag)
+
+```typescript
+// A central flag registry
+const flags = {
+  'new-checkout-flow': createFlag('new-checkout-flow', /* default */ false),
+};
+```
+
+```yaml
+# A config file of flag defaults
+feature_flags:
+  new-checkout-flow: false
+```
+
+### Annotation / struct-tag defaults
+
+Some typed languages encode the default in metadata rather than an argument.
+
+```go
+type Flags struct {
+    NewCheckoutFlow bool `ld:"new-checkout-flow,false"` // default = false
+}
+```
+
+```java
+@FeatureFlag(key = "new-checkout-flow", defaultValue = "false")
+boolean newCheckoutFlow;
+```
+
+Reconcile the value inside the annotation/tag, not a downstream copy of it.
+
+### Generated default files
+
+When flag defaults are compiled into a generated file (e.g. an auto-generated defaults map or typed accessor), **do not hand-edit the generated output**. Change the source of truth (the registry, annotation, or codegen input) and re-run the project's generation step. Mark `requires_generation: true` in the summary.
+
+## Search Strategy
+
+Search for the flag key with several forms, since codebases mix conventions:
+
+```bash
+# Exact key, both quote styles
+rg "'flag-key'" ; rg '"flag-key"'
+
+# camelCase accessor (kebab keys often surface as camelCase in code)
+rg "flagKey"
+
+# Wrapper / registry / config usage and constants
+rg "flag-key|flagKey|FLAG_KEY"
+
+# Likely declaration sites
+rg "flag-key" -g '*flags*' -g '*.constants.*' -g '*config*'
+```
+
+For each hit, decide whether it is: a direct evaluation (default = last arg), a declaration (default = the declared value), or a read of an already-declared flag (trace back to the declaration). Reconcile at the declaration; read sites need no change.

--- a/skills/feature-flags/launchdarkly-segment-create/README.md
+++ b/skills/feature-flags/launchdarkly-segment-create/README.md
@@ -1,0 +1,50 @@
+# LaunchDarkly Segment Create Skill
+
+An Agent Skill for creating and managing reusable audience segments in LaunchDarkly, so teams define targeting criteria once and reuse them across multiple feature flags.
+
+## Overview
+
+This skill teaches agents how to:
+- Check for existing segments before creating duplicates
+- Choose the right segment type: rule-based (attribute matching) vs list-based (explicit keys)
+- Create a segment in a specific environment with the right key, name, and tags
+- Configure segment membership via targeting rules or individual context targets
+- Wire a segment into a feature flag's targeting rules using the `segmentMatch` operator
+
+## Usage
+
+Once installed, the skill activates when you ask about segments:
+
+```
+Create a beta-testers segment in staging for users whose email ends in @example.com
+```
+
+```
+Add the enterprise-accounts segment to the new-dashboard flag so enterprise users get the true variation
+```
+
+```
+Set up an internal-qa segment in production with these specific user keys: [key1, key2, key3]
+```
+
+## Structure
+
+```
+launchdarkly-segment-create/
+├── SKILL.md
+├── README.md
+└── references/
+    ├── segment-types.md
+    └── segment-rule-patterns.md
+```
+
+## Related
+
+- [LaunchDarkly Flag Targeting](../launchdarkly-flag-targeting/) — Wire segments into flag targeting rules after creating them
+- [LaunchDarkly Flag Create](../launchdarkly-flag-create/) — Create the flags that segments will be wired into
+- [LaunchDarkly MCP Server](https://github.com/launchdarkly/mcp-server)
+- [LaunchDarkly Segments Docs](https://launchdarkly.com/docs/home/flags/segments)
+
+## License
+
+Apache-2.0

--- a/skills/feature-flags/launchdarkly-segment-create/SKILL.md
+++ b/skills/feature-flags/launchdarkly-segment-create/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: launchdarkly-segment-create
+description: "Create and configure LaunchDarkly segments — reusable audience definitions for flag targeting. Use when the user wants to create a segment, add targeting rules to a segment, add individual contexts to a segment, or wire an existing segment into a feature flag's targeting rules."
+license: Apache-2.0
+compatibility: Requires the remotely hosted LaunchDarkly MCP server
+metadata:
+  author: launchdarkly
+  version: "1.0.0-experimental"
+---
+
+# LaunchDarkly Segment Create & Configure
+
+You're using a skill that will guide you through creating a reusable audience segment in LaunchDarkly. Your job is to explore what segments already exist, choose the right segment type, create the segment, configure its membership through rules or individual targets, and optionally wire it into a feature flag's targeting rules.
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment.
+
+**Required MCP tools:**
+- `list-segments` — check what segments already exist before creating one
+- `create-segment` — create a new rule-based or list-based segment in an environment
+- `get-segment` — verify the segment was created and configured correctly
+
+**Configuration tools (use the one that matches the segment's membership model):**
+- `update-segment-rules` — add or modify attribute-based targeting rules
+- `update-segment-targets` — add or remove individual context keys
+
+**Optional MCP tool (to wire the segment into a flag):**
+- `update-targeting-rules` — add a `segmentMatch` rule to an existing feature flag
+
+## Core Principles
+
+1. **Check before creating.** A segment with the same name or purpose may already exist. Avoid creating duplicates by listing segments first and checking for overlap.
+2. **Segment type drives the configuration path.** Rule-based segments match contexts by attribute (email, plan tier, country). List-based segments target specific keys explicitly. The right type depends on whether the audience is defined by attributes or by identity. See [Segment Types](references/segment-types.md).
+3. **Segments are environment-specific.** A segment created in `staging` does not exist in `production`. If the segment needs to exist in multiple environments, it must be created separately in each.
+4. **The segment key is immutable.** Once created, the key cannot be changed. Choose it carefully — use `kebab-case`, match the project's existing naming convention, and make it descriptive.
+
+## Workflow
+
+### Step 1: Explore Existing Segments
+
+Before creating anything, confirm the environment and check what already exists.
+
+1. **Confirm the environment.** Segments are environment-specific. Always confirm which environment the user is targeting before proceeding. If not specified, ask rather than assume.
+2. **List existing segments.** Use `list-segments` to scan what's there. Look for:
+   - A segment that already covers the same audience (avoid duplicates)
+   - Naming conventions already in use (e.g., `beta-testers`, `internal-qa`, `enterprise-accounts`)
+   - Tags used to organize segments
+
+### Step 2: Assess the Segment Type
+
+Before creating, determine the right segment type based on what the user describes. See [Segment Types](references/segment-types.md) for the full guide.
+
+| Audience description | Segment type | Configuration path |
+|---|---|---|
+| "All users with an enterprise plan" | Rule-based | `update-segment-rules` → `addRule` with attribute clause |
+| "Users whose email ends in @company.com" | Rule-based | `update-segment-rules` → `addRule` with email clause |
+| "These specific user keys: [list]" | List-based | `update-segment-targets` → `addIncludedTargets` |
+| "Internal testers — I have their keys" | List-based | `update-segment-targets` → `addIncludedTargets` |
+| "All enterprise orgs except these two" | Rule-based + exclusions | `update-segment-rules` → `addRule` + `update-segment-targets` → `addExcludedTargets` |
+
+If in doubt, default to rule-based. It's more flexible and easier to maintain as the audience evolves.
+
+### Step 3: Create the Segment
+
+Use `create-segment` with the key, name, environment, and optional tags and description.
+
+Key notes:
+- Segment keys are **immutable** after creation — confirm the key before proceeding.
+- Set `unbounded: false` for standard rule-based and smaller list-based segments (15,000 or fewer individual targets). Only set `unbounded: true` for larger list-based segments requiring a BigSegment store.
+- Suggest tags based on the segment's purpose, team, or related feature area.
+
+After creation, the segment is empty — it has no rules and no individual targets. Proceed to Step 4 to configure membership.
+
+### Step 4: Configure Segment Membership
+
+Choose the path based on the segment type from Step 2.
+
+#### Path A: Rule-based — Use `update-segment-rules`
+
+Add targeting rules that match contexts by attribute. See [Segment Rule Patterns](references/segment-rule-patterns.md) for instruction examples.
+
+Supported instruction kinds:
+- `addRule` — add a new targeting rule with clauses
+- `removeRule` — remove a rule by ID
+- `addClauses` — add additional clauses to an existing rule
+- `removeClauses` — remove clauses from a rule
+- `updateClause` — replace a clause entirely
+- `addValuesToClause` — append values to a clause's values list
+- `removeValuesFromClause` — remove specific values from a clause
+- `reorderRules` — change rule evaluation order
+- `updateRuleDescription` — update a rule's label
+- `updateRuleRolloutAndContextKind` — change percentage and context kind for a percentage-based rule
+
+Rules within a single rule object are ANDed. To match multiple independent conditions with OR logic, add multiple separate rules.
+
+#### Path B: List-based — Use `update-segment-targets`
+
+Add or remove explicit context keys. Supported instruction kinds:
+- `addIncludedTargets` — include context keys (requires `contextKind` and `values`)
+- `removeIncludedTargets` — remove previously included keys
+- `addExcludedTargets` — explicitly exclude context keys from the segment
+- `removeExcludedTargets` — remove previously excluded keys
+
+Always include `contextKind` in the instruction. Defaults to `user` if omitted, but be explicit.
+
+### Step 5: Wire Into a Flag (Optional)
+
+If the user wants to use the segment in a feature flag, add a targeting rule to the flag that matches on the segment.
+
+Use the existing `update-targeting-rules` tool with a `segmentMatch` clause:
+
+```json
+{
+  "kind": "addRule",
+  "clauses": [
+    {
+      "contextKind": "user",
+      "attribute": "segmentMatch",
+      "op": "segmentMatch",
+      "values": ["<segment-key>"]
+    }
+  ],
+  "variationId": "<variation-id>",
+  "description": "Users in <segment-name> segment"
+}
+```
+
+The `variationId` must be the `_id` field from the flag's variations array (retrieved via `get-flag`). Do not use variation index — use the `_id` string.
+
+For non-user context kinds, set `contextKind` to match the segment's context kind.
+
+### Step 6: Verify
+
+After creating and configuring the segment:
+
+1. **Fetch the segment.** Use `get-segment` to confirm:
+   - `rulesCount` matches the number of rules added
+   - `included`/`excluded` counts reflect the target list changes
+   - `tags` and `description` are correct
+2. **If wired to a flag**, use `get-flag` to confirm the rule appears in the flag's targeting rules for the correct environment.
+3. **Summarize for the user.** Describe the resulting state in plain language:
+   - "The `beta-testers` segment in staging now has 1 targeting rule: users whose email ends in `@example.com`. It is wired into the `new-onboarding` flag — beta testers will receive the `true` variation."
+
+## Edge Cases
+
+| Situation | Action |
+|---|---|
+| Segment key already in use | Fetch the existing segment with `get-segment` and show the user what it contains. Ask if they want to configure that segment or create a new one with a different key. |
+| User wants to target multiple context kinds in one rule | Create separate rules for each context kind. A single rule's clauses all apply to the same context kind. |
+| User has a list of >15,000 context keys | Use `unbounded: true` when creating the segment. Warn the user that BigSegment storage must be configured in the environment for the SDK to evaluate it correctly. |
+| Wiring into a flag requires approval | The `update-targeting-rules` call will return `requiresApproval: true` with an `approvalUrl`. Surface this to the user and do not retry the change. |
+| User wants the segment in multiple environments | Segments are environment-specific. The workflow must be run once per environment. The segment key and name can be identical across environments, but each is independent. |
+| User wants to delete a segment | Deleting segments is out of scope for this skill. Use the LaunchDarkly UI or REST API directly. Caution: deleting a segment that is referenced by flag targeting rules will break those rules. |
+
+## What NOT to Do
+
+- Don't create a segment without first checking for duplicates. Step 1 exists for this reason.
+- Don't use the `unbounded: true` flag for small lists — it requires a BigSegment store and adds operational complexity without benefit.
+- Don't pass variation index numbers to `update-targeting-rules` when wiring a segment into a flag. The API requires the variation `_id` string. Use `get-flag` to look it up.
+- Don't add API-level implementation details (segment response shapes, endpoint paths) into conversations with the user. Keep the user experience at the workflow level.
+- Don't run `update-segment-rules` and `update-segment-targets` on the same PATCH request — they are separate tools targeting different instruction categories.
+
+## References
+
+- [Segment Types](references/segment-types.md) — Rule-based vs list-based decision guide, context kind considerations, size limits
+- [Segment Rule Patterns](references/segment-rule-patterns.md) — Semantic patch instruction examples for rules, individual targets, and wiring into flag targeting

--- a/skills/feature-flags/launchdarkly-segment-create/references/segment-rule-patterns.md
+++ b/skills/feature-flags/launchdarkly-segment-create/references/segment-rule-patterns.md
@@ -1,0 +1,285 @@
+# Segment Rule Patterns
+
+Reference for all semantic patch instruction shapes used when configuring segments and wiring them into flags.
+
+All `update-segment-rules` and `update-segment-targets` calls use semantic patch. Include the header:
+```
+Content-Type: application/json; domain-model=launchdarkly.semanticpatch
+```
+
+The request body takes `instructions` (required), `environmentKey` (required), and `comment` (optional).
+
+---
+
+## update-segment-rules Instructions
+
+### addRule
+
+Adds a new targeting rule to the segment. The rule matches contexts that satisfy all its clauses (AND logic between clauses).
+
+```json
+{
+  "kind": "addRule",
+  "clauses": [
+    {
+      "contextKind": "user",
+      "attribute": "email",
+      "op": "endsWith",
+      "negate": false,
+      "values": ["@company.com"]
+    }
+  ],
+  "description": "Company employees"
+}
+```
+
+To include only a percentage of matching contexts:
+```json
+{
+  "kind": "addRule",
+  "clauses": [
+    {
+      "contextKind": "user",
+      "attribute": "plan",
+      "op": "in",
+      "negate": false,
+      "values": ["enterprise"]
+    }
+  ],
+  "weight": 50000,
+  "rolloutContextKind": "user",
+  "description": "50% of enterprise users"
+}
+```
+
+Weight is in thousandths of a percent: 50000 = 50%.
+
+### removeRule
+
+Removes a rule by its ID. The `ruleId` is the `_id` field from the segment's rules array (returned by `get-segment`).
+
+```json
+{
+  "kind": "removeRule",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29"
+}
+```
+
+### addClauses
+
+Adds additional clauses to an existing rule (narrows the rule's match with AND logic).
+
+```json
+{
+  "kind": "addClauses",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "clauses": [
+    {
+      "contextKind": "user",
+      "attribute": "country",
+      "op": "in",
+      "negate": false,
+      "values": ["US", "CA"]
+    }
+  ]
+}
+```
+
+### removeClauses
+
+Removes specific clauses from a rule by clause IDs.
+
+```json
+{
+  "kind": "removeClauses",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "clauseIds": ["10a58772-3121-400f-846b-b8a04e8944ed"]
+}
+```
+
+### updateClause
+
+Replaces a clause entirely.
+
+```json
+{
+  "kind": "updateClause",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "clauseId": "10a58772-3121-400f-846b-b8a04e8944ed",
+  "clause": {
+    "contextKind": "user",
+    "attribute": "plan",
+    "op": "in",
+    "negate": false,
+    "values": ["enterprise", "pro"]
+  }
+}
+```
+
+### addValuesToClause / removeValuesFromClause
+
+Add or remove individual values from a clause without replacing it.
+
+```json
+{
+  "kind": "addValuesToClause",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "clauseId": "10a58772-3121-400f-846b-b8a04e8944ed",
+  "values": ["pro"]
+}
+```
+
+```json
+{
+  "kind": "removeValuesFromClause",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "clauseId": "10a58772-3121-400f-846b-b8a04e8944ed",
+  "values": ["pro"]
+}
+```
+
+### reorderRules
+
+Reorders all rules. The array must include every rule ID in the desired evaluation order.
+
+```json
+{
+  "kind": "reorderRules",
+  "ruleIds": [
+    "rule-id-2",
+    "rule-id-1",
+    "rule-id-3"
+  ]
+}
+```
+
+### updateRuleDescription
+
+Updates the display label for a rule.
+
+```json
+{
+  "kind": "updateRuleDescription",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "description": "Enterprise users in North America"
+}
+```
+
+### updateRuleRolloutAndContextKind
+
+Changes the percentage rollout and context kind for a percentage-based rule.
+
+```json
+{
+  "kind": "updateRuleRolloutAndContextKind",
+  "ruleId": "a902ef4a-2faf-4eaf-88e1-ecc356708a29",
+  "weight": 75000,
+  "contextKind": "user"
+}
+```
+
+---
+
+## update-segment-targets Instructions
+
+### addIncludedTargets / removeIncludedTargets
+
+Add or remove context keys from the segment's included list.
+
+```json
+{
+  "kind": "addIncludedTargets",
+  "contextKind": "user",
+  "values": ["user-key-abc", "user-key-def"]
+}
+```
+
+```json
+{
+  "kind": "removeIncludedTargets",
+  "contextKind": "user",
+  "values": ["user-key-abc"]
+}
+```
+
+### addExcludedTargets / removeExcludedTargets
+
+Add or remove context keys from the segment's excluded list. Excluded targets are never matched by the segment, even if they would satisfy a targeting rule.
+
+```json
+{
+  "kind": "addExcludedTargets",
+  "contextKind": "user",
+  "values": ["known-bad-user-key"]
+}
+```
+
+```json
+{
+  "kind": "removeExcludedTargets",
+  "contextKind": "user",
+  "values": ["known-bad-user-key"]
+}
+```
+
+---
+
+## Clause Operators Reference
+
+| Operator | Meaning | Example values |
+|---|---|---|
+| `in` | Exact match (any value in list) | `["enterprise", "pro"]` |
+| `endsWith` | String ends with | `["@company.com"]` |
+| `startsWith` | String starts with | `["test-"]` |
+| `contains` | String contains substring | `["enterprise"]` |
+| `matches` | Regex match | `[".*@company\\.com"]` |
+| `lessThan` | Numeric less than | `[100]` |
+| `greaterThan` | Numeric greater than | `[0]` |
+| `semVerEqual` | Semantic version equals | `["2.0.0"]` |
+| `semVerGreaterThan` | Semver greater than | `["1.5.0"]` |
+| `semVerLessThan` | Semver less than | `["3.0.0"]` |
+
+Set `"negate": true` on any clause to invert it (e.g., "email does NOT end with @company.com").
+
+---
+
+## Wiring a Segment into a Flag
+
+After creating and configuring the segment, use the existing `update-targeting-rules` tool to add a `segmentMatch` rule to a feature flag.
+
+### Step 1: Get the flag to find the variation _id
+
+Use `get-flag` to retrieve the flag's variations array. Each variation has a `_id` field (a UUID string). Use this `_id` — not the variation index — when calling `update-targeting-rules`.
+
+### Step 2: Add a segmentMatch rule
+
+```json
+{
+  "kind": "addRule",
+  "clauses": [
+    {
+      "contextKind": "user",
+      "attribute": "segmentMatch",
+      "op": "segmentMatch",
+      "values": ["beta-testers"]
+    }
+  ],
+  "variationId": "<variation-_id-from-get-flag>",
+  "description": "Users in the beta-testers segment"
+}
+```
+
+The `values` array contains segment keys. Multiple segment keys use OR logic — the rule matches if the context is in any of the listed segments.
+
+### Step 3: Verify
+
+Use `get-flag` again to confirm the new rule appears in the environment's targeting rules.
+
+### Common patterns
+
+| Goal | segmentMatch clause |
+|---|---|
+| Target a single segment | `"values": ["beta-testers"]` |
+| Target any of multiple segments | `"values": ["beta-testers", "internal-qa"]` |
+| Exclude segment members (negate) | Add `"negate": true` to the clause |
+| Non-user context kind | Set `contextKind` to the correct kind (e.g., `"organization"`) |

--- a/skills/feature-flags/launchdarkly-segment-create/references/segment-types.md
+++ b/skills/feature-flags/launchdarkly-segment-create/references/segment-types.md
@@ -1,0 +1,85 @@
+# Segment Types
+
+Reference for choosing the right segment type and understanding the constraints of each.
+
+## Quick Decision Guide
+
+| Audience definition | Segment type | Size limit |
+|---|---|---|
+| Attribute-based (email, plan, country, etc.) | Rule-based | Up to 15,000 individual overrides |
+| Explicit list of known context keys | Smaller list-based | Up to 15,000 keys |
+| Large list of context keys (>15,000) | Larger list-based (unbounded) | No hard limit; requires BigSegment store |
+| Synced from external tool (Amplitude, Twilio, etc.) | Synced segment | Depends on store |
+
+## Rule-Based Segments
+
+Rule-based segments match contexts by evaluating attribute conditions. They are the most flexible type and support both targeting rules and individual target overrides.
+
+**Best for:**
+- Audiences defined by a business characteristic ("all enterprise accounts", "users in the EU", "email ends in @company.com")
+- Audiences that change naturally as attributes change — no manual maintenance required
+- Audiences that combine multiple conditions
+
+**Constraints:**
+- Up to 5,000 targeting rules per segment
+- Up to 50,000 values across all rule clauses
+- Up to 15,000 individual context targets (included + excluded combined)
+
+**API creation:** `POST /segments` with no special fields (default is rule-based).
+
+## Smaller List-Based Segments
+
+Smaller list-based segments are for when you have a known, explicit list of context keys. They support both individual targets and targeting rules.
+
+**Best for:**
+- Early access programs where you have collected specific user signups
+- Internal employee lists ("our 50 internal testers")
+- Partner or customer lists maintained manually
+
+**Constraints:**
+- Maximum 15,000 individual context targets
+- Same as rule-based for rule support (5,000 rules, 50,000 values)
+
+**API creation:** Same as rule-based — no special fields needed unless exceeding 15,000 targets.
+
+## Larger List-Based Segments (Unbounded / BigSegments)
+
+Larger list-based segments are for audiences exceeding 15,000 entries. LaunchDarkly uses a different implementation ("BigSegments") to maintain performance at scale.
+
+**Best for:**
+- Large customer lists (tens of thousands to millions of entries)
+- Bulk imports via CSV
+
+**Critical requirement:** Server-side SDKs require a persistent store integration (Redis, DynamoDB, etc.) to be configured in each environment before BigSegments work. Without this, the SDK cannot evaluate BigSegment membership and will return the fallback variation.
+
+**API creation:** Set `unbounded: true` in the POST body.
+
+**When to flag this:** If a user mentions "we have 50,000 users" or uploads a CSV, prompt them about BigSegment store configuration before proceeding.
+
+## Context Kinds
+
+All segment types are context-kind-aware. Each rule clause and individual target instruction applies to one context kind.
+
+| Situation | What to do |
+|---|---|
+| Targeting user contexts | Use `contextKind: "user"` (or omit — it defaults to user) |
+| Targeting org/account contexts | Use `contextKind: "organization"` (or whatever the project uses) |
+| Multiple kinds in one segment | Use separate rules per context kind — a single rule applies to one kind |
+
+To find what context kinds a project uses, check existing flag targeting rules or ask the user.
+
+## Segment vs. Flag Targeting Rules
+
+A common question: when should you define rules in a segment vs. directly in a flag's targeting rules?
+
+**Use a segment when:**
+- The same audience applies to multiple flags
+- The audience definition may change (you'd rather update one place)
+- The audience has a reusable business meaning ("enterprise customers", "beta testers")
+
+**Use flag targeting rules directly when:**
+- The rule only applies to this one flag
+- The rule is a one-off, experiment-specific condition
+- You want to keep targeting logic close to the flag
+
+If a user defines an audience that is already being used — or will be used — in multiple flags, suggest creating a segment and wiring it in, rather than duplicating the rule in each flag.


### PR DESCRIPTION
## Summary
Adds two new LaunchDarkly agent skills under `skills/feature-flags/`, each following the repo's SKILL.md + README.md + references convention, with `README.md` and `skills.json` catalog entries updated.

- **`launchdarkly-flag-drift`** (new): detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Resolves the expected value via `get-flag`, locates the default argument at every evaluation/declaration, and updates only the default argument on drift, without removing the flag or changing its evaluation. Includes `references/sdk-default-patterns.md` and `references/pr-template.md`.
- **`launchdarkly-segment-create`**: create and configure reusable audience segments (rule-based or list-based) and optionally wire them into a flag's targeting. Includes `references/segment-types.md` and `references/segment-rule-patterns.md`.

## Validation
- `python3 scripts/validate_skills.py` passes (12 skills valid)
- `python3 scripts/generate_catalog.py --check` reports `skills.json` up to date
- `python3 -m unittest tests.test_validate_skills` passes (7 tests)

## Test plan
- [ ] Confirm both skills load in the agent client from `skills/feature-flags/`
- [ ] `launchdarkly-flag-drift`: trigger on a flag whose fallthrough differs from the in-code default; verify only the default argument changes
- [ ] `launchdarkly-segment-create`: create a rule-based and a list-based segment, then wire one into a flag

Made with [Cursor](https://cursor.com)