### PR TITLE
fix(flag-release): correct immediate-release timing in auto-release reference

### DIFF
--- a/skills/feature-flags/flag-release/references/auto-release.md
+++ b/skills/feature-flags/flag-release/references/auto-release.md
@@ -15,7 +15,7 @@ the way the team has decided similar changes should roll out — no human toggli
 `create-automated-rollout-config` takes an `environments` array; each entry is
 `{ environmentKey, releaseType }`.
 
-- **`simple`** (default): serve `true` in that environment as soon as the config is created. Because a freshly created flag isn't evaluated anywhere yet, this is effectively a no-op until the merged code ships — then that environment is simply "on." Use it for dev/staging environments you want fully enabled without ceremony.
+- **`simple`** (default): serve `true` in that environment once the flag begins evaluating — the same trigger `policy` waits for, just with no policy resolution or stages. Use it for dev/staging environments you want fully enabled without ceremony.
 
 - **`policy`**: wait until the PR merges and the flag begins evaluating, then resolve that environment's configured release policy and perform the matching release — immediate, progressive, or guarded — automatically. Use it for production and any environment where you want a governed, monitored rollout with the safety net the team already defined.
 


### PR DESCRIPTION
## Summary
- `references/auto-release.md` described `simple` release type as serving `true` "as soon as the config is created." That's stale: immediate (`simple`) releases now release when flag evaluations are detected, the same trigger `policy` already correctly waits for in this same doc — `simple` just skips policy resolution and stages.
- Related fixes already opened/merged for the same stale claim in `launchdarkly/gonfalon` (`.agents/skills/gonfalon-flag-rollout/SKILL.md`, merged) and `launchdarkly/gram-functions` (`create-automated-rollout-config` tool description, PR #168).

## Test plan
- [ ] Docs-only change (skill reference markdown) — no code paths affected.

via LD Research 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown reference-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates **`references/auto-release.md`** so the **`simple`** release type is documented correctly: it turns the flag on when **flag evaluation starts**, not when the automated rollout config is created.
> 
> That matches how **`policy`** is already described in the same doc—**`simple`** just skips policy resolution and staged rollout—and avoids misleading guidance that staging/production could flip before merged code is actually evaluating the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9dc1ae919d1c667711719362f3d418c4ab5db78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->