### PR TITLE
fix(experiments): A/A route returns components all false [EXPT-4665]

### DIFF
--- a/skills/experiments/launchdarkly-experiment-hypothesis-builder/SKILL.md
+++ b/skills/experiments/launchdarkly-experiment-hypothesis-builder/SKILL.md
@@ -193,7 +193,7 @@ When the caller requests JSON only (the experiment builder's headless entry poin
 ```
 
 - `route` — one of `scaffold | rewrite | junk | aa`, from Step 0.
-- `components` — presence booleans judged on the input after the semantic-validity check (not on the scaffold you return). For `junk` all three are false; for `rewrite` and `aa` all three are true. A 3/3 hypothesis already in canonical order is `route: scaffold` with all three true and no holes (the strong "looks ready" state), not `rewrite`.
+- `components` — presence booleans judged on the input after the semantic-validity check (not on the scaffold you return). For `junk` and `aa` all three are false; for `rewrite` all three are true. A 3/3 hypothesis already in canonical order is `route: scaffold` with all three true and no holes (the strong "looks ready" state), not `rewrite`.
 - `hypothesis` — the sentence for the field, with `{{component:hint}}` holes for missing slots (component is `change`, `measurement`, or `rationale`; hint is a short question). No holes for `rewrite`/`aa`. Never use `{{ }}` for anything except holes.
 - `measurements` — every measurement stated in the input as `{ "text": "...", "primary": true|false }`, with exactly one primary when non-empty; empty when the input states none.
 


### PR DESCRIPTION
## Summary

Aligns the machine contract in the `launchdarkly-experiment-hypothesis-builder` skill so `route: aa` reports `components` all `false` (consistent with `junk`) instead of all `true`. Raised by Nam in #proj-exp-ai: an A/A test asserts no change or effect, so all-true was inconsistent and made us lean on the model routing A/A perfectly. The builder ignores components for A/A (it renders the A/A badge), so this is a contract-only change.

Kept byte-identical to the o11y `experiment-hypothesis` skill's contract (companion o11y PR).

## Testing approaches

- N/A (skill markdown only). The o11y companion PR adds a regression test asserting `aa` components are all false.

## Feature flags

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line skill markdown contract clarification with no code or security impact.
> 
> **Overview**
> Updates the **structured JSON contract** in `launchdarkly-experiment-hypothesis-builder` so `route: aa` documents **`components` all `false`**, same as `junk`, instead of all `true` like `rewrite`.
> 
> That matches the product model (A/A asserts no change/effect; the rubric is replaced by the A/A badge) and keeps the contract aligned with the o11y `experiment-hypothesis` skill for shared grading. **Documentation-only** in this repo—no runtime behavior change in the builder beyond what callers infer from the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d6f293106eb5bb5ecb89dbd6681954271bdc221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->