### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is not a deployable app. It is a collection of agent **skills** (markdown
+playbooks under `skills/`) packaged as Claude Code / Cursor / Codex plugins, plus a
+Promptfoo-based LLM eval suite (`evals/`) and Python skill-validation tooling
+(`scripts/`, `tests/`). There is no server to run and no build step; `skills.json`
+is a generated catalog.
+
+### What you can run without any secrets
+
+These are the CI checks and the fastest way to prove the environment works. Standard
+commands are defined in `.github/workflows/validate-skills.yml` and `evals/package.json`:
+
+- Skill validation: `python3 scripts/validate_skills.py` (stdlib only, no pip installs).
+- Python unit tests: `python3 -m unittest discover -s tests`.
+- Catalog check: `python3 scripts/generate_catalog.py --check` (regenerate without
+  `--check` to update `skills.json`).
+- Eval harness unit tests: `npm test --prefix evals` (Node `node --test`, no API key).
+
+### Running the LLM evals (`npm run eval` / `npm run eval:all`) — two gotchas
+
+1. **Node version.** Promptfoo requires Node `^20.20.0 || >=22.22.0`. The default
+   `node` on PATH here is the pinned `/exec-daemon/node` (currently `v22.14.0`), which
+   is too old and makes promptfoo exit immediately. A supported Node 22 is installed
+   via nvm; select it before running any promptfoo command in the current shell:
+   `export PATH="$HOME/.nvm/versions/node/$(nvm version 22)/bin:$PATH"` (or
+   `nvm use 22`). The `node --test` harness unit tests run fine on the default node;
+   only the promptfoo CLI needs the newer one.
+2. **Anthropic API key.** Both the system-under-test agent and the default rubric
+   grader need `ANTHROPIC_API_KEY`. Copy `evals/.env.example` to `evals/.env` and set
+   it (`.env` is gitignored). Without it, the harness loads the skill and launches the
+   provider but each case errors with "ANTHROPIC_API_KEY environment variable is not
+   set". The LaunchDarkly MCP server is mocked during evals
+   (`evals/mocks/`), so no LaunchDarkly credentials are needed.
+
+Run all suites from the repo root with `npm run eval` (alias for `eval:all --prefix
+evals`); run one suite with `cd evals && npm run eval:<suite>` (e.g. `eval:flag-create`),
+or its `:single` variant to smoke-test the first case only. View results with
+`npm run eval:view` (Promptfoo UI on port 15500).
+
+Note: `tests/` contains a second, secondary Promptfoo setup; the active suite is
+`evals/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sets up and documents the local dev environment for this agent-skills repo (no deployable app; skills + Promptfoo eval suite + Python validation tooling).
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing two non-obvious gotchas for running the LLM evals: (1) the default `/exec-daemon/node` (`v22.14.0`) is too old for Promptfoo which needs `>=22.22.0` (use the nvm-installed Node 22), and (2) `ANTHROPIC_API_KEY` is required for `npm run eval`.
- No product code changed.

## Testing

- [x] Manual (describe below)

Ran the CI-equivalent checks (all pass, no secrets needed):

- `python3 scripts/validate_skills.py` -> Validated 48 SKILL.md files successfully.
- `python3 -m unittest discover -s tests` -> Ran 8 tests, OK.
- `python3 scripts/generate_catalog.py --check` -> skills.json is up to date.
- `npm test --prefix evals` -> 90 pass / 0 fail.
- `npm run eval:flag-command:single` (with nvm Node 22) -> harness loads the skill and launches the provider, erroring only on the unset `ANTHROPIC_API_KEY`, confirming end-to-end wiring up to the API boundary.

## Notes

- The full LLM eval suite (`npm run eval`) is blocked only on a missing `ANTHROPIC_API_KEY` secret; everything else runs locally.
- Update script (dependency refresh on VM startup): `npm ci --legacy-peer-deps --prefix evals` and `npm ci --legacy-peer-deps --prefix tests`. Python tooling is stdlib-only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c97c118-7da6-4897-a112-5e4721396a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c97c118-7da6-4897-a112-5e4721396a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

