### PR TITLE
fix: Codex plugin manifest name mismatch

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "launchdarkly-mcp",
+  "name": "launchdarkly",
   "version": "0.6.1",
   "description": "Connect Codex to LaunchDarkly over MCP: configs and feature management (FM) hosted endpoints, plus bundled guidance for using the tools.",
   "author": {

--- a/tests/test_plugin_manifests.py
+++ b/tests/test_plugin_manifests.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+CODEX_MANIFEST = ROOT / ".codex-plugin" / "plugin.json"
+
+
+class PluginManifestTests(unittest.TestCase):
+    def test_codex_plugin_name_matches_marketplace(self):
+        marketplace = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+        codex_manifest = json.loads(CODEX_MANIFEST.read_text(encoding="utf-8"))
+
+        marketplace_plugins = marketplace.get("plugins", [])
+        root_plugin = next(
+            (plugin for plugin in marketplace_plugins if plugin.get("source") == "."),
+            None,
+        )
+
+        self.assertIsNotNone(root_plugin, "marketplace must include the root plugin")
+        self.assertEqual(
+            codex_manifest.get("name"),
+            root_plugin.get("name"),
+            "Codex manifest name must match the marketplace plugin name",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- align `.codex-plugin/plugin.json` with the `launchdarkly` name advertised by the marketplace
- add a regression test that requires the Codex manifest and root marketplace entry to use the same plugin name

Without this, `codex plugin add launchdarkly@launchdarkly-ai-tooling` fails with: `plugin.json name launchdarkly-mcp does not match marketplace plugin name launchdarkly`.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"`
- `python3 scripts/validate_skills.py`
- verified the corrected snapshot installs successfully with Codex CLI 0.145.0