### PR TITLE
feat: add launchdarkly-flag-drift skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `feature-flags/launchdarkly-flag-create` | Create new feature flags in a way that fits existing codebase patterns |
 | `feature-flags/launchdarkly-flag-targeting` | Control targeting, rollouts, rules, and cross-environment config |
 | `feature-flags/launchdarkly-flag-cleanup` | Safely remove flags from code using LaunchDarkly as the source of truth |
+| `feature-flags/launchdarkly-flag-drift` | Detect and reconcile drift between an in-code SDK fallback default and the LaunchDarkly default rule |
 | `feature-flags/launchdarkly-guarded-rollout` | Configure guarded rollouts with progressive traffic, metric monitoring, and rollback |
 | `feature-flags/flag-release` | Record a flag's automated release for a PR, honoring release intent and per-environment release policies |
 | `feature-flags/flag-and-release-change` | End-to-end PR orchestrator: decide → create + wire the flag → record its release (composes the skills above) |

--- a/evals/launchdarkly-flag-drift/promptfooconfig.yaml
+++ b/evals/launchdarkly-flag-drift/promptfooconfig.yaml
@@ -12,6 +12,13 @@
 # fallthrough.variation is 1, and variations[1].value is `false`. So the
 # "expected default" the agent should resolve for every flag here is `false`.
 # Drift cases seed an in-code default of `true`; the no-drift case seeds `false`.
+#
+# Cross-environment note: the mock returns the OPPOSITE default
+# (fallthrough.variation 0 -> `true`) for any environment whose key matches
+# /federal/i. So a build serving both `production` (-> `false`) and `federal`
+# (-> `true`) sees divergent fallthroughs, and no single in-code default can
+# match both. Test 4 exercises this: the skill must check every critical
+# environment and surface the divergence instead of blindly reconciling.
 description: "End-to-end evaluation of the launchdarkly-flag-drift skill"
 
 prompts:
@@ -209,5 +216,82 @@ tests:
           3. The agent reconciled the registry default from `true` to `false`, and did not
              remove the flag or change unrelated code.
           Deduct 0.34 for each criterion missed.
+        metric: workflow_quality
+        weight: 3
+
+  # ------------------------------------------------------------------
+  # Test 4: Cross-environment divergence — one build, two critical
+  # environments that disagree on the fallthrough.
+  # The build serves both `production` (fallthrough -> false) and `federal`
+  # (fallthrough -> true, via the mock's /federal/i hook). A single in-code
+  # default cannot match both, so the skill must check each critical
+  # environment and surface the divergence rather than silently editing.
+  # ------------------------------------------------------------------
+  - description: "Divergence: checks each critical env and surfaces cross-env disagreement"
+    vars:
+      max_turns: 20
+      user_request: >
+        Check whether the hardcoded SDK fallback default for the `billing-v2` flag has
+        drifted from LaunchDarkly, and fix it if it has. Project key is "payments".
+        Heads up: this same service is deployed to BOTH our `production` and `federal`
+        LaunchDarkly environments, so the fallback has to be right for both.
+      codebase_context: >
+        Node.js service using the LaunchDarkly server-side Node SDK. The same build is
+        released to both the `production` and `federal` environments. The flag is
+        evaluated once in src/billing.js:
+          const useV2 = await client.boolVariation('billing-v2', context, false);
+          if (useV2) { return chargeV2(order); } else { return chargeV1(order); }
+      mock_files:
+        "package.json": '{"dependencies":{"@launchdarkly/node-server-sdk":"^9.0.0"}}'
+        "src/billing.js": "const useV2 = await client.boolVariation('billing-v2', context, false);\nif (useV2) {\n  return chargeV2(order);\n} else {\n  return chargeV1(order);\n}\n"
+    assert:
+      - type: javascript
+        value: |
+          const traj = output.trajectory || [];
+          const envs = new Set(
+            traj
+              .filter((t) => t.tool === 'get-flag')
+              .map((t) => (t.arguments || {}).environmentKey || (t.arguments || {}).env)
+              .filter(Boolean)
+          );
+          const pass = envs.size >= 2;
+          return { pass, score: pass ? 1 : 0, reason: 'get-flag environments: ' + [...envs].join(', ') };
+        metric: checks_each_critical_environment
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const forbidden = ['delete-flag','archive-flag','toggle-flag','update-rollout','update-targeting-rules','update-individual-targets','update-flag-settings','update-prerequisites','copy-flag-config','create-flag','create-feature-flag'];
+          const called = forbidden.filter((f) => tools.includes(f));
+          const pass = called.length === 0;
+          return { pass, score: pass ? 1 : 0, reason: pass ? 'No LD mutations' : 'Called: ' + called.join(', ') };
+        metric: no_ld_mutations
+        weight: 2
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const explored = tools.some((t) => ['Read','Grep','Glob'].includes(t));
+          return { pass: true, score: explored ? 1 : 0.5, reason: 'Explored: ' + explored };
+        metric: explores_code
+        weight: 1
+
+      - type: llm-rubric
+        value: |
+          The same build serves two critical LaunchDarkly environments that DISAGREE on the
+          default rule: `production` resolves the fallthrough to `false`, while `federal`
+          resolves it to `true`. The in-code fallback default is `false`.
+          Score 1.0 if ALL of the following hold:
+          1. The agent resolved the fallthrough from LaunchDarkly (get-flag) in BOTH the
+             `production` and `federal` environments, rather than checking only one.
+          2. The agent identified the cross-environment divergence (production `false` vs
+             federal `true`) and recognized that a single in-code default cannot satisfy both.
+          3. The agent did NOT silently reconcile the code to one environment's value; instead
+             it surfaced the divergence and asked which environment is authoritative (or
+             recommended resolving the divergence in LaunchDarkly first).
+          4. The agent did NOT remove, archive, toggle, or otherwise mutate the flag in
+             LaunchDarkly.
+          Deduct 0.25 for each criterion missed.
         metric: workflow_quality
         weight: 3

--- a/evals/launchdarkly-flag-drift/promptfooconfig.yaml
+++ b/evals/launchdarkly-flag-drift/promptfooconfig.yaml
@@ -1,0 +1,213 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+#
+# Run with shared defaults:
+#   promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-drift/promptfooconfig.yaml
+#
+# The launchdarkly-flag-drift skill checks whether a flag's in-code SDK fallback
+# default has drifted from its LaunchDarkly default rule (fallthrough), and, only
+# when it has, reconciles the in-code default — without removing the flag or
+# changing its evaluation logic.
+#
+# Mock note: the shared get-flag mock returns an environment whose
+# fallthrough.variation is 1, and variations[1].value is `false`. So the
+# "expected default" the agent should resolve for every flag here is `false`.
+# Drift cases seed an in-code default of `true`; the no-drift case seeds `false`.
+description: "End-to-end evaluation of the launchdarkly-flag-drift skill"
+
+prompts:
+  - file://../../skills/feature-flags/launchdarkly-flag-drift/SKILL.md
+
+providers:
+  - id: file://../providers/claude-skill-agent-sdk.js
+    label: claude-skill-agent-sdk
+    config:
+      skill_slug: launchdarkly-flag-drift
+      allow_builtins: true
+
+tests:
+  # ------------------------------------------------------------------
+  # Test 1: Drift detected — direct SDK call, reconcile the default only
+  # In-code default is `true`; the fallthrough resolves to `false`.
+  # ------------------------------------------------------------------
+  - description: "Drift: reconciles in-code default to match the fallthrough"
+    vars:
+      max_turns: 20
+      user_request: >
+        We changed the default rule for the `billing-v2` flag in production.
+        Check whether the hardcoded SDK fallback default in our code has drifted
+        from LaunchDarkly, and fix it if it has. Project key is "payments".
+      codebase_context: >
+        Node.js service using the LaunchDarkly server-side Node SDK.
+        The flag is evaluated once in src/billing.js:
+          const useV2 = await client.boolVariation('billing-v2', context, true);
+          if (useV2) { return chargeV2(order); } else { return chargeV1(order); }
+      mock_files:
+        "package.json": '{"dependencies":{"@launchdarkly/node-server-sdk":"^9.0.0"}}'
+        "src/billing.js": "const useV2 = await client.boolVariation('billing-v2', context, true);\nif (useV2) {\n  return chargeV2(order);\n} else {\n  return chargeV1(order);\n}\n"
+    assert:
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const pass = tools.includes('get-flag');
+          return { pass, score: pass ? 1 : 0, reason: 'Tools: ' + tools.join(' -> ') };
+        metric: resolves_fallthrough_via_get_flag
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const forbidden = ['delete-flag','archive-flag','toggle-flag','update-rollout','update-targeting-rules','update-individual-targets','update-flag-settings','update-prerequisites','copy-flag-config','create-flag','create-feature-flag'];
+          const called = forbidden.filter(f => tools.includes(f));
+          const pass = called.length === 0;
+          return { pass, score: pass ? 1 : 0, reason: pass ? 'No LD mutations' : 'Called: ' + called.join(', ') };
+        metric: no_ld_mutations
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const edited = tools.some(t => ['Edit','Write','MultiEdit'].includes(t));
+          return { pass: edited, score: edited ? 1 : 0.4, reason: edited ? 'Edited code' : 'No code edit recorded' };
+        metric: reconciles_in_code_default
+        weight: 2
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const explored = tools.some(t => ['Read','Grep','Glob'].includes(t));
+          return { pass: true, score: explored ? 1 : 0.5, reason: 'Explored: ' + explored };
+        metric: explores_code
+        weight: 1
+
+      - type: llm-rubric
+        value: |
+          The user asked to reconcile drift for the `billing-v2` flag. The LaunchDarkly
+          default rule (fallthrough) resolves to `false`, but the in-code fallback default
+          was `true`.
+          Score 1.0 if ALL of the following hold:
+          1. The agent resolved the flag's fallthrough value from LaunchDarkly (get-flag)
+             rather than guessing.
+          2. The agent identified drift: in-code default `true` vs fallthrough `false`.
+          3. The agent changed ONLY the fallback default argument to `false`
+             (e.g. boolVariation('billing-v2', context, false)).
+          4. The agent left the evaluation/branching logic intact and did NOT remove the
+             flag or archive/delete/toggle it.
+          Deduct 0.25 for each criterion missed.
+        metric: workflow_quality
+        weight: 3
+
+  # ------------------------------------------------------------------
+  # Test 2: No drift — in-code default already matches; no edit, no PR
+  # In-code default is `false`, matching the fallthrough.
+  # ------------------------------------------------------------------
+  - description: "No drift: reports no change and makes no code edits"
+    vars:
+      max_turns: 15
+      user_request: >
+        Does the hardcoded SDK default for the `billing-v2` flag still match its
+        default rule in production? Project key is "payments".
+      codebase_context: >
+        Node.js service using the LaunchDarkly server-side Node SDK.
+        Evaluated in src/billing.js:
+          const useV2 = await client.boolVariation('billing-v2', context, false);
+      mock_files:
+        "package.json": '{"dependencies":{"@launchdarkly/node-server-sdk":"^9.0.0"}}'
+        "src/billing.js": "const useV2 = await client.boolVariation('billing-v2', context, false);\nif (useV2) {\n  return chargeV2(order);\n} else {\n  return chargeV1(order);\n}\n"
+    assert:
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const pass = tools.includes('get-flag');
+          return { pass, score: pass ? 1 : 0, reason: 'Tools: ' + tools.join(' -> ') };
+        metric: resolves_fallthrough_via_get_flag
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const edits = tools.filter(t => ['Edit','Write','MultiEdit'].includes(t));
+          const pass = edits.length === 0;
+          return { pass, score: pass ? 1 : 0, reason: pass ? 'No code edits' : 'Edited: ' + edits.join(', ') };
+        metric: no_code_edits_when_no_drift
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const forbidden = ['delete-flag','archive-flag','toggle-flag','update-rollout','update-targeting-rules','create-flag'];
+          const called = forbidden.filter(f => tools.includes(f));
+          const pass = called.length === 0;
+          return { pass, score: pass ? 1 : 0, reason: pass ? 'No LD mutations' : 'Called: ' + called.join(', ') };
+        metric: no_ld_mutations
+        weight: 2
+
+      - type: llm-rubric
+        value: |
+          The in-code fallback default (`false`) already matches the flag's fallthrough
+          value (`false`).
+          Score 1.0 if ALL of the following hold:
+          1. The agent resolved the fallthrough value from LaunchDarkly (get-flag).
+          2. The agent concluded there is NO drift (drift_detected: false).
+          3. The agent made no code changes and did NOT open a pull request.
+          Deduct 0.34 for each criterion missed.
+        metric: workflow_quality
+        weight: 3
+
+  # ------------------------------------------------------------------
+  # Test 3: Drift in a wrapper/registry declaration (exploration)
+  # The default is declared once in a defaults registry, not at the call site.
+  # ------------------------------------------------------------------
+  - description: "Wrapper default: finds and reconciles a registry-declared default"
+    vars:
+      max_turns: 20
+      user_request: >
+        The default rule for `checkout-redirect` changed in production. Make sure
+        our in-code default matches. Project key is "web".
+      codebase_context: >
+        TypeScript app. Flag defaults are declared once in a registry, not at the
+        call site. src/flags/defaults.ts holds a map of flag key to fallback value,
+        and components read the flag by key through a wrapper.
+      mock_files:
+        "package.json": '{"dependencies":{"@launchdarkly/js-client-sdk":"^1.0.0"}}'
+        "src/flags/defaults.ts": "export const FLAG_DEFAULTS = {\n  'checkout-redirect': true,\n  'promo-banner': false,\n};\n"
+        "src/checkout.ts": "import { FLAG_DEFAULTS } from './flags/defaults';\nconst redirect = ff.getBool('checkout-redirect', FLAG_DEFAULTS['checkout-redirect']);\n"
+    assert:
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const pass = tools.includes('get-flag');
+          return { pass, score: pass ? 1 : 0, reason: 'Tools: ' + tools.join(' -> ') };
+        metric: resolves_fallthrough_via_get_flag
+        weight: 3
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const explored = tools.some(t => ['Read','Grep','Glob'].includes(t));
+          return { pass: explored, score: explored ? 1 : 0.5, reason: 'Explored: ' + explored };
+        metric: explores_code
+        weight: 2
+
+      - type: javascript
+        value: |
+          const tools = output.tools_called || [];
+          const forbidden = ['delete-flag','archive-flag','toggle-flag','update-rollout','update-targeting-rules','create-flag'];
+          const called = forbidden.filter(f => tools.includes(f));
+          const pass = called.length === 0;
+          return { pass, score: pass ? 1 : 0, reason: pass ? 'No LD mutations' : 'Called: ' + called.join(', ') };
+        metric: no_ld_mutations
+        weight: 2
+
+      - type: llm-rubric
+        value: |
+          The in-code default for `checkout-redirect` is declared in the registry
+          src/flags/defaults.ts as `true`, but the flag's fallthrough resolves to `false`.
+          Score 1.0 if ALL of the following hold:
+          1. The agent resolved the fallthrough value from LaunchDarkly (get-flag).
+          2. The agent located the default in the registry declaration (src/flags/defaults.ts)
+             rather than only inspecting the call site.
+          3. The agent reconciled the registry default from `true` to `false`, and did not
+             remove the flag or change unrelated code.
+          Deduct 0.34 for each criterion missed.
+        metric: workflow_quality
+        weight: 3

--- a/evals/package.json
+++ b/evals/package.json
@@ -15,6 +15,8 @@
     "eval:flag-create:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-create/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
     "eval:flag-command": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-command/promptfooconfig.yaml --env-file .env --no-cache -o launchdarkly-flag-command/results.json",
     "eval:flag-command:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-command/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
+    "eval:flag-drift": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-drift/promptfooconfig.yaml --env-file .env --no-cache -o launchdarkly-flag-drift/results.json",
+    "eval:flag-drift:single": "promptfoo eval -c shared/defaults.yaml -c launchdarkly-flag-drift/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
     "eval:should-flag-change": "promptfoo eval -c shared/defaults.yaml -c should-flag-change/promptfooconfig.yaml --env-file .env --no-cache -o should-flag-change/results.json",
     "eval:should-flag-change:single": "promptfoo eval -c shared/defaults.yaml -c should-flag-change/promptfooconfig.yaml --env-file .env --no-cache --filter-first-n 1",
     "eval:flag-release": "promptfoo eval -c shared/defaults.yaml -c flag-release/promptfooconfig.yaml --env-file .env --no-cache -o flag-release/results.json",

--- a/evals/providers/_mock.js
+++ b/evals/providers/_mock.js
@@ -195,6 +195,24 @@ function renderMockResponse(template, input, toolName, state) {
   if (toolName === "get-flag" || toolName === "get-feature-flag") {
     const key = input.flagKey || input.key;
     if (key && state.flags[key]) return state.flags[key];
+
+    // Cross-environment divergence hook: a `federal`-style environment serves
+    // the opposite default (variation 0 / `true`) from every other environment
+    // (which resolve to variation 1 / `false` via the static template). This
+    // lets the flag-drift eval exercise the case where a single in-code default
+    // cannot match every critical environment. No other suite queries a
+    // `federal` environment, so their behavior is unchanged.
+    const env = input.environmentKey || input.env;
+    if (typeof env === "string" && /federal/i.test(env)) {
+      const rendered = walk(template, replacements);
+      if (rendered && rendered.environment) {
+        rendered.environment = {
+          ...rendered.environment,
+          fallthrough: { variation: 0 },
+        };
+      }
+      return rendered;
+    }
   }
 
   // ---------- stateful writes ----------

--- a/evals/scripts/_manifest.js
+++ b/evals/scripts/_manifest.js
@@ -50,6 +50,12 @@ const SUITES = [
     readme: "skills/feature-flags/launchdarkly-flag-command/README.md",
   },
   {
+    suite: "launchdarkly-flag-drift",
+    skillKey: "feature-flags/launchdarkly-flag-drift",
+    skillDir: "skills/feature-flags/launchdarkly-flag-drift",
+    readme: "skills/feature-flags/launchdarkly-flag-drift/README.md",
+  },
+  {
     suite: "should-flag-change",
     skillKey: "feature-flags/should-flag-change",
     skillDir: "skills/feature-flags/should-flag-change",

--- a/evals/tests/mock.test.js
+++ b/evals/tests/mock.test.js
@@ -380,6 +380,24 @@ test("get-flag falls back to template substitution for unknown flag", () => {
   assert.equal(result.key, "unknown-flag");
 });
 
+test("get-flag resolves the template fallthrough (variation 1) for a non-federal env", () => {
+  const state = createMockState();
+  const result = renderMockResponse(TEMPLATES["get-flag"], {
+    flagKey: "billing-v2",
+    environmentKey: "production",
+  }, "get-flag", state);
+  assert.equal(result.environment.fallthrough.variation, 1); // -> false
+});
+
+test("get-flag returns the opposite fallthrough (variation 0) for a federal env", () => {
+  const state = createMockState();
+  const result = renderMockResponse(TEMPLATES["get-flag"], {
+    flagKey: "billing-v2",
+    environmentKey: "federal",
+  }, "get-flag", state);
+  assert.equal(result.environment.fallthrough.variation, 0); // -> true (diverges)
+});
+
 // ---------------------------------------------------------------------------
 // stateless template rendering ({{placeholder}} substitution)
 // ---------------------------------------------------------------------------

--- a/skills.json
+++ b/skills.json
@@ -320,6 +320,25 @@
       ]
     },
     {
+      "name": "launchdarkly-flag-drift",
+      "description": "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation.",
+      "path": "skills/feature-flags/launchdarkly-flag-drift",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feature-management",
+        "flag-drift",
+        "default-drift",
+        "sdk",
+        "reconciliation",
+        "devops",
+        "mcp"
+      ]
+    },
+    {
       "name": "launchdarkly-flag-targeting",
       "description": "Control LaunchDarkly feature flag targeting including toggling flags on/off, percentage rollouts, targeting rules, individual targets, and copying flag configurations between environments. Use when the user wants to change who sees a flag, roll out to a percentage, add targeting rules, or promote config between environments.",
       "path": "skills/feature-flags/launchdarkly-flag-targeting",

--- a/skills/feature-flags/launchdarkly-flag-drift/README.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/README.md
@@ -5,7 +5,8 @@ An Agent Skill for detecting and reconciling drift between a feature flag's in-c
 ## Overview
 
 This skill teaches agents how to:
-- Resolve a flag's current default rule (fallthrough) value from LaunchDarkly
+- Resolve a flag's current default rule (fallthrough) value from LaunchDarkly in every critical environment the build serves
+- Detect cross-environment divergence (e.g. EU vs. Federal serving different defaults), where a single in-code default cannot match every environment
 - Locate the fallback default argument in every SDK evaluation and declaration in code
 - Compare the two and detect drift
 - Reconcile only the in-code default when it has drifted, without removing the flag or changing its evaluation

--- a/skills/feature-flags/launchdarkly-flag-drift/README.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/README.md
@@ -1,0 +1,66 @@
+# LaunchDarkly Flag Drift Skill
+
+An Agent Skill for detecting and reconciling drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule, keeping outage behavior consistent with production.
+
+## Overview
+
+This skill teaches agents how to:
+- Resolve a flag's current default rule (fallthrough) value from LaunchDarkly
+- Locate the fallback default argument in every SDK evaluation and declaration in code
+- Compare the two and detect drift
+- Reconcile only the in-code default when it has drifted, without removing the flag or changing its evaluation
+- Open a well-scoped pull request that documents the change
+
+## Installation (Local)
+
+For now, install by placing this skill directory where your agent client loads skills.
+
+Examples:
+
+- **Generic**: copy `skills/feature-flags/launchdarkly-flag-drift/` into your client's skills path
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment. The remote server provides higher-level, agent-optimized tools that orchestrate multiple API calls and return pruned, actionable responses.
+
+Refer to your LaunchDarkly account settings for instructions on connecting to the remotely hosted MCP server.
+
+## Usage
+
+Once installed, the skill activates automatically when you ask about flag default drift:
+
+```
+The default rule for `new-checkout-flow` changed in production. Check if the code default drifted
+```
+
+```
+Does the hardcoded default for `dark-mode` still match LaunchDarkly?
+```
+
+```
+Open a PR to sync the in-code default for `enable-new-billing` with its fallthrough
+```
+
+## Structure
+
+```
+launchdarkly-flag-drift/
+├── SKILL.md
+├── marketplace.json
+├── README.md
+└── references/
+    ├── sdk-default-patterns.md
+    └── pr-template.md
+```
+
+## Related
+
+- [LaunchDarkly Flag Cleanup](../launchdarkly-flag-cleanup/SKILL.md): Remove a flag from code entirely
+- [LaunchDarkly Flag Targeting](../launchdarkly-flag-targeting/SKILL.md): Change the default rule in LaunchDarkly instead of the code
+- [LaunchDarkly MCP Server](https://github.com/launchdarkly/mcp-server)
+- [LaunchDarkly Docs](https://docs.launchdarkly.com)
+- [Agent Skills Specification](https://agentskills.io/specification)
+
+## License
+
+Apache-2.0

--- a/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
@@ -17,32 +17,55 @@ You're using a skill that will guide you through checking whether a feature flag
 This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment.
 
 **Required MCP tools:**
-- `get-flag`: fetch the flag's configuration in a specific environment (fallthrough, variations, offVariation)
+- `get-flag`: fetch the flag's configuration **in a specific environment** (fallthrough, variations, offVariation). Fallthrough is environment-specific, so call this **once per critical environment**.
 
 **Optional MCP tools:**
 - `list-flags`: find the flag key if the user only described the flag by name
+- `get-environments`: enumerate the project's environments to determine which are critical
+- `get-flag-status-across-envs`: quick snapshot of a flag's state across environments (a fast way to spot cross-environment differences before pulling each `get-flag`)
 
 ## Core Concept: The SDK Fallback Default Is Not the Off Variation
 
 Every SDK evaluation call takes a **fallback default**: the value returned when LaunchDarkly is unreachable, the client is uninitialized, or the flag is unavailable. This is a code-side safety value, distinct from the flag's `offVariation` (served when the flag is toggled off) and from its `fallthrough` (the default rule served when no targeting rule matches).
 
-This skill treats one specific invariant as "correct": **the in-code fallback default should match the current default rule (fallthrough) value** for the source environment. When they diverge, that's *drift*. Reconciling it keeps the value returned during an outage consistent with what most users would otherwise receive.
+This skill treats one specific invariant as "correct": **the in-code fallback default should match the current default rule (fallthrough) value**. When they diverge, that's *drift*. Reconciling it keeps the value returned during an outage consistent with what most users would otherwise receive.
+
+## Core Concept: One In-Code Default, Many Environments
+
+The in-code fallback default is a **single value compiled into the deployed code**. The flag's fallthrough, however, is configured **per environment** and can differ between them (e.g. `production`, `eu-production`, and `federal` may each serve a different default rule). So the fallthrough must be resolved in **every critical environment the code runs against**, not just one.
+
+- When the critical environments **agree** on the fallthrough, that shared value is the expected default. Reconcile as normal.
+- When they **disagree** (e.g. EU serves `true` but Federal serves `false`), a single in-code default *cannot* match all of them. That divergence is itself a finding: surface it and confirm which environment is authoritative for this build rather than silently reconciling to one. See Edge Cases.
+
+Checking only one environment is the most common way this skill produces a wrong or misleading result, so always establish the full set of critical environments first.
 
 Some teams intentionally keep the fallback as a conservative/off value instead. Treat a mismatch as a finding to surface, not always an automatic edit. See Edge Cases.
 
 ## Workflow
 
-### Step 1: Identify the Flag and Source Environment
+### Step 1: Identify the Flag and the Critical Environments
 
 1. **Get the flag key.** If the user described the flag by name, use `list-flags` to resolve the key. Confirm before proceeding.
-2. **Confirm the environment.** The fallthrough is environment-specific; a default rule that changed in `production` may differ in `staging`. Always confirm which environment is the source of truth. If not specified, ask rather than assume.
+2. **Establish the critical environments.** The fallthrough is environment-specific, and the same in-code default has to stand in for every environment the deployed code serves. Determine that full set before comparing:
+   - If one build serves **multiple** production-grade environments (e.g. `production`, `eu-production`, `federal`), **all** of them are critical.
+   - If the build is scoped to **one** environment (a region- or tenant-specific deployment, e.g. a Federal-only build), that single environment is the only critical one.
+   - Look for signals in the repo (deploy config, environment names in CI, SDK key wiring) and confirm with the user. Use `get-environments` to enumerate what exists if the set is unclear. Do not assume a single `production`.
 
 ### Step 2: Determine the Expected Default from LaunchDarkly
 
-Use `get-flag` for the flag key and source environment. Read:
-- `fallthrough`: the default rule. If it points to a single `variation` (an index), that's your expected value. If it's a percentage `rollout`, there is **no single default value**, so stop and handle as an edge case.
-- `variations`: map `fallthrough.variation` (the index) to `variations[index].value`. This resolved value is the **expected default**.
+Call `get-flag` **once per critical environment**. For each environment, read:
+- `fallthrough`: the default rule. If it points to a single `variation` (an index), that's the resolved value. If it's a percentage `rollout`, there is **no single default value**, so stop and handle as an edge case.
+- `variations`: map `fallthrough.variation` (the index) to `variations[index].value`. This resolved value is that environment's expected default.
 - `offVariation` and flag type: useful context for the comparison and for spotting type mismatches.
+
+Then reconcile across environments:
+
+| Across critical environments | Expected default |
+|------------------------------|------------------|
+| All resolve to the **same** value | That shared value is the expected default. Continue to Step 3. |
+| They resolve to **different** values | **Cross-environment divergence.** One in-code default cannot satisfy all of them. Do **not** auto-pick. Report the per-environment values and confirm which environment is authoritative for this build (or that the divergence should be resolved in LaunchDarkly first). See Edge Cases. |
+
+(`get-flag-status-across-envs` can give a fast heads-up on whether environments differ, but always resolve the actual fallthrough value with `get-flag` before editing.)
 
 Never guess the fallthrough value. Always resolve it from `get-flag`.
 
@@ -61,7 +84,8 @@ Normalize both sides before comparing (see Edge Cases for JSON/number/type notes
 
 | Result | Action |
 |--------|--------|
-| In-code default **matches** the expected default | **No drift.** Report `drift_detected: false` and stop. Do not open a PR. |
+| Critical environments **disagree** on the fallthrough | **Stop — no single expected default exists.** Report the per-environment values and confirm which environment is authoritative for this build before editing (or resolve the divergence in LaunchDarkly first). Do not auto-reconcile to one environment. |
+| In-code default **matches** the expected default (in every critical environment) | **No drift.** Report `drift_detected: false` and stop. Do not open a PR. |
 | In-code default **differs** | **Drift detected.** Proceed to Step 5 to reconcile. |
 | Multiple evaluations with **different** in-code defaults | Drift. Reconcile all of them to the expected value and note the prior inconsistency. |
 
@@ -93,7 +117,7 @@ Run the project's configured checks scoped to the changed files. Discover them f
 
 ### Step 7: Open the Pull Request
 
-Only after validation passes. Use [references/pr-template.md](references/pr-template.md). The description must state: the flag key, the source environment, the old vs new in-code default, and that **only** the SDK fallback default changed (the flag and its evaluation are preserved).
+Only after validation passes. Use [references/pr-template.md](references/pr-template.md). The description must state: the flag key, the critical environments checked and their resolved fallthrough values, the old vs new in-code default, and that **only** the SDK fallback default changed (the flag and its evaluation are preserved).
 
 - Follow the repository's contribution conventions (branch naming, commit style). Check `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md` first.
 - A clear default: branch `fix/flag-default-drift-<flag-key>`, commit `fix: sync in-code default for <flag-key> to match fallthrough`.
@@ -103,14 +127,16 @@ Only after validation passes. Use [references/pr-template.md](references/pr-temp
 Produce a concise summary with these fields:
 
 ```
-flag_key:            <key>
-drift_detected:      true | false
-old_default:         <in-code value before, or n/a>
-new_default:         <expected value / value written, or n/a>
-files_modified:      [<paths>]
-pr_url:              <url or null>
-requires_generation: true | false
-notes:               <anything the reviewer should know>
+flag_key:              <key>
+environments_checked:  [<env>: <resolved fallthrough value>, ...]
+environments_diverge:  true | false
+drift_detected:        true | false
+old_default:           <in-code value before, or n/a>
+new_default:           <expected value / value written, or n/a>
+files_modified:        [<paths>]
+pr_url:                <url or null>
+requires_generation:   true | false
+notes:                 <anything the reviewer should know, incl. any cross-environment divergence>
 ```
 
 ## Edge Cases
@@ -124,13 +150,16 @@ notes:               <anything the reviewer should know>
 | **JSON / object / float** defaults | Compare by normalized value, not string form (`{"a":1}` == `{ "a": 1 }`, `0` == `0.0`). |
 | Flag **not found** or wrong environment | Inform the user; check for typos in the key and confirm the environment. |
 | **Dynamic flag keys** (`flag-${id}`) | Automated detection may be incomplete; flag for manual review. |
-| Environments **disagree** on the fallthrough | The fallback can only match one. Confirm which environment is the source of truth. |
+| Critical environments **disagree** on the fallthrough (e.g. `eu-production` serves `true`, `federal` serves `false`) | A single in-code default cannot match all of them. If the build is scoped to **one** environment, reconcile to that environment's value and note the others. If the build serves **several** divergent environments, do not silently pick one — surface every per-environment value and confirm which environment is authoritative, or recommend resolving the divergence in LaunchDarkly first. |
+| Build targets a **single environment** (region- or tenant-specific deployment) | Treat that environment as the sole critical one; other environments' fallthroughs are not relevant to this build's default. |
 | Flag spans **multiple repositories** | This skill operates on the current repo. Note other repos that also reference the key so they can be reconciled separately. |
 
 ## What NOT to Do
 
 - Don't remove the flag or its evaluation; this skill only touches the default argument.
 - Don't change evaluation logic, branching, or off-path behavior beyond the fallback default.
+- Don't check only one environment; resolve the fallthrough in every critical environment the build serves.
+- Don't reconcile to one environment's fallthrough when critical environments disagree — a single default can't satisfy divergent environments, so surface the divergence and confirm the authoritative environment first.
 - Don't hand-edit generated files; regenerate from the source of truth.
 - Don't open a PR when there is no drift.
 - Don't guess the fallthrough value; resolve it from `get-flag`.

--- a/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: launchdarkly-flag-drift
+description: "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation."
+license: Apache-2.0
+compatibility: Requires the remotely hosted LaunchDarkly MCP server
+metadata:
+  author: launchdarkly
+  version: "0.1.0"
+---
+
+# LaunchDarkly Flag Drift Detection
+
+You're using a skill that will guide you through checking whether a feature flag's **in-code SDK fallback default** has drifted from its **LaunchDarkly default rule (fallthrough)**, and reconciling the code if it has. Your job is to determine the flag's current default rule value from LaunchDarkly, locate the default argument passed to every SDK evaluation in code, compare them, and, only when they differ, update the in-code default so it matches. You never remove the flag or change its evaluation logic.
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment.
+
+**Required MCP tools:**
+- `get-flag`: fetch the flag's configuration in a specific environment (fallthrough, variations, offVariation)
+
+**Optional MCP tools:**
+- `list-flags`: find the flag key if the user only described the flag by name
+
+## Core Concept: The SDK Fallback Default Is Not the Off Variation
+
+Every SDK evaluation call takes a **fallback default**: the value returned when LaunchDarkly is unreachable, the client is uninitialized, or the flag is unavailable. This is a code-side safety value, distinct from the flag's `offVariation` (served when the flag is toggled off) and from its `fallthrough` (the default rule served when no targeting rule matches).
+
+This skill treats one specific invariant as "correct": **the in-code fallback default should match the current default rule (fallthrough) value** for the source environment. When they diverge, that's *drift*. Reconciling it keeps the value returned during an outage consistent with what most users would otherwise receive.
+
+Some teams intentionally keep the fallback as a conservative/off value instead. Treat a mismatch as a finding to surface, not always an automatic edit. See Edge Cases.
+
+## Workflow
+
+### Step 1: Identify the Flag and Source Environment
+
+1. **Get the flag key.** If the user described the flag by name, use `list-flags` to resolve the key. Confirm before proceeding.
+2. **Confirm the environment.** The fallthrough is environment-specific; a default rule that changed in `production` may differ in `staging`. Always confirm which environment is the source of truth. If not specified, ask rather than assume.
+
+### Step 2: Determine the Expected Default from LaunchDarkly
+
+Use `get-flag` for the flag key and source environment. Read:
+- `fallthrough`: the default rule. If it points to a single `variation` (an index), that's your expected value. If it's a percentage `rollout`, there is **no single default value**, so stop and handle as an edge case.
+- `variations`: map `fallthrough.variation` (the index) to `variations[index].value`. This resolved value is the **expected default**.
+- `offVariation` and flag type: useful context for the comparison and for spotting type mismatches.
+
+Never guess the fallthrough value. Always resolve it from `get-flag`.
+
+### Step 3: Locate Every In-Code Default
+
+Find every place the flag is evaluated in code and, critically, the **default/fallback argument** passed to the SDK call. Search for the flag key across the codebase, then identify the default in each hit.
+
+- The default is typically the **last positional argument** to `variation(...)` / `*Variation(...)` calls (e.g. `boolVariation("<key>", context, <default>)`).
+- Teams often wrap the SDK. Check wrapper/registry/config layers that declare a default once per flag, annotation- or struct-tag-based defaults, and generated default files.
+
+See [SDK Default Patterns](references/sdk-default-patterns.md) for the full set of patterns by language and abstraction, and how to distinguish the default argument from the context argument.
+
+### Step 4: Compare and Decide
+
+Normalize both sides before comparing (see Edge Cases for JSON/number/type notes), then:
+
+| Result | Action |
+|--------|--------|
+| In-code default **matches** the expected default | **No drift.** Report `drift_detected: false` and stop. Do not open a PR. |
+| In-code default **differs** | **Drift detected.** Proceed to Step 5 to reconcile. |
+| Multiple evaluations with **different** in-code defaults | Drift. Reconcile all of them to the expected value and note the prior inconsistency. |
+
+### Step 5: Reconcile the In-Code Default
+
+Update **only** the default/fallback argument so it matches the expected value.
+
+- Do **not** change evaluation logic, branching, or off-path behavior.
+- Do **not** remove the flag or its evaluation.
+- If the default lives in a **generated file**, do not hand-edit it. Update the source of truth (the constructor/registry/annotation) and regenerate using the project's codegen command. Note `requires_generation: true` in your summary.
+
+**Example (before then after), expected default = `true`:**
+
+```typescript
+// Before: outage returns false even though the default rule now serves true
+const enabled = await ldClient.variation('new-checkout-flow', context, false);
+
+// After: fallback default reconciled to match the fallthrough
+const enabled = await ldClient.variation('new-checkout-flow', context, true);
+```
+
+The surrounding `if (enabled) { ... } else { ... }` branching is left untouched.
+
+### Step 6: Validate Before Committing
+
+Run the project's configured checks scoped to the changed files. Discover them from `package.json` scripts, a `Makefile`, `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md`, or the CI config. Typically: format, lint, type-check, build, and the relevant tests.
+
+**Hard stop:** if any check fails and you cannot fix it, do not commit or push. Narrow your change instead. Never ship code that fails format/lint/type-check/build/test.
+
+### Step 7: Open the Pull Request
+
+Only after validation passes. Use [references/pr-template.md](references/pr-template.md). The description must state: the flag key, the source environment, the old vs new in-code default, and that **only** the SDK fallback default changed (the flag and its evaluation are preserved).
+
+- Follow the repository's contribution conventions (branch naming, commit style). Check `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md` first.
+- A clear default: branch `fix/flag-default-drift-<flag-key>`, commit `fix: sync in-code default for <flag-key> to match fallthrough`.
+
+### Step 8: Report a Structured Summary
+
+Produce a concise summary with these fields:
+
+```
+flag_key:            <key>
+drift_detected:      true | false
+old_default:         <in-code value before, or n/a>
+new_default:         <expected value / value written, or n/a>
+files_modified:      [<paths>]
+pr_url:              <url or null>
+requires_generation: true | false
+notes:               <anything the reviewer should know>
+```
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Fallthrough is a **percentage rollout** | There is no single default value. Report the split, do not auto-edit, and ask the user which value the fallback should represent. |
+| Fallback appears **intentionally conservative** (matches `offVariation` or a safe value) | Surface the mismatch and confirm intent before changing. Some teams keep the fallback as a safe value on purpose. |
+| In-code default lives in a **generated file** | Edit the source of truth and regenerate; never hand-edit generated output. Set `requires_generation: true`. |
+| **Type mismatch** between code default and the variation's type | Flag as a bug in the PR/summary; the default and variation types should agree. |
+| **JSON / object / float** defaults | Compare by normalized value, not string form (`{"a":1}` == `{ "a": 1 }`, `0` == `0.0`). |
+| Flag **not found** or wrong environment | Inform the user; check for typos in the key and confirm the environment. |
+| **Dynamic flag keys** (`flag-${id}`) | Automated detection may be incomplete; flag for manual review. |
+| Environments **disagree** on the fallthrough | The fallback can only match one. Confirm which environment is the source of truth. |
+| Flag spans **multiple repositories** | This skill operates on the current repo. Note other repos that also reference the key so they can be reconciled separately. |
+
+## What NOT to Do
+
+- Don't remove the flag or its evaluation; this skill only touches the default argument.
+- Don't change evaluation logic, branching, or off-path behavior beyond the fallback default.
+- Don't hand-edit generated files; regenerate from the source of truth.
+- Don't open a PR when there is no drift.
+- Don't guess the fallthrough value; resolve it from `get-flag`.
+- Don't ship code that fails format, lint, type-check, build, or tests.
+
+## References
+
+- [SDK Default Patterns](references/sdk-default-patterns.md): Where the fallback default lives by language, wrapper, annotation, and generated-file pattern; how to find it
+- [PR Template](references/pr-template.md): Structured PR description for a drift reconciliation
+- [Flag Cleanup](../launchdarkly-flag-cleanup/SKILL.md): If the goal is to remove the flag entirely, not reconcile its default
+- [Flag Targeting](../launchdarkly-flag-targeting/SKILL.md): If the goal is to change the default rule in LaunchDarkly instead of the code

--- a/skills/feature-flags/launchdarkly-flag-drift/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-drift/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "launchdarkly-flag-drift",
+  "description": "Detect and reconcile drift between an in-code SDK fallback default and a LaunchDarkly default rule",
+  "version": "0.1.0",
+  "author": "LaunchDarkly",
+  "repository": "https://github.com/launchdarkly/agent-skills",
+  "skills": ["./"],
+  "tags": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management",
+    "flag-drift",
+    "default-drift",
+    "sdk",
+    "reconciliation",
+    "devops",
+    "mcp"
+  ],
+  "requirements": {
+    "mcp-servers": ["@launchdarkly/mcp-server"]
+  }
+}

--- a/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
@@ -1,0 +1,72 @@
+# PR Template for Flag Default Drift
+
+Use this template when opening a pull request that reconciles an in-code SDK fallback default with the LaunchDarkly default rule (fallthrough). The change is intentionally narrow: only the default argument moves. The flag and its evaluation stay.
+
+```markdown
+## Sync in-code default: `{flag-key}`
+
+### Summary
+- **Flag**: `{flag-key}`
+- **Source environment**: `{environment}`
+- **Old in-code default**: `{old value}`
+- **New in-code default**: `{new value}` (matches current default rule / fallthrough)
+- **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
+
+### Why
+The flag's default rule (fallthrough) in `{environment}` serves `{new value}`, but the
+hardcoded fallback in code returned `{old value}` when LaunchDarkly is unreachable.
+This drift meant an outage would serve a different value than normal operation. This PR
+reconciles the fallback so the outage value matches the default rule.
+
+### Changes
+- Files modified: `{list files}`
+- Occurrences updated: `{count}`
+- Requires code generation: `{yes/no}` {if yes, note the command run, e.g. `make generate`}
+
+### Not changed
+- Flag evaluation and branching logic
+- Off-path behavior (`offVariation`)
+- The flag itself (not removed, not archived)
+
+### Reviewer checklist
+- [ ] New default matches the fallthrough value from `get-flag` for `{environment}`
+- [ ] Only the default argument changed (no logic/branching edits)
+- [ ] Default type matches the flag's variation type
+- [ ] Generated files (if any) were regenerated, not hand-edited
+- [ ] Format, lint, type-check, build, and tests pass
+```
+
+## Example
+
+```markdown
+## Sync in-code default: `new-checkout-flow`
+
+### Summary
+- **Flag**: `new-checkout-flow`
+- **Source environment**: `production`
+- **Old in-code default**: `false`
+- **New in-code default**: `true` (matches current default rule / fallthrough)
+- **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
+
+### Why
+The default rule in `production` now serves `true`, but the code fallback returned `false`
+during outages. This PR reconciles the fallback to `true` so behavior is consistent when
+LaunchDarkly is unreachable.
+
+### Changes
+- Files modified: `CheckoutService.ts`
+- Occurrences updated: 1
+- Requires code generation: no
+
+### Not changed
+- The `if (enabled) { renderNew() } else { renderOld() }` branching
+- `offVariation` behavior
+- The flag itself
+
+### Reviewer checklist
+- [x] New default matches the fallthrough value from `get-flag` for `production`
+- [x] Only the default argument changed (no logic/branching edits)
+- [x] Default type matches the flag's variation type
+- [x] No generated files involved
+- [x] Format, lint, type-check, build, and tests pass
+```

--- a/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/references/pr-template.md
@@ -7,16 +7,22 @@ Use this template when opening a pull request that reconciles an in-code SDK fal
 
 ### Summary
 - **Flag**: `{flag-key}`
-- **Source environment**: `{environment}`
+- **Critical environments checked**: `{env-a}` -> `{value}`, `{env-b}` -> `{value}` (all agree on `{new value}`)
 - **Old in-code default**: `{old value}`
 - **New in-code default**: `{new value}` (matches current default rule / fallthrough)
 - **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
 
 ### Why
-The flag's default rule (fallthrough) in `{environment}` serves `{new value}`, but the
-hardcoded fallback in code returned `{old value}` when LaunchDarkly is unreachable.
-This drift meant an outage would serve a different value than normal operation. This PR
-reconciles the fallback so the outage value matches the default rule.
+The flag's default rule (fallthrough) serves `{new value}` across every critical
+environment this build runs against, but the hardcoded fallback in code returned
+`{old value}` when LaunchDarkly is unreachable. This drift meant an outage would serve a
+different value than normal operation. This PR reconciles the fallback so the outage value
+matches the default rule.
+
+> If the critical environments **disagree** on the fallthrough (e.g. `eu-production` serves
+> `true` but `federal` serves `false`), do not open a reconciliation PR: a single in-code
+> default cannot match all of them. Surface the per-environment values and confirm which
+> environment is authoritative, or resolve the divergence in LaunchDarkly first.
 
 ### Changes
 - Files modified: `{list files}`
@@ -29,7 +35,8 @@ reconciles the fallback so the outage value matches the default rule.
 - The flag itself (not removed, not archived)
 
 ### Reviewer checklist
-- [ ] New default matches the fallthrough value from `get-flag` for `{environment}`
+- [ ] Fallthrough was resolved from `get-flag` in **every** critical environment, and they agree
+- [ ] New default matches that agreed fallthrough value
 - [ ] Only the default argument changed (no logic/branching edits)
 - [ ] Default type matches the flag's variation type
 - [ ] Generated files (if any) were regenerated, not hand-edited
@@ -43,15 +50,15 @@ reconciles the fallback so the outage value matches the default rule.
 
 ### Summary
 - **Flag**: `new-checkout-flow`
-- **Source environment**: `production`
+- **Critical environments checked**: `production` -> `true`, `eu-production` -> `true` (all agree on `true`)
 - **Old in-code default**: `false`
 - **New in-code default**: `true` (matches current default rule / fallthrough)
 - **Scope**: Only the SDK fallback default changed. The flag and its evaluation are preserved.
 
 ### Why
-The default rule in `production` now serves `true`, but the code fallback returned `false`
-during outages. This PR reconciles the fallback to `true` so behavior is consistent when
-LaunchDarkly is unreachable.
+The default rule now serves `true` in every critical environment (`production` and
+`eu-production`), but the code fallback returned `false` during outages. This PR reconciles
+the fallback to `true` so behavior is consistent when LaunchDarkly is unreachable.
 
 ### Changes
 - Files modified: `CheckoutService.ts`
@@ -64,7 +71,8 @@ LaunchDarkly is unreachable.
 - The flag itself
 
 ### Reviewer checklist
-- [x] New default matches the fallthrough value from `get-flag` for `production`
+- [x] Fallthrough was resolved from `get-flag` in `production` and `eu-production`, and they agree on `true`
+- [x] New default matches that agreed fallthrough value
 - [x] Only the default argument changed (no logic/branching edits)
 - [x] Default type matches the flag's variation type
 - [x] No generated files involved

--- a/skills/feature-flags/launchdarkly-flag-drift/references/sdk-default-patterns.md
+++ b/skills/feature-flags/launchdarkly-flag-drift/references/sdk-default-patterns.md
@@ -1,0 +1,144 @@
+# SDK Default Patterns Reference
+
+How to find the **fallback default**: the value the SDK returns when LaunchDarkly is unreachable, uninitialized, or the flag is unavailable. This is the argument this skill compares against the flag's default rule (fallthrough) and, on drift, the only thing it changes.
+
+## How to Spot the Default Argument
+
+In a direct SDK evaluation, the arguments are usually: **flag key**, **context/user**, **default**. The default is almost always the **last positional argument**. Do not confuse it with the context.
+
+```text
+ldClient.<typed>Variation( "<flag-key>", <context>, <DEFAULT> )
+                            ^ key         ^ context   ^ the value this skill checks
+```
+
+The default's type should match the flag's variation type (bool flag → boolean default, string flag → string default, etc.). A type mismatch is a bug worth flagging.
+
+## Direct Evaluation by Language
+
+### JavaScript / TypeScript (Node & client)
+
+```typescript
+ldClient.variation('flag-key', context, defaultValue);
+ldClient.boolVariation('flag-key', context, false);      // default = false
+ldClient.stringVariation('flag-key', context, 'control'); // default = 'control'
+ldClient.numberVariation('flag-key', context, 0);
+ldClient.jsonVariation('flag-key', context, {});
+ldClient.variationDetail('flag-key', context, defaultValue);
+```
+
+React SDK note: `useFlags()` reads already-evaluated values and does not expose a per-call default. The default for those flags is set where `LDProvider` / `asyncWithLDProvider` is configured (`flags` bootstrap / default map). Check the provider setup, not the call site.
+
+### Python
+
+```python
+ld_client.variation('flag-key', context, default_value)
+ld_client.bool_variation('flag-key', context, False)
+ld_client.string_variation('flag-key', context, 'control')
+ld_client.int_variation('flag-key', context, 0)
+ld_client.variation_detail('flag-key', context, default_value)
+```
+
+### Go
+
+```go
+ldClient.BoolVariation("flag-key", context, false)      // default = false
+ldClient.StringVariation("flag-key", context, "control")
+ldClient.IntVariation("flag-key", context, 0)
+ldClient.JSONVariation("flag-key", context, ldvalue.Null())
+ldClient.BoolVariationDetail("flag-key", context, false)
+```
+
+### Java / Kotlin
+
+```java
+ldClient.boolVariation("flag-key", context, false);
+ldClient.stringVariation("flag-key", context, "control");
+ldClient.intVariation("flag-key", context, 0);
+ldClient.jsonValueVariation("flag-key", context, LDValue.ofNull());
+```
+
+### Ruby
+
+```ruby
+ld_client.variation('flag-key', context, default_value)
+ld_client.bool_variation('flag-key', context, false)
+ld_client.string_variation('flag-key', context, 'control')
+```
+
+### .NET (C#)
+
+```csharp
+ldClient.BoolVariation("flag-key", context, false);
+ldClient.StringVariation("flag-key", context, "control");
+ldClient.IntVariation("flag-key", context, 0);
+ldClient.JsonVariation("flag-key", context, LdValue.Null);
+```
+
+## Abstraction Patterns (where the default is declared once)
+
+Many teams don't call the SDK directly at each site. They declare the default in a central place, then read the flag by key elsewhere. When present, the default in these declarations is the value to check and reconcile.
+
+### Wrapper / service method
+
+```typescript
+featureFlags.getBool('flag-key', false);   // default = false
+featureFlags.getValue('flag-key', 'control');
+```
+
+Open the wrapper implementation to confirm how the passed value flows into the underlying `variation(...)` call.
+
+### Registry / config map (one default per flag)
+
+```typescript
+// A central flag registry
+const flags = {
+  'new-checkout-flow': createFlag('new-checkout-flow', /* default */ false),
+};
+```
+
+```yaml
+# A config file of flag defaults
+feature_flags:
+  new-checkout-flow: false
+```
+
+### Annotation / struct-tag defaults
+
+Some typed languages encode the default in metadata rather than an argument.
+
+```go
+type Flags struct {
+    NewCheckoutFlow bool `ld:"new-checkout-flow,false"` // default = false
+}
+```
+
+```java
+@FeatureFlag(key = "new-checkout-flow", defaultValue = "false")
+boolean newCheckoutFlow;
+```
+
+Reconcile the value inside the annotation/tag, not a downstream copy of it.
+
+### Generated default files
+
+When flag defaults are compiled into a generated file (e.g. an auto-generated defaults map or typed accessor), **do not hand-edit the generated output**. Change the source of truth (the registry, annotation, or codegen input) and re-run the project's generation step. Mark `requires_generation: true` in the summary.
+
+## Search Strategy
+
+Search for the flag key with several forms, since codebases mix conventions:
+
+```bash
+# Exact key, both quote styles
+rg "'flag-key'" ; rg '"flag-key"'
+
+# camelCase accessor (kebab keys often surface as camelCase in code)
+rg "flagKey"
+
+# Wrapper / registry / config usage and constants
+rg "flag-key|flagKey|FLAG_KEY"
+
+# Likely declaration sites
+rg "flag-key" -g '*flags*' -g '*.constants.*' -g '*config*'
+```
+
+For each hit, decide whether it is: a direct evaluation (default = last arg), a declaration (default = the declared value), or a read of an already-declared flag (trace back to the declaration). Reconcile at the declaration; read sites need no change.


### PR DESCRIPTION
## Summary
Adds a new LaunchDarkly agent skill, `launchdarkly-flag-drift`, under `skills/feature-flags/`, following the repo's SKILL.md + README.md + references convention. Updates the repo `README.md` skill table and regenerates `skills.json`.

The skill detects and reconciles drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough):
- Resolves the expected value via `get-flag`
- Locates the fallback default argument at every evaluation/declaration (patterns in `references/sdk-default-patterns.md`)
- Updates only the default argument on drift, without removing the flag or changing its evaluation logic
- Documents the change with `references/pr-template.md`

Isolated PR containing only this skill (branched from `main`).

## Validation
- `python3 scripts/validate_skills.py` passes
- `python3 scripts/generate_catalog.py --check` reports `skills.json` up to date
- `python3 -m unittest tests.test_validate_skills` passes

## Test plan
- [ ] Confirm the skill loads in the agent client from `skills/feature-flags/launchdarkly-flag-drift/`
- [ ] Trigger on a flag whose fallthrough differs from the in-code default; verify only the default argument changes
- [ ] Trigger on a flag with no drift; verify it reports `drift_detected: false` and opens no PR

Made with [Cursor](https://cursor.com)