### PR TITLE
[EMSR-1912] Add Qualitative Feedback Setup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Agent Skills are modular, text-based playbooks that teach an agent how to perfor
 | `feature-flags/launchdarkly-guarded-rollout` | Configure guarded rollouts with progressive traffic, metric monitoring, and rollback |
 | `feature-flags/flag-release` | Record a flag's automated release for a PR, honoring release intent and per-environment release policies |
 | `feature-flags/flag-and-release-change` | End-to-end PR orchestrator: decide → create + wire the flag → record its release (composes the skills above) |
+| `feature-flags/launchdarkly-flag-qualitative-feedback-setup` | Add a qualitative user feedback widget tied to a flag, adapting to the project's framework and design system |
 
 ### AgentControl
 

--- a/skills.json
+++ b/skills.json
@@ -320,6 +320,26 @@
       ]
     },
     {
+      "name": "launchdarkly-flag-qualitative-feedback-setup",
+      "description": "Integrate LaunchDarkly qualitative user feedback into a JavaScript/TypeScript codebase. Guides framework and design system detection, builds the sendFeedback utility and feedback widget matching existing project patterns. Use when the user wants to add a Give Feedback widget, collect user sentiment tied to feature flags, set up feedback collection, or wire up the $ld:feedback tracking event.",
+      "path": "skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup",
+      "version": "1.0.0-experimental",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feedback",
+        "qualitative-feedback",
+        "user-feedback",
+        "sentiment",
+        "sdk",
+        "javascript",
+        "react",
+        "mcp"
+      ]
+    },
+    {
       "name": "launchdarkly-flag-targeting",
       "description": "Control LaunchDarkly feature flag targeting including toggling flags on/off, percentage rollouts, targeting rules, individual targets, and copying flag configurations between environments. Use when the user wants to change who sees a flag, roll out to a percentage, add targeting rules, or promote config between environments.",
       "path": "skills/feature-flags/launchdarkly-flag-targeting",

--- a/skills.json
+++ b/skills.json
@@ -320,6 +320,25 @@
       ]
     },
     {
+      "name": "launchdarkly-flag-drift",
+      "description": "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation.",
+      "path": "skills/feature-flags/launchdarkly-flag-drift",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
+      "tags": [
+        "launchdarkly",
+        "feature-flags",
+        "feature-management",
+        "flag-drift",
+        "default-drift",
+        "sdk",
+        "reconciliation",
+        "devops",
+        "mcp"
+      ]
+    },
+    {
       "name": "launchdarkly-flag-qualitative-feedback-setup",
       "description": "Integrate LaunchDarkly qualitative user feedback into a JavaScript/TypeScript codebase. Guides framework and design system detection, builds the sendFeedback utility and feedback widget matching existing project patterns. Use when the user wants to add a Give Feedback widget, collect user sentiment tied to feature flags, set up feedback collection, or wire up the $ld:feedback tracking event.",
       "path": "skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup",
@@ -336,25 +355,6 @@
         "sdk",
         "javascript",
         "react",
-        "mcp"
-      ]
-    },
-    {
-      "name": "launchdarkly-flag-drift",
-      "description": "Detect and reconcile drift between a feature flag's in-code SDK fallback default and its LaunchDarkly default rule (fallthrough). Use when a flag's default rule changed, when the user asks to detect flag drift, check whether a hardcoded default still matches LaunchDarkly, sync an in-code default, or open a PR reconciling a fallback value, without removing the flag or its evaluation.",
-      "path": "skills/feature-flags/launchdarkly-flag-drift",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "compatibility": "Requires the remotely hosted LaunchDarkly MCP server",
-      "tags": [
-        "launchdarkly",
-        "feature-flags",
-        "feature-management",
-        "flag-drift",
-        "default-drift",
-        "sdk",
-        "reconciliation",
-        "devops",
         "mcp"
       ]
     },

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/README.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/README.md
@@ -1,0 +1,112 @@
+# LaunchDarkly Qualitative Feedback Skill
+
+An Agent Skill that walks users through a step-by-step wizard to add LaunchDarkly's qualitative user feedback feature to a JavaScript/TypeScript codebase, adapting to the project's framework and design system.
+
+## Overview
+
+This skill guides users through an interactive wizard:
+
+1. **Verify setup** — checks the SDK (client-side, v3.0+), framework, and design system
+2. **Gather requirements** — asks about the target flag, prompt text, feedback type, and widget placement
+3. **Verify the flag** — confirms or creates the flag in LaunchDarkly
+4. **Confirm the plan** — summarizes planned changes and waits for approval
+5. **Generate code** — creates the `sendFeedback` utility and feedback widget matching existing project patterns
+6. **Verify** — confirms the build passes and everything is wired up correctly
+
+Along the way the skill:
+- Detects the UI framework (React, Vue, Angular, Svelte, vanilla JS) and design system (MUI, Chakra, shadcn, Tailwind, etc.)
+- Identifies or creates the feature flag to attach feedback to
+- Optionally links feedback to session replays via LaunchDarkly observability
+
+## Widget Styles
+
+The skill asks two questions to determine the widget style: feedback type and icon style.
+
+**Feedback type:**
+
+| Type | Description |
+|------|-------------|
+| Sentiment + text | Popover with sentiment buttons and a text area for comments |
+| Sentiment only | Inline one-click sentiment buttons, no popover or text input |
+| Text only | Popover with a text area, no sentiment buttons |
+
+**Icon style** (when sentiment is involved):
+
+| Style | Buttons |
+|-------|---------|
+| Thumbs up / down | Two buttons: positive / negative |
+| Smiley faces | Three buttons: positive / neutral / negative |
+
+This produces five widget variants:
+
+| Type | Icons | Template |
+|------|-------|----------|
+| Sentiment + text | Thumbs | `PopoverFeedback` with `icons="thumbs"` |
+| Sentiment + text | Smileys | `PopoverFeedback` with `icons="smileys"` |
+| Sentiment only | Thumbs | `InlineFeedback` with `icons="thumbs"` |
+| Sentiment only | Smileys | `InlineFeedback` with `icons="smileys"` |
+| Text only | — | `PopoverFeedback` with `icons="none"` |
+
+All widget components accept `flagKey` and `prompt` as props and track a `submitted` state that replaces the widget with a confirmation message after feedback is sent.
+
+## Installation (Local)
+
+For now, install by placing this skill directory where your agent client loads skills.
+
+Examples:
+
+- **Generic**: copy `skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/` into your client's skills path
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment. The remote server provides higher-level, agent-optimized tools that orchestrate multiple API calls and return pruned, actionable responses.
+
+The target application must use the LaunchDarkly JavaScript SDK v3.0+ (client-side).
+
+## Usage
+
+Once installed, the skill activates automatically when a user asks about collecting user feedback:
+
+```
+Add a Give Feedback widget for my new search feature
+```
+
+```
+Set up qualitative feedback collection on the checkout-redesign flag
+```
+
+```
+I want to collect user sentiment on my feature rollout
+```
+
+```
+Wire up the LaunchDarkly feedback popover using our shadcn components
+```
+
+## Structure
+
+```
+launchdarkly-flag-qualitative-feedback-setup/
+├── SKILL.md                       # Wizard workflow and agent instructions
+├── marketplace.json
+├── README.md
+└── references/
+    ├── client-side-sdk-list.md    # SDK packages that support qualitative feedback
+    ├── server-side-sdk-list.md    # SDK packages that do NOT support qualitative feedback
+    ├── sendFeedback.ts            # Template: sends $ld:feedback event with session replay support
+    ├── PopoverFeedback.tsx        # Template: popover with text area + configurable sentiment icons
+    └── InlineFeedback.tsx         # Template: inline one-click sentiment buttons
+```
+
+## Related
+
+- [LaunchDarkly Flag Create](../launchdarkly-flag-create/) — Create the flag to attach feedback to
+- [LaunchDarkly Flag Targeting](../launchdarkly-flag-targeting/) — Control who sees the feedback widget via targeting rules
+- [LaunchDarkly Flag Cleanup](../launchdarkly-flag-cleanup/) — Remove the feedback flag when collection is complete
+- [Official Docs: User feedback](https://launchdarkly.com/docs/sdk/features/user-feedback)
+- [Official Docs: Viewing feedback](https://launchdarkly.com/docs/home/releases/user-feedback)
+- [LaunchDarkly MCP Server](https://github.com/launchdarkly/mcp-server)
+
+## License
+
+Apache-2.0

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
@@ -74,10 +74,10 @@ Before gathering requirements, verify that this project can support qualitative 
 Search for LaunchDarkly SDK imports:
 - `launchdarkly-js-client-sdk` — vanilla JS/TS client SDK (v3.x)
 - `@launchdarkly/js-client-sdk` — vanilla JS/TS client SDK (v4.x, renamed scoped package)
-- `@launchdarkly/react-client-sdk` — React SDK (provides hooks and providers)
-- `launchdarkly-react-client-sdk` — older React SDK package name
+- `@launchdarkly/react-sdk` — React Web SDK (current; provides hooks and providers)
+- `launchdarkly-react-client-sdk` — older React Web SDK package name (renamed to `@launchdarkly/react-sdk`)
 
-Also search for SDK initialization (`initialize(` for v3.x, or `createClient(`/`start(` for v4.x, plus `<LDProvider`, `asyncWithLDProvider`). If not found, ask the user where LDClient is initialized or accessible.
+Also search for SDK initialization (`initialize(` for v3.x, or `createClient(`/`start(` for v4.x, plus React provider signals `<LDProvider`, `asyncWithLDProvider`, or `createLDReactProvider`). If not found, ask the user where LDClient is initialized or accessible.
 
 - If **no LD SDK is found at all** → inform the user that qualitative feedback requires a LaunchDarkly client-side SDK to be installed and initialized → **STOP. Do not proceed.**
 - If found → continue to Check 2.
@@ -112,7 +112,7 @@ After the checks above pass, gather the remaining context:
 1. **Find the SDK initialization.** Search for:
    - `initialize(` from `launchdarkly-js-client-sdk` (v3.x)
    - `createClient(` / `start(` from `@launchdarkly/js-client-sdk` (v4.x)
-   - `<LDProvider` or `asyncWithLDProvider` from the React SDK
+   - `<LDProvider`, `asyncWithLDProvider`, or `createLDReactProvider` from the React SDK
    - How the `LDClient` instance is accessed (direct reference, React context, custom hook, etc.)
 
 2. **Check for observability.** Search for `@launchdarkly/observability` and `@launchdarkly/session-replay`. If present, feedback can be linked to session replays.
@@ -298,7 +298,7 @@ After the user confirms everything works, mention:
 | Server-side SDK only, no client SDK | **STOP** — handled by Check 2 |
 | SDK version < 3.0 | **STOP** — handled by Check 3 |
 | Existing `sendFeedback` function found | Reuse it, skip Step 5 — handled by Check 4 |
-| React SDK (`@launchdarkly/react-client-sdk`) | Access client via `useLDClient()` hook instead of a direct reference |
+| React SDK (`@launchdarkly/react-sdk` / `launchdarkly-react-client-sdk`) | Access client via `useLDClient()` hook instead of a direct reference |
 | Flag doesn't have client-side availability | User must enable it in the flag's Advanced Controls |
 | Observability not installed | Skip the `o11y_session_id` field; session replay won't be available |
 | No design system detected | Use the template component with minimal inline styles as a starting point |
@@ -335,7 +335,7 @@ All templates are TypeScript — for JavaScript projects, adapt by removing type
 These show how the decision tree plays out for common scenarios.
 
 **Happy path — React + TypeScript, new flag, thumbs popover:**
-Step 0 → welcome. Step 1 → finds `@launchdarkly/react-client-sdk` v3.6, React + Tailwind, no existing feedback. Step 2 → user picks a new flag `checkout-redesign`, prompt "How do you feel about the new checkout?", thumbs style, placed below the order summary. Step 3 → creates flag via `create-flag`. Step 4 → user approves. Step 5 → creates `sendFeedback.ts` in `lib/ld/`. Step 6 → creates `FeedbackPopover.tsx` adapted to Tailwind, wires it into `CheckoutPage.tsx` with `useLDClient()`. Step 7 → build passes, event fires.
+Step 0 → welcome. Step 1 → finds `@launchdarkly/react-sdk`, React + Tailwind, no existing feedback. Step 2 → user picks a new flag `checkout-redesign`, prompt "How do you feel about the new checkout?", thumbs style, placed below the order summary. Step 3 → creates flag via `create-flag`. Step 4 → user approves. Step 5 → creates `sendFeedback.ts` in `lib/ld/`. Step 6 → creates `FeedbackPopover.tsx` adapted to Tailwind, wires it into `CheckoutPage.tsx` with `useLDClient()`. Step 7 → build passes, event fires.
 
 **Existing sendFeedback — reuse and skip:**
 Step 1 → Check 4 finds `src/utils/sendFeedback.ts` already calling `client.track('$ld:feedback', ...)`. Records the import path. Step 2 → gathers requirements normally. Steps 3–4 → as usual. Step 5 → **skipped** (reuses existing function). Step 6 → builds widget, imports `sendFeedback` from the existing path. Step 7 → build passes, event fires.

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
@@ -72,11 +72,12 @@ Before gathering requirements, verify that this project can support qualitative 
 #### Check 1/4: Is the LD SDK present?
 
 Search for LaunchDarkly SDK imports:
-- `launchdarkly-js-client-sdk` — vanilla JS/TS client SDK
+- `launchdarkly-js-client-sdk` — vanilla JS/TS client SDK (v3.x)
+- `@launchdarkly/js-client-sdk` — vanilla JS/TS client SDK (v4.x, renamed scoped package)
 - `@launchdarkly/react-client-sdk` — React SDK (provides hooks and providers)
 - `launchdarkly-react-client-sdk` — older React SDK package name
 
-Also search for SDK initialization (`initialize(`, `<LDProvider`, `asyncWithLDProvider`). If not found, ask the user where LDClient is initialized or accessible.
+Also search for SDK initialization (`initialize(` for v3.x, or `createClient(`/`start(` for v4.x, plus `<LDProvider`, `asyncWithLDProvider`). If not found, ask the user where LDClient is initialized or accessible.
 
 - If **no LD SDK is found at all** → inform the user that qualitative feedback requires a LaunchDarkly client-side SDK to be installed and initialized → **STOP. Do not proceed.**
 - If found → continue to Check 2.
@@ -109,7 +110,8 @@ Search for `$ld:feedback`, `sendFeedback`, `FeedbackPopover`, or `Give feedback`
 After the checks above pass, gather the remaining context:
 
 1. **Find the SDK initialization.** Search for:
-   - `initialize(` from `launchdarkly-js-client-sdk`
+   - `initialize(` from `launchdarkly-js-client-sdk` (v3.x)
+   - `createClient(` / `start(` from `@launchdarkly/js-client-sdk` (v4.x)
    - `<LDProvider` or `asyncWithLDProvider` from the React SDK
    - How the `LDClient` instance is accessed (direct reference, React context, custom hook, etc.)
 
@@ -201,6 +203,7 @@ client.flush();
 ```
 
 **Key decisions:**
+- Match the `LDClient` type import to the project's SDK version: `launchdarkly-js-client-sdk` for v3.x, `@launchdarkly/js-client-sdk` for v4.x. The templates import from `launchdarkly-js-client-sdk` — update it if the project is on v4. (The `client.track` / `client.flush` calls are the same across both.)
 - If `@launchdarkly/session-replay` is in the project, include the session ID via `LDRecord.getSession()?.sessionSecureID`. If not, remove the session replay import and `o11y_session_id` logic from the template.
 - Place the utility where the project keeps its LD-related code (alongside existing flag helpers, in a `lib/` or `utils/` directory, etc.)
 - Export the `LDFeedbackSentiment` type if using TypeScript

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: launchdarkly-flag-qualitative-feedback-setup
+description: "Integrate LaunchDarkly qualitative user feedback into a JavaScript/TypeScript codebase. Guides framework and design system detection, builds the sendFeedback utility and feedback widget matching existing project patterns. Use when the user wants to add a Give Feedback widget, collect user sentiment tied to feature flags, set up feedback collection, or wire up the $ld:feedback tracking event."
+license: Apache-2.0
+compatibility: Requires the remotely hosted LaunchDarkly MCP server
+metadata:
+  author: launchdarkly
+  version: "1.0.0-experimental"
+---
+
+# LaunchDarkly Qualitative Feedback
+
+You're using a skill that will guide you through adding qualitative user feedback collection to a codebase. Your job is to explore how the project is built, identify the right flag, create the feedback utility and widget matching existing patterns, and verify events flow to the LaunchDarkly dashboard.
+
+**This is a step-by-step wizard.** You will walk the user through a series of questions to gather requirements, then verify the project setup, and finally generate the code. Ask questions one at a time and wait for each answer before continuing. Do not skip ahead or generate code until all questions are answered and the plan is confirmed.
+
+Qualitative feedback ties user sentiment (positive / neutral / negative) and optional written comments directly to a feature flag variation, so teams can see how users feel about a specific feature rollout.
+
+**Availability:** JavaScript SDK v3.0+ (client-side only). React components are provided for convenience.
+
+## Prerequisites
+
+This skill requires the remotely hosted LaunchDarkly MCP server to be configured in your environment.
+
+**Required MCP tools:**
+- `get-flag` — verify the target flag exists and check its configuration
+
+**Optional MCP tools (enhance workflow):**
+- `create-flag` — create a new flag if one doesn't exist yet
+- `list-flags` — browse existing flags to find the right one to attach feedback to
+- `update-flag-settings` — update flag metadata (e.g., add a `feedback` tag)
+
+## Core Principles
+
+1. **Design system first**: Never ship the unstyled template component to production. Detect the project's design system and use its primitives.
+2. **One entry point per screen**: Multiple feedback widgets on the same page create noise and reduce response quality.
+3. **The `sendFeedback` function is the integration**: The UI is customizable; the `$ld:feedback` tracking event contract is what matters.
+
+## Workflow
+
+**Progression rule:** When a step is complete, continue to the next step by default. Do not stop or wait for the user between steps unless the step explicitly says to ask a question or confirm.
+
+**Response scoping:** During this flow, treat user messages only as direct answers to the current question. Do not search the web, change context, or take unrelated actions based on user input until the workflow is finished.
+
+**Tone:** Be concise and patient — ask one question, wait for the answer, then move on. Keep responses focused on the current step.
+
+**State tracking:** Track gathered requirements across the conversation. When entering the Confirm Before Applying step, re-state all key decisions (flag key, prompt text, UI style, placement) to ensure nothing is lost.
+
+### Step 0: Welcome the User
+
+Before asking any questions, present this intro message to the user (you may lightly adapt the wording, but keep the structure):
+
+> **Qualitative Feedback Setup**
+>
+> I'll walk you through adding a feedback widget to your app in a few short steps:
+>
+> 1. **Verify your setup** — I'll check your SDK, framework, and design system.
+> 2. **Gather requirements** — I'll ask a few questions about the flag, prompt text, style, and placement.
+> 3. **Verify the flag** — I'll confirm or create the flag in LaunchDarkly.
+> 4. **Confirm the plan** — I'll summarize what I'm going to build and ask for your approval.
+> 5. **Generate the code** — I'll create the feedback utility and widget matching your project's patterns.
+> 6. **Verify** — I'll make sure everything builds and is wired up correctly.
+>
+> Let's get started!
+
+Then proceed immediately to Step 1.
+
+### Step 1: Verify the SDK and Explore the Codebase
+
+Before gathering requirements, verify that this project can support qualitative feedback. Run these checks in order — each is a gate.
+
+#### Check 1/4: Is the LD SDK present?
+
+Search for LaunchDarkly SDK imports:
+- `launchdarkly-js-client-sdk` — vanilla JS/TS client SDK
+- `@launchdarkly/react-client-sdk` — React SDK (provides hooks and providers)
+- `launchdarkly-react-client-sdk` — older React SDK package name
+
+Also search for SDK initialization (`initialize(`, `<LDProvider`, `asyncWithLDProvider`). If not found, ask the user where LDClient is initialized or accessible.
+
+- If **no LD SDK is found at all** → inform the user that qualitative feedback requires a LaunchDarkly client-side SDK to be installed and initialized → **STOP. Do not proceed.**
+- If found → continue to Check 2.
+
+#### Check 2/4: Is it a client-side SDK?
+
+Qualitative feedback is a **client-side only** feature. Verify the SDK found in Check 1 is a client-side SDK. Refer to [references/client-side-sdk-list.md](references/client-side-sdk-list.md) and [references/server-side-sdk-list.md](references/server-side-sdk-list.md) for the complete lists.
+
+If the SDK is **server-side only** with no client SDK present → explain that qualitative feedback requires a client-side SDK and cannot be sent from server code → **STOP. Do not proceed.**
+
+If unclear, ask the user whether their SDK is client-side or server-side before continuing.
+
+#### Check 3/4: Is the SDK version compatible?
+
+Check `package.json` for the exact version. The `$ld:feedback` event requires **v3.0+** of the JavaScript/React SDK.
+
+- If version **< 3.0** → inform the user they need to upgrade before feedback can be added → **STOP. Do not proceed.**
+- If version **>= 3.0** → continue to Check 4.
+
+#### Check 4/4: Is feedback already configured?
+
+Search for `$ld:feedback`, `sendFeedback`, `FeedbackPopover`, or `Give feedback` to check for existing feedback integration.
+
+- If a **`sendFeedback` function exists** that calls `client.track('$ld:feedback', ...)` → **reuse it**. Record its import path — Step 5 will be skipped. Continue to Step 2.
+- If a **feedback widget exists** but not the `sendFeedback` utility → note the widget pattern for consistency.
+- If **nothing found** → continue normally.
+
+#### Remaining exploration
+
+After the checks above pass, gather the remaining context:
+
+1. **Find the SDK initialization.** Search for:
+   - `initialize(` from `launchdarkly-js-client-sdk`
+   - `<LDProvider` or `asyncWithLDProvider` from the React SDK
+   - How the `LDClient` instance is accessed (direct reference, React context, custom hook, etc.)
+
+2. **Check for observability.** Search for `@launchdarkly/observability` and `@launchdarkly/session-replay`. If present, feedback can be linked to session replays.
+
+3. **Detect the UI framework and design system.**
+
+   | Signal | Framework |
+   |--------|-----------|
+   | `react`, `react-dom` in deps | React |
+   | `vue` in deps | Vue (adapt vanilla JS pattern to Vue component) |
+   | `@angular/core` in deps | Angular (adapt vanilla JS pattern to Angular component) |
+   | `svelte` in deps | Svelte (adapt vanilla JS pattern to Svelte component) |
+   | None of the above | Vanilla JS/TS |
+
+   Then check for a **design system or component library**:
+   - `@mui/material`, `@emotion/react` → MUI
+   - `@chakra-ui/react` → Chakra UI
+   - `antd` → Ant Design
+   - `@radix-ui/*` or `@shadcn/*` → Radix/shadcn
+   - `tailwindcss` in deps or `tailwind.config.*` → Tailwind CSS
+   - `bootstrap` or `react-bootstrap` → Bootstrap
+   - Custom design system → look for a `components/` directory with shared primitives (Button, Modal, Popover, etc.)
+
+   **If a design system is detected, use its primitives** (Button, Popover, TextArea, IconButton) instead of the inline-styled template component. The template components in [references/](references/) are a **starting point** — always adapt them to match the project's existing patterns.
+
+### Step 2: Understand the Goal
+
+**STOP. Do not proceed to Step 3 until you have answers to ALL of the following.** Check the user's request — if it already answers a question, you don't need to re-ask it. For anything not covered, ask the user and wait for their response before continuing.
+
+**Ask only one question at a time.** Wait for the user's answer before asking the next. Do not list multiple questions in one message. **When presenting options, use `AskUserQuestion`** to render interactive selectors in the agent console. For free-text questions (like prompt text), ask as a normal text message.
+
+1. **Which feature/flag?** Feedback is always tied to a flag key. Search the codebase for existing flag keys, then use `AskUserQuestion` with the discovered flags as options (plus a "Create a new flag" option). If no flags are found, ask as a text question.
+2. **What question do you want to ask the user?** This becomes the prompt text shown in the feedback widget (e.g., "How do you feel about this view?" or "Did this work as expected?"). Ask this as a normal text message since it requires free-text input.
+3. **What type of feedback?** Use `AskUserQuestion` with header "Type" and these options:
+   - label: "Sentiment + text (Recommended)", description: "Sentiment buttons with a text area for comments, in a popover"
+   - label: "Sentiment only", description: "One-click sentiment buttons inline — no popover, no text input"
+   - label: "Text only", description: "Just a text area for written feedback in a popover, no sentiment buttons"
+   If the user selects "Sentiment + text" or "Sentiment only", follow up with `AskUserQuestion` header "Icons" and these options:
+   - label: "Thumbs up / down", description: "Two buttons: positive / negative"
+   - label: "Smiley faces", description: "Three buttons: positive / neutral / negative"
+4. **Where should the feedback widget go?** Before asking, search the codebase for pages, routes, or main components. Then use `AskUserQuestion` with header "Placement" and 2–4 concrete placement options that make sense for this repo (e.g., "Next to the results heading on the Simulator page", "In the page header", "Below the main content area"). Prefer page-level placement — don't bury feedback in small sub-components unless it's workflow-specific confirmation.
+
+### Step 3: Verify the Flag in LaunchDarkly
+
+Use `get-flag` to confirm the target flag exists and is configured for client-side use.
+
+- If the flag **doesn't exist**, use `create-flag` (or direct the user to the [flag create skill](../launchdarkly-flag-create/SKILL.md)).
+- If the flag **exists but doesn't have client-side SDK availability enabled**, inform the user they need to enable it in the flag's Advanced Controls section.
+- If the flag was created or verified, **provide the user with a direct link** to the flag in the LaunchDarkly dashboard.
+- Optionally use `update-flag-settings` to add a `feedback` tag.
+
+### Step 4: Confirm Before Applying
+
+**STOP. Do not write any code until the user explicitly confirms the plan.** This applies every time — including when the user provides all details upfront, when re-running for a second flag in the same conversation, or when reusing existing utilities. A detailed user request is not implicit approval.
+
+Summarize the planned changes using **future tense** (e.g., "Files to create", "Files to modify") — no code has been written yet:
+- Flag key and whether it exists or needs creation
+- The `sendFeedback` utility: where it will live, whether it will be reused from a prior step, and whether it includes session replay
+- The feedback widget: component name, UI style, placement location
+- Which files will be created or modified
+
+Then use `AskUserQuestion` with header "Confirm" and these options:
+- label: "Looks good", description: "Proceed with the plan as described"
+- label: "Change something", description: "I want to adjust part of the plan before you start"
+
+If the user selects "Change something" (or provides custom input), address their feedback and re-present the updated plan with the same confirmation prompt. Do not proceed to Step 5 until the user selects "Looks good".
+
+### Step 5: Add the sendFeedback Function
+
+**If Check 4 found an existing `sendFeedback` function, skip this step entirely.** Use the recorded import path from that check and proceed directly to Step 6.
+
+This is the core integration. Create a utility function that sends the `$ld:feedback` tracking event.
+
+Start from the template in [references/sendFeedback.ts](references/sendFeedback.ts). For JavaScript projects, adapt by removing type annotations.
+
+The essential contract:
+
+```typescript
+client.track('$ld:feedback', {
+    feedback_answer: string,  // required — the user's written feedback
+    flag_key: string,         // required — the flag this feedback is about
+    sentiment: "positive" | "neutral" | "negative",  // defaults to "neutral"
+    feedback_prompt: string,  // optional — the question shown to the user
+    o11y_session_id: string,  // optional — links to session replay
+    custom_properties: Record<string, any>,  // optional — extra metadata to attach to the feedback event
+});
+client.flush();
+```
+
+**Key decisions:**
+- If `@launchdarkly/session-replay` is in the project, include the session ID via `LDRecord.getSession()?.sessionSecureID`. If not, remove the session replay import and `o11y_session_id` logic from the template.
+- Place the utility where the project keeps its LD-related code (alongside existing flag helpers, in a `lib/` or `utils/` directory, etc.)
+- Export the `LDFeedbackSentiment` type if using TypeScript
+
+**Verification:** After creating the file, search the codebase to confirm it exists and contains the expected content — a `sendFeedback` export that calls `client.track('$ld:feedback', ...)` followed by `client.flush()`. If not found, fix before proceeding.
+
+### Step 6: Build the Feedback Widget
+
+Build the UI using the project's existing design system and component patterns.
+
+Start from the appropriate template in [references/](references/). For JavaScript projects, adapt by removing type annotations.
+- **Sentiment + text** → [PopoverFeedback.tsx](references/PopoverFeedback.tsx) with `icons="thumbs"` or `icons="smileys"`
+- **Text only** → [PopoverFeedback.tsx](references/PopoverFeedback.tsx) with `icons="none"`
+- **Sentiment only** → [InlineFeedback.tsx](references/InlineFeedback.tsx) with `icons="thumbs"` or `icons="smileys"`
+
+These templates use inline styles and SVG icons so they work without any CSS framework or icon library. When the project has a design system, replace template elements with its primitives:
+
+| Template element | Replace with |
+|------------------|-------------|
+| Inline `style={{...}}` | Project's CSS approach (Tailwind classes, CSS modules, styled-components, etc.) |
+| `<button>` | Design system's `<Button>` component |
+| Positioned `<div>` popover | Design system's `<Popover>` or `<Dropdown>` component |
+| `<textarea>` | Design system's `<TextArea>` or `<Input>` component |
+| Inline SVG icons | Project's icon library (Lucide, Heroicons, MUI icons, etc.) |
+
+Always use `fill="currentColor"` (not hardcoded hex colors) in SVG icons so they inherit the parent's text color.
+
+**Do NOT use find-and-replace for `PROMPT_TO_REPLACE`.** Instead, make `prompt` a string prop on the component. This makes the widget reusable across flags without code duplication. Pass the user's prompt text from Step 2 as a prop when rendering.
+
+**Standard UX pattern** (follow this regardless of design system):
+- A **trigger button** with a speech-bubble icon and "Give feedback" label (for popover styles)
+- A **popover** that opens on click, containing:
+  - A text area with the prompt text as its placeholder
+  - Sentiment controls matching the style chosen in Step 2:
+    - **Thumbs up / thumbs down** — two icon buttons toggling positive/negative
+    - **Smiley-face scale** — three icon buttons for positive (smile), neutral (meh), negative (frown)
+    - **Text-only** — no sentiment buttons; omit the `sentiment` field from `sendFeedback`
+  - A submit button
+- **After submission:** Track a `submitted` state. Replace the widget with a "Thanks for your feedback!" confirmation message. Do not just close the popover silently — the user needs to know their feedback was received.
+- **Quick thumbs / inline smileys** (no popover): inline prompt text with sentiment buttons; sends feedback immediately on click with no text input. After click, replace with a thank-you message.
+
+**Placement:** Use the location chosen in Step 2. Do not add multiple feedback entry points on the same screen.
+
+#### Wire the component into the target
+
+After building the widget, add it to the target location from Step 2:
+
+1. **Find the target file.** Search the codebase for the page or component matching the placement chosen in Step 2. State the file path you found and ask the user to confirm it's correct before modifying it. If they say no, ask for clarification and try again.
+2. **Import and render.** Import the feedback component into the confirmed target file. Render it and pass the required props: `flagKey` string and `prompt` string. For React SDK projects, the component should use the `useLDClient()` hook internally rather than accepting `ldClient` as a prop.
+3. **Verification:** Search the target component to confirm it imports and renders the feedback component with the required props (`flagKey`, `prompt`). If the import or render is missing, fix before proceeding.
+
+#### Framework-specific approach
+
+**React** — Start from the template, then adapt to the project's design system using the table above.
+
+**Vanilla JS/TS** — Wire up DOM elements to the `sendFeedback` function:
+```typescript
+submitButton.addEventListener('click', () => {
+    sendFeedback(client, flagKey, feedbackInput.value, selectedSentiment, promptText);
+});
+```
+
+**Vue / Angular / Svelte** — Translate the React component pattern into the framework's idiom. The `sendFeedback` function is framework-agnostic; only the UI wrapper changes.
+
+### Step 7: Verify
+
+**Pre-condition check:** Before verifying, confirm that all prior steps produced their expected outputs:
+- (a) The `sendFeedback` utility file exists (or an existing one was reused from Check 4).
+- (b) The feedback widget component file exists.
+- (c) The widget is imported and rendered in the target location with the required props.
+
+If any are missing, go back and complete the relevant step before proceeding.
+
+Walk the user through validation step by step:
+
+1. **Run the build.** Execute the project's build or lint command. If it fails, fix the errors before continuing.
+2. **Start the app locally.** Ask the user to run their dev server (or run it yourself if you can). Confirm it starts without errors.
+3. **Navigate to the feedback location.** Tell the user to open the page where the widget was placed. Ask them to confirm the "Give feedback" button (or inline thumbs) is visible and styled correctly.
+4. **Submit test feedback.** Walk the user through: click the trigger → enter test text → select a sentiment → click Send. Ask them to open the browser's Network tab and confirm a POST to the LaunchDarkly events endpoint fired containing `$ld:feedback`.
+5. **Check the dashboard.** Provide a direct link to the flag's **Feedback** tab in the LaunchDarkly dashboard. Tell the user to wait ~1 minute and then refresh — their test feedback should appear.
+6. **Session replay (if applicable).** If `@launchdarkly/session-replay` is configured, ask the user to check for a **Replay** button next to the feedback entry in the dashboard.
+
+After the user confirms everything works, mention:
+- They can subscribe Slack channels to receive feedback notifications: go to the flag's **Feedback** tab → **Subscribe** → select Slack channels (requires the LaunchDarkly Slack app).
+- Provide the direct link to the flag's Feedback tab so they can bookmark it for monitoring.
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| No LD SDK found | **STOP** — handled by Check 1 |
+| Server-side SDK only, no client SDK | **STOP** — handled by Check 2 |
+| SDK version < 3.0 | **STOP** — handled by Check 3 |
+| Existing `sendFeedback` function found | Reuse it, skip Step 5 — handled by Check 4 |
+| React SDK (`@launchdarkly/react-client-sdk`) | Access client via `useLDClient()` hook instead of a direct reference |
+| Flag doesn't have client-side availability | User must enable it in the flag's Advanced Controls |
+| Observability not installed | Skip the `o11y_session_id` field; session replay won't be available |
+| No design system detected | Use the template component with minimal inline styles as a starting point |
+| Multiple flags need feedback | Create separate `sendFeedback` calls per flag; each widget targets one flag key |
+
+## What NOT to Do
+
+- Don't ship the unstyled template component to production — always adapt to the project's design system.
+- Don't add multiple feedback widgets on the same screen.
+- Don't forget to call `client.flush()` after `client.track()`.
+- Don't hardcode flag keys — use the project's existing constant/config pattern for flag keys.
+- Don't send feedback from server-side code — this is a client-side feature only.
+
+## Templates
+
+Code templates live in [references/](references/) alongside the SDK lists:
+
+| File | Description |
+|------|-------------|
+| [sendFeedback.ts](references/sendFeedback.ts) | Utility that sends the `$ld:feedback` tracking event, with session replay support |
+| [PopoverFeedback.tsx](references/PopoverFeedback.tsx) | Popover with text area + configurable sentiment icons (`icons="thumbs"` / `"smileys"` / `"none"`) |
+| [InlineFeedback.tsx](references/InlineFeedback.tsx) | Inline one-click sentiment buttons (`icons="thumbs"` / `"smileys"`) |
+
+All templates are TypeScript — for JavaScript projects, adapt by removing type annotations. Templates include inline SVG icons and work without external icon libraries. Adapt them to the project's design system and pass the user's prompt text as a prop.
+
+## References
+
+- [Official Docs: User feedback SDK](https://launchdarkly.com/docs/sdk/features/user-feedback)
+- [Official Docs: Viewing feedback](https://launchdarkly.com/docs/home/releases/user-feedback)
+- [Tutorial: Collecting user feedback](https://launchdarkly.com/docs/tutorials/collect-qualitative-user-feedback-homepage)
+
+## Example Flows
+
+These show how the decision tree plays out for common scenarios.
+
+**Happy path — React + TypeScript, new flag, thumbs popover:**
+Step 0 → welcome. Step 1 → finds `@launchdarkly/react-client-sdk` v3.6, React + Tailwind, no existing feedback. Step 2 → user picks a new flag `checkout-redesign`, prompt "How do you feel about the new checkout?", thumbs style, placed below the order summary. Step 3 → creates flag via `create-flag`. Step 4 → user approves. Step 5 → creates `sendFeedback.ts` in `lib/ld/`. Step 6 → creates `FeedbackPopover.tsx` adapted to Tailwind, wires it into `CheckoutPage.tsx` with `useLDClient()`. Step 7 → build passes, event fires.
+
+**Existing sendFeedback — reuse and skip:**
+Step 1 → Check 4 finds `src/utils/sendFeedback.ts` already calling `client.track('$ld:feedback', ...)`. Records the import path. Step 2 → gathers requirements normally. Steps 3–4 → as usual. Step 5 → **skipped** (reuses existing function). Step 6 → builds widget, imports `sendFeedback` from the existing path. Step 7 → build passes, event fires.
+
+**Server-side SDK — early STOP:**
+Step 1 → Check 1 finds `@launchdarkly/node-server-sdk`. Check 2 → it's in `server-side-sdk-list.md`, no client SDK present. → Informs user that qualitative feedback requires a client-side SDK. **STOP.**
+
+**No design system — minimal styles:**
+Step 1 → finds `launchdarkly-js-client-sdk` v3.2, no React, no Tailwind, no component library. Step 6 → uses the template with inline styles as the baseline, adapts to the project's vanilla JS patterns and existing CSS conventions.

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/marketplace.json
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "launchdarkly-flag-qualitative-feedback-setup",
+  "description": "Integrate LaunchDarkly qualitative user feedback into a JavaScript/TypeScript codebase",
+  "version": "1.0.0-experimental",
+  "author": "LaunchDarkly",
+  "repository": "https://github.com/launchdarkly/ai-tooling",
+  "skills": ["./"],
+  "tags": [
+    "launchdarkly",
+    "feature-flags",
+    "feedback",
+    "qualitative-feedback",
+    "user-feedback",
+    "sentiment",
+    "sdk",
+    "javascript",
+    "react",
+    "mcp"
+  ],
+  "requirements": {
+    "mcp-servers": ["@launchdarkly/mcp-server"]
+  }
+}

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/InlineFeedback.tsx
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/InlineFeedback.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import type { LDClient } from "launchdarkly-js-client-sdk";
+import { sendFeedback, type LDFeedbackSentiment } from './sendFeedback';
+
+const ThumbsUpIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" clipRule="evenodd" d="M10.8333 4.0835C10.5902 4.0835 10.3571 4.18007 10.1852 4.35198C10.0132 4.52389 9.91667 4.75705 9.91667 5.00016V5.8335C9.91667 6.91646 9.48646 7.95508 8.72069 8.72085C8.1341 9.30744 7.38741 9.69713 6.58333 9.84738V14.1668C6.58333 14.631 6.76771 15.0761 7.0959 15.4043C7.42409 15.7325 7.8692 15.9168 8.33333 15.9168H14.1667C14.1879 15.9168 14.2091 15.9177 14.2302 15.9195C14.3314 15.9281 14.4807 15.8951 14.6552 15.7206C14.8345 15.5414 15.0045 15.2418 15.1005 14.8403L15.9145 10.7702C15.8993 10.5502 15.8051 10.3422 15.6482 10.1853C15.4763 10.0134 15.2431 9.91683 15 9.91683H12.5C12.0858 9.91683 11.75 9.58104 11.75 9.16683V5.00016C11.75 4.75705 11.6534 4.52389 11.4815 4.35198C11.3096 4.18007 11.0764 4.0835 10.8333 4.0835ZM6.31554 16.7146C6.25856 16.7997 6.19305 16.8796 6.11959 16.9531C5.82265 17.25 5.41992 17.4168 5 17.4168H3.33333C2.91341 17.4168 2.51068 17.25 2.21375 16.9531C1.91681 16.6561 1.75 16.2534 1.75 15.8335V10.0002C1.75 9.58024 1.91682 9.17751 2.21375 8.88058C2.51068 8.58365 2.91341 8.41683 3.33333 8.41683H5.83333C6.51848 8.41683 7.17556 8.14466 7.66003 7.66019C8.1445 7.17572 8.41667 6.51864 8.41667 5.8335V5.00016C8.41667 4.35922 8.67128 3.74453 9.12449 3.29132C9.57771 2.83811 10.1924 2.5835 10.8333 2.5835C11.4743 2.5835 12.089 2.83811 12.5422 3.29132C12.9954 3.74453 13.25 4.35922 13.25 5.00016V8.41683H15C15.6409 8.41683 16.2556 8.67144 16.7088 9.12466C17.1621 9.57787 17.4167 10.1926 17.4167 10.8335C17.4167 10.8829 17.4118 10.9322 17.4021 10.9806L16.5688 15.1473C16.5672 15.1553 16.5654 15.1633 16.5635 15.1713C16.4193 15.7866 16.1361 16.3611 15.7159 16.7813C15.2974 17.1998 14.7451 17.4569 14.1388 17.4168H8.33333C7.59724 17.4168 6.88688 17.1671 6.31554 16.7146ZM5.08333 9.91683H3.33333C3.31123 9.91683 3.29004 9.92561 3.27441 9.94124C3.25878 9.95687 3.25 9.97806 3.25 10.0002V15.8335C3.25 15.8556 3.25878 15.8768 3.27441 15.8924C3.29003 15.908 3.31123 15.9168 3.33333 15.9168H5C5.0221 15.9168 5.0433 15.908 5.05893 15.8924C5.07455 15.8768 5.08333 15.8556 5.08333 15.8335V9.91683Z" fill="currentColor"/>
+  </svg>
+);
+
+const ThumbsDownIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" clipRule="evenodd" d="M14.1388 2.58319C14.7451 2.54314 15.2974 2.80022 15.7159 3.21873C16.1361 3.63897 16.4193 4.21339 16.5635 4.82868C16.5654 4.83668 16.5672 4.84471 16.5688 4.85277L17.4021 9.01944C17.4118 9.06787 17.4167 9.11714 17.4167 9.16653C17.4167 9.80747 17.1621 10.4222 16.7088 10.8754C16.2556 11.3286 15.6409 11.5832 15 11.5832H13.25V14.9999C13.25 15.6408 12.9954 16.2555 12.5422 16.7087C12.089 17.1619 11.4743 17.4165 10.8333 17.4165C10.1924 17.4165 9.5777 17.1619 9.12449 16.7087C8.67128 16.2555 8.41667 15.6408 8.41667 14.9999V14.1665C8.41667 13.4814 8.1445 12.8243 7.66003 12.3398C7.17556 11.8554 6.51848 11.5832 5.83333 11.5832H3.33333C2.91341 11.5832 2.51068 11.4164 2.21375 11.1194C1.91682 10.8225 1.75 10.4198 1.75 9.99986V4.16653C1.75 3.7466 1.91681 3.34387 2.21375 3.04694C2.51068 2.75001 2.91341 2.58319 3.33333 2.58319H5C5.41993 2.58319 5.82265 2.75001 6.11959 3.04694C6.19305 3.12041 6.25856 3.20035 6.31554 3.28543C6.88688 2.83291 7.59723 2.58319 8.33333 2.58319H14.1388ZM5.08333 4.16653C5.08333 4.14443 5.07455 4.12323 5.05893 4.1076C5.0433 4.09197 5.0221 4.08319 5 4.08319H3.33333C3.31123 4.08319 3.29004 4.09197 3.27441 4.1076C3.25878 4.12323 3.25 4.14442 3.25 4.16653V9.99986C3.25 10.022 3.25878 10.0432 3.27441 10.0588C3.29004 10.0744 3.31123 10.0832 3.33333 10.0832H5.08333V4.16653ZM6.58333 10.1526V5.83319C6.58333 5.36906 6.76771 4.92394 7.0959 4.59576C7.42409 4.26757 7.8692 4.08319 8.33333 4.08319H14.1667C14.1879 4.08319 14.2091 4.08229 14.2302 4.08049C14.3314 4.07189 14.4807 4.10489 14.6552 4.27939C14.8345 4.45867 15.0045 4.75827 15.1005 5.15978L15.9145 9.22985C15.8993 9.44983 15.8051 9.65779 15.6482 9.81471C15.4763 9.98662 15.2431 10.0832 15 10.0832H12.5C12.0858 10.0832 11.75 10.419 11.75 10.8332V14.9999C11.75 15.243 11.6534 15.4761 11.4815 15.648C11.3096 15.82 11.0764 15.9165 10.8333 15.9165C10.5902 15.9165 10.3571 15.82 10.1852 15.648C10.0132 15.4761 9.91667 15.243 9.91667 14.9999V14.1665C9.91667 13.0836 9.48646 12.0449 8.72069 11.2792C8.1341 10.6926 7.38741 10.3029 6.58333 10.1526Z" fill="currentColor"/>
+  </svg>
+);
+
+const HappyFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#happy)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01" />
+      <path d="M9.5 15a3.5 3.5 0 0 0 5 0" />
+    </g>
+    <defs><clipPath id="happy"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+const NeutralFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#neutral)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01M9 15h6" />
+    </g>
+    <defs><clipPath id="neutral"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+const FrownyFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#frown)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01" />
+      <path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" />
+    </g>
+    <defs><clipPath id="frown"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+type SentimentOption = { value: LDFeedbackSentiment; label: string; Icon: React.FC };
+
+const THUMBS_OPTIONS: SentimentOption[] = [
+  { value: "positive", label: "Thumbs up", Icon: ThumbsUpIcon },
+  { value: "negative", label: "Thumbs down", Icon: ThumbsDownIcon },
+];
+
+const SMILEY_OPTIONS: SentimentOption[] = [
+  { value: "positive", label: "Happy face", Icon: HappyFaceIcon },
+  { value: "neutral", label: "Neutral face", Icon: NeutralFaceIcon },
+  { value: "negative", label: "Frowny face", Icon: FrownyFaceIcon },
+];
+
+export function InlineFeedback({
+  flagKey,
+  prompt,
+  icons,
+  ldClient,
+}: {
+  flagKey: string;
+  prompt: string;
+  icons: "thumbs" | "smileys";
+  ldClient: LDClient;
+}) {
+  const [voted, setVoted] = useState(false);
+
+  const sentimentOptions = icons === "thumbs" ? THUMBS_OPTIONS : SMILEY_OPTIONS;
+
+  const handleClick = (sentiment: LDFeedbackSentiment) => {
+    sendFeedback(ldClient, flagKey, "", sentiment, prompt);
+    setVoted(true);
+  };
+
+  if (voted) {
+    return <span>Thanks for your feedback!</span>;
+  }
+
+  return (
+    <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+      <span>{prompt}</span>
+      {sentimentOptions.map(({ value, label, Icon }) => (
+        <button
+          key={value}
+          onClick={() => handleClick(value)}
+          aria-label={label}
+          style={{ cursor: "pointer", background: "none", border: "none", padding: "0.25rem" }}
+        >
+          <Icon />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// Usage examples:
+// <InlineFeedback flagKey="my-flag" prompt="Was this helpful?" icons="thumbs" ldClient={ldClient} />
+// <InlineFeedback flagKey="my-flag" prompt="Was this helpful?" icons="smileys" ldClient={ldClient} />

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/PopoverFeedback.tsx
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/PopoverFeedback.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import type { LDClient } from "launchdarkly-js-client-sdk";
+import { sendFeedback, type LDFeedbackSentiment } from './sendFeedback';
+
+const ThumbsUpIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" clipRule="evenodd" d="M10.8333 4.0835C10.5902 4.0835 10.3571 4.18007 10.1852 4.35198C10.0132 4.52389 9.91667 4.75705 9.91667 5.00016V5.8335C9.91667 6.91646 9.48646 7.95508 8.72069 8.72085C8.1341 9.30744 7.38741 9.69713 6.58333 9.84738V14.1668C6.58333 14.631 6.76771 15.0761 7.0959 15.4043C7.42409 15.7325 7.8692 15.9168 8.33333 15.9168H14.1667C14.1879 15.9168 14.2091 15.9177 14.2302 15.9195C14.3314 15.9281 14.4807 15.8951 14.6552 15.7206C14.8345 15.5414 15.0045 15.2418 15.1005 14.8403L15.9145 10.7702C15.8993 10.5502 15.8051 10.3422 15.6482 10.1853C15.4763 10.0134 15.2431 9.91683 15 9.91683H12.5C12.0858 9.91683 11.75 9.58104 11.75 9.16683V5.00016C11.75 4.75705 11.6534 4.52389 11.4815 4.35198C11.3096 4.18007 11.0764 4.0835 10.8333 4.0835ZM6.31554 16.7146C6.25856 16.7997 6.19305 16.8796 6.11959 16.9531C5.82265 17.25 5.41992 17.4168 5 17.4168H3.33333C2.91341 17.4168 2.51068 17.25 2.21375 16.9531C1.91681 16.6561 1.75 16.2534 1.75 15.8335V10.0002C1.75 9.58024 1.91682 9.17751 2.21375 8.88058C2.51068 8.58365 2.91341 8.41683 3.33333 8.41683H5.83333C6.51848 8.41683 7.17556 8.14466 7.66003 7.66019C8.1445 7.17572 8.41667 6.51864 8.41667 5.8335V5.00016C8.41667 4.35922 8.67128 3.74453 9.12449 3.29132C9.57771 2.83811 10.1924 2.5835 10.8333 2.5835C11.4743 2.5835 12.089 2.83811 12.5422 3.29132C12.9954 3.74453 13.25 4.35922 13.25 5.00016V8.41683H15C15.6409 8.41683 16.2556 8.67144 16.7088 9.12466C17.1621 9.57787 17.4167 10.1926 17.4167 10.8335C17.4167 10.8829 17.4118 10.9322 17.4021 10.9806L16.5688 15.1473C16.5672 15.1553 16.5654 15.1633 16.5635 15.1713C16.4193 15.7866 16.1361 16.3611 15.7159 16.7813C15.2974 17.1998 14.7451 17.4569 14.1388 17.4168H8.33333C7.59724 17.4168 6.88688 17.1671 6.31554 16.7146ZM5.08333 9.91683H3.33333C3.31123 9.91683 3.29004 9.92561 3.27441 9.94124C3.25878 9.95687 3.25 9.97806 3.25 10.0002V15.8335C3.25 15.8556 3.25878 15.8768 3.27441 15.8924C3.29003 15.908 3.31123 15.9168 3.33333 15.9168H5C5.0221 15.9168 5.0433 15.908 5.05893 15.8924C5.07455 15.8768 5.08333 15.8556 5.08333 15.8335V9.91683Z" fill="currentColor"/>
+  </svg>
+);
+
+const ThumbsDownIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" clipRule="evenodd" d="M14.1388 2.58319C14.7451 2.54314 15.2974 2.80022 15.7159 3.21873C16.1361 3.63897 16.4193 4.21339 16.5635 4.82868C16.5654 4.83668 16.5672 4.84471 16.5688 4.85277L17.4021 9.01944C17.4118 9.06787 17.4167 9.11714 17.4167 9.16653C17.4167 9.80747 17.1621 10.4222 16.7088 10.8754C16.2556 11.3286 15.6409 11.5832 15 11.5832H13.25V14.9999C13.25 15.6408 12.9954 16.2555 12.5422 16.7087C12.089 17.1619 11.4743 17.4165 10.8333 17.4165C10.1924 17.4165 9.5777 17.1619 9.12449 16.7087C8.67128 16.2555 8.41667 15.6408 8.41667 14.9999V14.1665C8.41667 13.4814 8.1445 12.8243 7.66003 12.3398C7.17556 11.8554 6.51848 11.5832 5.83333 11.5832H3.33333C2.91341 11.5832 2.51068 11.4164 2.21375 11.1194C1.91682 10.8225 1.75 10.4198 1.75 9.99986V4.16653C1.75 3.7466 1.91681 3.34387 2.21375 3.04694C2.51068 2.75001 2.91341 2.58319 3.33333 2.58319H5C5.41993 2.58319 5.82265 2.75001 6.11959 3.04694C6.19305 3.12041 6.25856 3.20035 6.31554 3.28543C6.88688 2.83291 7.59723 2.58319 8.33333 2.58319H14.1388ZM5.08333 4.16653C5.08333 4.14443 5.07455 4.12323 5.05893 4.1076C5.0433 4.09197 5.0221 4.08319 5 4.08319H3.33333C3.31123 4.08319 3.29004 4.09197 3.27441 4.1076C3.25878 4.12323 3.25 4.14442 3.25 4.16653V9.99986C3.25 10.022 3.25878 10.0432 3.27441 10.0588C3.29004 10.0744 3.31123 10.0832 3.33333 10.0832H5.08333V4.16653ZM6.58333 10.1526V5.83319C6.58333 5.36906 6.76771 4.92394 7.0959 4.59576C7.42409 4.26757 7.8692 4.08319 8.33333 4.08319H14.1667C14.1879 4.08319 14.2091 4.08229 14.2302 4.08049C14.3314 4.07189 14.4807 4.10489 14.6552 4.27939C14.8345 4.45867 15.0045 4.75827 15.1005 5.15978L15.9145 9.22985C15.8993 9.44983 15.8051 9.65779 15.6482 9.81471C15.4763 9.98662 15.2431 10.0832 15 10.0832H12.5C12.0858 10.0832 11.75 10.419 11.75 10.8332V14.9999C11.75 15.243 11.6534 15.4761 11.4815 15.648C11.3096 15.82 11.0764 15.9165 10.8333 15.9165C10.5902 15.9165 10.3571 15.82 10.1852 15.648C10.0132 15.4761 9.91667 15.243 9.91667 14.9999V14.1665C9.91667 13.0836 9.48646 12.0449 8.72069 11.2792C8.1341 10.6926 7.38741 10.3029 6.58333 10.1526Z" fill="currentColor"/>
+  </svg>
+);
+
+const HappyFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#happy)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01" />
+      <path d="M9.5 15a3.5 3.5 0 0 0 5 0" />
+    </g>
+    <defs><clipPath id="happy"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+const NeutralFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#neutral)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01M9 15h6" />
+    </g>
+    <defs><clipPath id="neutral"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+const FrownyFaceIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" clipPath="url(#frown)">
+      <path d="M3 12a9 9 0 1 0 18.001 0A9 9 0 0 0 3 12M9 10h.01M15 10h.01" />
+      <path d="M9.5 15.25a3.5 3.5 0 0 1 5 0" />
+    </g>
+    <defs><clipPath id="frown"><path fill="#fff" d="M0 0h24v24H0z" /></clipPath></defs>
+  </svg>
+);
+
+const SpeechBubbleIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M14 1H2C1.45 1 1 1.45 1 2V11C1 11.55 1.45 12 2 12H4V15L8 12H14C14.55 12 15 11.55 15 11V2C15 1.45 14.55 1 14 1Z" fill="currentColor"/>
+  </svg>
+);
+
+type SentimentOption = { value: LDFeedbackSentiment; label: string; Icon: React.FC };
+
+const THUMBS_OPTIONS: SentimentOption[] = [
+  { value: "positive", label: "Thumbs up", Icon: ThumbsUpIcon },
+  { value: "negative", label: "Thumbs down", Icon: ThumbsDownIcon },
+];
+
+const SMILEY_OPTIONS: SentimentOption[] = [
+  { value: "positive", label: "Happy face", Icon: HappyFaceIcon },
+  { value: "neutral", label: "Neutral face", Icon: NeutralFaceIcon },
+  { value: "negative", label: "Frowny face", Icon: FrownyFaceIcon },
+];
+
+export function PopoverFeedback({
+  flagKey,
+  prompt,
+  icons,
+  ldClient,
+}: {
+  flagKey: string;
+  prompt: string;
+  icons: "thumbs" | "smileys" | "none";
+  ldClient: LDClient;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const [sentiment, setSentiment] = useState<LDFeedbackSentiment | undefined>(undefined);
+  const [submitted, setSubmitted] = useState(false);
+
+  const sentimentOptions = icons === "thumbs" ? THUMBS_OPTIONS : icons === "smileys" ? SMILEY_OPTIONS : [];
+
+  const handleSubmit = () => {
+    sendFeedback(ldClient, flagKey, feedback, sentiment, prompt);
+    setIsOpen(false);
+    setFeedback("");
+    setSentiment(undefined);
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return <span>Thanks for your feedback!</span>;
+  }
+
+  return (
+    <div style={{ position: "relative", display: "inline-block" }}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        style={{ display: "flex", alignItems: "center", gap: "0.375rem", background: "none", border: "none", cursor: "pointer" }}
+      >
+        <SpeechBubbleIcon />
+        Give feedback
+      </button>
+      {isOpen && (
+        <div style={{ position: "absolute", top: "100%", left: 0, marginTop: "0.5rem", backgroundColor: "white", border: "1px solid #ccc", borderRadius: "0.25rem", padding: "16px", boxSizing: "border-box", width: "300px", zIndex: 1000 }}>
+          <textarea
+            name="feedback"
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder={prompt}
+            rows={3}
+            style={{ width: "100%", padding: "0.5rem", marginBottom: "0.5rem", boxSizing: "border-box", border: "1px solid #ccc", borderRadius: "0.25rem", fontFamily: "sans-serif" }}
+          />
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            {sentimentOptions.length > 0 && (
+              <div style={{ display: "flex", gap: "0.25rem" }}>
+                {sentimentOptions.map(({ value, label, Icon }) => (
+                  <button
+                    key={value}
+                    onClick={() => setSentiment(sentiment === value ? undefined : value)}
+                    aria-label={label}
+                    style={{ cursor: "pointer", background: sentiment === value ? "#eee" : "none", border: "none", borderRadius: "0.25rem", padding: "0.25rem 0.5rem" }}
+                  >
+                    <Icon />
+                  </button>
+                ))}
+              </div>
+            )}
+            <button onClick={handleSubmit} style={{ backgroundColor: "black", color: "white", border: "none", borderRadius: "0.25rem", padding: "0.5rem 1rem", cursor: "pointer" }}>
+              Send
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Usage examples:
+// <PopoverFeedback flagKey="my-flag" prompt="How do you feel?" icons="thumbs" ldClient={ldClient} />
+// <PopoverFeedback flagKey="my-flag" prompt="How do you feel?" icons="smileys" ldClient={ldClient} />
+// <PopoverFeedback flagKey="my-flag" prompt="Any feedback?" icons="none" ldClient={ldClient} />

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
@@ -6,8 +6,8 @@ These SDK package names indicate a **client-side** SDK that supports qualitative
 |---|---|
 | `launchdarkly-js-client-sdk` | Vanilla JS/TS (v3.x) |
 | `@launchdarkly/js-client-sdk` | Vanilla JS/TS (v4.x, renamed scoped package) |
-| `@launchdarkly/react-client-sdk` | React (current) |
-| `launchdarkly-react-client-sdk` | React (older package name) |
+| `@launchdarkly/react-sdk` | React Web (current) |
+| `launchdarkly-react-client-sdk` | React Web (older package name) |
 | `launchdarkly-react-native-client-sdk` | React Native (older) |
 | `@launchdarkly/react-native-client-sdk` | React Native (current) |
 | `launchdarkly-flutter-client-sdk` | Flutter |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
@@ -1,0 +1,19 @@
+# Client-Side LaunchDarkly SDKs
+
+These SDK package names indicate a **client-side** SDK that supports qualitative feedback.
+
+| Package name | Platform |
+|---|---|
+| `launchdarkly-js-client-sdk` | Vanilla JS/TS |
+| `@launchdarkly/react-client-sdk` | React (current) |
+| `launchdarkly-react-client-sdk` | React (older package name) |
+| `launchdarkly-react-native-client-sdk` | React Native (older) |
+| `@launchdarkly/react-native-client-sdk` | React Native (current) |
+| `launchdarkly-flutter-client-sdk` | Flutter |
+| `.NET` client SDK | .NET (client) |
+| `Android` SDK | Android |
+| `C++` client SDK | C++ (client) |
+| `Electron` SDK | Electron |
+| `iOS` SDK | iOS |
+| `Roku` SDK | Roku |
+| `Vue` SDK | Vue |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
@@ -10,7 +10,7 @@ These SDK package names indicate a **client-side** SDK that supports qualitative
 | `launchdarkly-react-client-sdk` | React Web (older package name) |
 | `launchdarkly-react-native-client-sdk` | React Native (older) |
 | `@launchdarkly/react-native-client-sdk` | React Native (current) |
-| `launchdarkly-flutter-client-sdk` | Flutter |
+| `launchdarkly_flutter_client_sdk` | Flutter (pub.dev, snake_case) |
 | `launchdarkly-node-client-sdk` | Node.js (client-side) |
 | `.NET` client SDK | .NET (client) |
 | `Android` SDK | Android |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/client-side-sdk-list.md
@@ -4,12 +4,14 @@ These SDK package names indicate a **client-side** SDK that supports qualitative
 
 | Package name | Platform |
 |---|---|
-| `launchdarkly-js-client-sdk` | Vanilla JS/TS |
+| `launchdarkly-js-client-sdk` | Vanilla JS/TS (v3.x) |
+| `@launchdarkly/js-client-sdk` | Vanilla JS/TS (v4.x, renamed scoped package) |
 | `@launchdarkly/react-client-sdk` | React (current) |
 | `launchdarkly-react-client-sdk` | React (older package name) |
 | `launchdarkly-react-native-client-sdk` | React Native (older) |
 | `@launchdarkly/react-native-client-sdk` | React Native (current) |
 | `launchdarkly-flutter-client-sdk` | Flutter |
+| `launchdarkly-node-client-sdk` | Node.js (client-side) |
 | `.NET` client SDK | .NET (client) |
 | `Android` SDK | Android |
 | `C++` client SDK | C++ (client) |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/sendFeedback.ts
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/sendFeedback.ts
@@ -1,0 +1,43 @@
+// Session replay import — remove this line if @launchdarkly/session-replay is not installed
+import { LDRecord } from "@launchdarkly/session-replay";
+import type { LDClient } from "launchdarkly-js-client-sdk";
+
+export type LDFeedbackData = {
+  feedback_answer: string;
+  flag_key: string;
+  sentiment?: LDFeedbackSentiment;
+  feedback_prompt?: string;
+  o11y_session_id?: string;
+  custom_properties?: Record<string, any>;
+};
+
+export type LDFeedbackSentiment = "positive" | "neutral" | "negative";
+
+export function sendFeedback(
+  client: LDClient,
+  flagKey: string,
+  feedback: string,
+  sentiment?: LDFeedbackSentiment,
+  prompt?: string,
+  customProperties?: Record<string, any>,
+) {
+  const feedbackData: LDFeedbackData = {
+    feedback_answer: feedback,
+    flag_key: flagKey,
+    sentiment: sentiment ?? "neutral",
+    custom_properties: customProperties,
+  };
+
+  // Session replay — remove this block if @launchdarkly/session-replay is not installed
+  const sessionID = LDRecord?.getSession()?.sessionSecureID;
+  if (sessionID) {
+    feedbackData.o11y_session_id = sessionID;
+  }
+
+  if (prompt) {
+    feedbackData.feedback_prompt = prompt;
+  }
+
+  client.track("$ld:feedback", feedbackData);
+  client.flush();
+}

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
@@ -6,7 +6,7 @@ These SDK package names indicate a **server-side** SDK. Qualitative feedback **c
 |---|---|
 | `@launchdarkly/node-server-sdk` | Node.js (current) |
 | `launchdarkly-node-server-sdk` | Node.js (older) |
-| `launchdarkly-py-server-sdk` | Python |
+| `launchdarkly-server-sdk` | Python (PyPI) |
 | Go SDK | Go |
 | Java SDK | Java |
 | Ruby SDK | Ruby |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
@@ -6,7 +6,6 @@ These SDK package names indicate a **server-side** SDK. Qualitative feedback **c
 |---|---|
 | `@launchdarkly/node-server-sdk` | Node.js (current) |
 | `launchdarkly-node-server-sdk` | Node.js (older) |
-| `launchdarkly-node-client-sdk` | Node.js (despite "client" in name, this is server-side) |
 | `launchdarkly-py-server-sdk` | Python |
 | Go SDK | Go |
 | Java SDK | Java |

--- a/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
+++ b/skills/feature-flags/launchdarkly-flag-qualitative-feedback-setup/references/server-side-sdk-list.md
@@ -1,0 +1,21 @@
+# Server-Side LaunchDarkly SDKs
+
+These SDK package names indicate a **server-side** SDK. Qualitative feedback **cannot** be sent from server-side code.
+
+| Package name | Platform |
+|---|---|
+| `@launchdarkly/node-server-sdk` | Node.js (current) |
+| `launchdarkly-node-server-sdk` | Node.js (older) |
+| `launchdarkly-node-client-sdk` | Node.js (despite "client" in name, this is server-side) |
+| `launchdarkly-py-server-sdk` | Python |
+| Go SDK | Go |
+| Java SDK | Java |
+| Ruby SDK | Ruby |
+| PHP SDK | PHP |
+| Apex SDK | Apex |
+| C++ server SDK | C++ (server) |
+| .NET server SDK | .NET (server) |
+| Erlang SDK | Erlang |
+| Haskell SDK | Haskell |
+| Lua SDK | Lua |
+| Rust SDK | Rust |


### PR DESCRIPTION
## Summary
Adds a new agent skill, `launchdarkly-flag-qualitative-feedback-setup`, that walks users through wiring LaunchDarkly qualitative user feedback into a JS/TS codebase.

The skill is a step-by-step wizard, where it:
- verifies the project has a compatible client-side SDK (v3.0+), 
- detects the framework and design system, 
- gathers requirements (flag, prompt, widget style, placement), 
- confirms the plan, then 
- generates a `sendFeedback` utility and a feedback widget that emit the `$ld:feedback` event and match the project's existing patterns. 

It also includes TypeScript templates (`sendFeedback.ts`, `PopoverFeedback.tsx`, `InlineFeedback.tsx`) and client/server SDK reference lists, and slots into the existing `feature-flags` skill family (let me know if you disagree and we can chat placement!).

## Testing

- [ ] Not applicable
- [x] Manual (describe below)
  - Ran the skill end-to-end against a Next.js / React demo app across multiple iterations, verifying generated code builds and feedback events reach LaunchDarkly.
    - Environment: Next.js 16 + React 19 app with Tailwind, `launchdarkly-react-client-sdk` v3.9, and `@launchdarkly/observability` + `@launchdarkly/session-replay` installed. Client-side SDK gate, design-system detection, and session-replay linkage were all exercised.
    - Scenarios: raw skill invocation, partial and full natural-language prompts, and a follow-up request adding a second feedback widget to a different flag in the same conversation. Covered smiley-face and thumbs-plus-text popover styles across separate flags/pages.
    - Verification each run: rebuilt the app (`next build` + container rebuild), confirmed the widget rendered at the chosen placement, the `$ld:feedback` event fired, and feedback surfaced on the flag's dashboard.
    - Repo checks: `validate_skills.py` (49 skills), `generate_catalog.py --check` (catalog current), and the unit test suite all pass.

## Notes
This skill was authored in a separate repo, so this PR also packages it to match `ai-tooling` conventions. 
- This does lose some of the [[git history associated with the iterations](https://github.com/launchdarkly-labs/qualitative-feedback-setup-skill/commits/fsareshwala/productionize_qf_feedback_skill/)](https://github.com/launchdarkly-labs/qualitative-feedback-setup-skill/commits/fsareshwala/productionize_qf_feedback_skill/), but I doubt those are super valuable here either way.
- Several of the skill's behaviors were shaped by the iterative test runs above, e.g. the explicit "step-by-step wizard" framing, the numbered `Check 1/4`–`4/4` gates, the labeled confirmation selection, and the sentiment-vs-text widget-style question.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill assets only; no runtime or production app code changes in this repo.
> 
> **Overview**
> Adds **`launchdarkly-flag-qualitative-feedback-setup`** to the feature-flags skill family and registers it in **`README.md`** and **`skills.json`**.
> 
> The new package is a **step-by-step agent wizard** (`SKILL.md`) that gates on client-side LaunchDarkly JS SDK v3+, collects flag/prompt/widget/placement choices, uses MCP to verify or create the flag, requires explicit plan approval, then guides codegen and end-to-end verification of **`$ld:feedback`** events.
> 
> It ships **reference templates** (`sendFeedback.ts`, `PopoverFeedback.tsx`, `InlineFeedback.tsx`) plus client/server SDK allowlists, with **`marketplace.json`** declaring the LaunchDarkly MCP dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d097d86ffa163a3e7659df2767c02df3912921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->