### PR TITLE
Remove foundation team code owner review requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @launchdarkly/team-foundation 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the requirement for the foundation team (`@launchdarkly/team-foundation`) to review every PR before merge.

The `.github/CODEOWNERS` file contained a single catch-all rule:

```
* @launchdarkly/team-foundation
```

Combined with the branch protection setting "Require review from Code Owners", this made the foundation team a required reviewer on every pull request. Deleting the file removes that code-owner requirement entirely.

## Changes

- Deleted `.github/CODEOWNERS`

## Note

If the goal is to keep code-owner rules for some paths but stop requiring foundation review specifically, let me know and I can scope the CODEOWNERS file down instead of removing it. Also note that if branch protection separately requires a minimum number of approving reviews, that setting is configured in GitHub repo settings (not in the repo) and would need to be adjusted there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019feddc-0c84-716d-b889-84a566e7a024?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019feddc-0c84-716d-b889-84a566e7a024&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

