### PR TITLE
fix: Codex plugin manifest name mismatch

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "launchdarkly-mcp",
+  "name": "launchdarkly",
   "version": "0.6.1",
   "description": "Connect Codex to LaunchDarkly over MCP: configs and feature management (FM) hosted endpoints, plus bundled guidance for using the tools.",
   "author": {

--- a/tests/test_plugin_manifests.py
+++ b/tests/test_plugin_manifests.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+CODEX_MANIFEST = ROOT / ".codex-plugin" / "plugin.json"
+
+
+class PluginManifestTests(unittest.TestCase):
+    def test_codex_plugin_name_matches_marketplace(self):
+        marketplace = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+        codex_manifest = json.loads(CODEX_MANIFEST.read_text(encoding="utf-8"))
+
+        marketplace_plugins = marketplace.get("plugins", [])
+        root_plugin = next(
+            (plugin for plugin in marketplace_plugins if plugin.get("source") == "."),
+            None,
+        )
+
+        self.assertIsNotNone(root_plugin, "marketplace must include the root plugin")
+        self.assertEqual(
+            codex_manifest.get("name"),
+            root_plugin.get("name"),
+            "Codex manifest name must match the marketplace plugin name",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- align `.codex-plugin/plugin.json` with the `launchdarkly` name advertised by the marketplace
- add a regression test that requires the Codex manifest and root marketplace entry to use the same plugin name

Without this, `codex plugin add launchdarkly@launchdarkly-ai-tooling` fails with: `plugin.json name launchdarkly-mcp does not match marketplace plugin name launchdarkly`.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"`
- `python3 scripts/validate_skills.py`
- verified the corrected snapshot installs successfully with Codex CLI 0.145.0

---

Supersedes #120 (same commit, `089cd09`). That PR was opened from a fork, so `pull_request` runs could not see `secrets.ANTHROPIC_API_KEY` and every Skill Evals suite errored with `ANTHROPIC_API_KEY environment variable is not set` → 0% against the 75% threshold. Re-opening from a branch in this repo so the evals actually run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only manifest rename plus a CI guard; no runtime MCP or skill behavior changes.
> 
> **Overview**
> Renames the Codex plugin id in `.codex-plugin/plugin.json` from `launchdarkly-mcp` to **`launchdarkly`** so it matches the root entry in `.claude-plugin/marketplace.json`. That mismatch blocked `codex plugin add launchdarkly@launchdarkly-ai-tooling`.
> 
> Adds **`tests/test_plugin_manifests.py`**, a unittest that loads both manifests and asserts the Codex `name` equals the marketplace plugin with `"source": "."`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089cd0904aa5f6bcb3077817dec369c380317f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->